### PR TITLE
Exclude storybook files from editor build

### DIFF
--- a/packages/editor/.storybook/main.ts
+++ b/packages/editor/.storybook/main.ts
@@ -21,5 +21,8 @@ const config: StorybookConfig = {
     name: getAbsolutePath("@storybook/react-vite"),
     options: {},
   },
+  typescript: {
+    tsconfigPath: join(__dirname, "../tsconfig.storybook.json"),
+  },
 };
 export default config;

--- a/packages/editor/tsconfig.app.json
+++ b/packages/editor/tsconfig.app.json
@@ -31,5 +31,8 @@
       "@softmaple/ui/*": ["../../packages/ui/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  // Keep Storybook sources out of the application build.
+  // They are compiled separately using tsconfig.storybook.json.
+  "exclude": ["src/**/*.stories.*", "src/stories/**"]
 }

--- a/packages/editor/tsconfig.storybook.json
+++ b/packages/editor/tsconfig.storybook.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.app.json",
+  "include": ["src", ".storybook"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- keep Storybook sources out of the editor build by ignoring them in tsconfig
- add dedicated tsconfig for Storybook and point config to it

## Testing
- `pnpm build -F @softmaple/editor`
- `pnpm --filter @softmaple/editor run build-storybook`


------
https://chatgpt.com/codex/tasks/task_e_683fb13a6f08832c90570cfe763f570a