### PR TITLE
chore: optimize chromatic CI to run only on editor changes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,22 @@
 name: "Chromatic"
 
-on: push
+on:
+  push:
+    branches:
+      - main
+      - next
+    paths:
+      - 'packages/editor/**'
+      - '.github/workflows/chromatic.yml'
+      - 'pnpm-lock.yaml'
+  pull_request:
+    branches:
+      - main
+      - next
+    paths:
+      - 'packages/editor/**'
+      - '.github/workflows/chromatic.yml'
+      - 'pnpm-lock.yaml'
 
 permissions:
   contents: read
@@ -9,6 +25,11 @@ jobs:
   chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
+    # Only run if changes are in packages/editor or workflow itself
+    if: |
+      github.event_name == 'push' || 
+      (github.event_name == 'pull_request' && 
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -27,8 +48,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run:
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Run Chromatic
         uses: chromaui/action@latest
@@ -36,3 +56,7 @@ jobs:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/editor
+          # Only upload and test if packages/editor changed
+          onlyChanged: true
+          # Skip if no Storybook changes detected
+          exitZeroOnChanges: true


### PR DESCRIPTION
- Add path filters to only trigger on packages/editor changes
- Run on push to main/next branches and pull requests
- Add conditional check to prevent unnecessary runs
- Enable onlyChanged and exitZeroOnChanges options
- Include workflow file and pnpm-lock.yaml in path triggers

<!-- ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- If it fixed a bug, please use **fixes #<issue-number>** -->
<!-- If it resolved a issue, please use **resolves #<issue-number>** -->
<!-- otherwise, use **closes #<issue-number>** instead. -->
Fixes # .

Changes proposed in this pull request:
- 
- 
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline configuration to improve build efficiency and reduce unnecessary test executions. Enhanced environment setup and dependency installation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->