### PR TITLE
chore(ci): cancel in-progress E2E runs on new pushes

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -18,11 +18,10 @@ on:
       - 'pnpm-lock.yaml'
       - 'turbo.json'
 
-# Concurrency control - only one Playwright test suite (smoke or E2E) runs at a time globally
-# New runs will wait in queue behind the currently running one
+# Concurrency control - cancel in-progress runs when a new push arrives on the same branch
 concurrency:
-  group: playwright-global  # Shared group with E2E tests
-  cancel-in-progress: false  # Queue new runs, don't cancel
+  group: playwright-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,11 +18,10 @@ on:
       - 'pnpm-lock.yaml'
       - 'turbo.json'
 
-# Concurrency control - only one Playwright test suite (smoke or E2E) runs at a time globally
-# New runs will wait in queue behind the currently running one
+# Concurrency control - cancel in-progress runs when a new push arrives on the same branch
 concurrency:
-  group: playwright-global  # Shared group with smoke tests
-  cancel-in-progress: false  # Queue new runs, don't cancel
+  group: playwright-e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to cancel overlapping test runs on each branch, improving feedback speed and resource efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->