### PR TITLE
refactor(packages/typescript-config,packages/eslint-config): disable `any` type and add guidelines

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -89,7 +89,11 @@ const processInput = (input: string): string =>
 
 ### 2. TypeScript Best Practices
 
-- Use strict TypeScript (no \`any\`, avoid \`@ts-ignore\`)
+- **No `any` type:** The `@typescript-eslint/no-explicit-any` rule is enforced as an error
+- When encountering `any` types:
+  1. **Preferred:** Replace with proper types (union types, generics, or specific interfaces)
+  2. **If proper typing is not feasible:** Use `@ts-expect-error` with a descriptive comment explaining why
+  3. **Never use `@ts-ignore`:** Always use `@ts-expect-error` to ensure the error still exists
 - Prefer type inference when obvious
 - Use discriminated unions for complex types
 - Define interfaces for data structures

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,13 @@ Turborepo monorepo with `apps/web/` (Next.js 16), `packages/` (shared code), and
 - **Linting:** ESLint configs in `packages/eslint-config/`
 - Husky pre-commit hooks auto-format staged files
 
+### TypeScript Guidelines
+- **No `any` type:** The `@typescript-eslint/no-explicit-any` rule is enforced as an error
+- When encountering `any` types:
+  1. **Preferred:** Replace with proper types (union types, generics, or specific interfaces)
+  2. **If proper typing is not feasible:** Use `@ts-expect-error` with a descriptive comment explaining why
+  3. **Never use `@ts-ignore`:** Always use `@ts-expect-error` to ensure the error still exists
+
 ### Functional Programming Principles
 Where possible, prefer functional programming patterns:
 - **Pure functions:** Functions should not have side effects and should return the same output for the same inputs

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -32,8 +32,8 @@ export default mergeConfig(
             browser: {
               enabled: true,
               // Make sure to install Playwright
-              // TODO: fix me type issue
-              provider: playwright({}) as any,
+              // @ts-expect-error - Playwright provider has type incompatibility with vitest browser config
+              provider: playwright({}),
               headless: true,
               instances: [{ browser: 'chromium' }],
             },

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -19,6 +19,7 @@ export const config = [
     },
     rules: {
       "turbo/no-undeclared-env-vars": "warn",
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
   {

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
+    "noImplicitAny": true,
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
- Added @typescript-eslint/no-explicit-any as error in ESLint config
- Added noImplicitAny to TypeScript base config (already enabled by strict mode)
- Fixed editor vitest.config.ts to use @ts-expect-error instead of 'as any'
- Added TypeScript guidelines to AGENTS.md and .claude/CLAUDE.md
  - Prefer proper types over any
  - Use @ts-expect-error with comments when unavoidable
  - Never use @ts-ignore

All linting passes with 0 errors.