### PR TITLE
chore(packages/eslint-config): disallow TypeScript enums for performance

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -94,6 +94,24 @@ const processInput = (input: string): string =>
   1. **Preferred:** Replace with proper types (union types, generics, or specific interfaces)
   2. **If proper typing is not feasible:** Use `@ts-expect-error` with a descriptive comment explaining why
   3. **Never use `@ts-ignore`:** Always use `@ts-expect-error` to ensure the error still exists
+- **No TypeScript enums:** Enums are disallowed for performance and bundle-size optimization
+  - **Instead:** Use const objects with `as const` assertion
+  - **Benefit:** Better tree-shaking, smaller bundle size, no additional runtime code
+  - **Example:**
+    ```typescript
+    // ❌ Avoid: TypeScript enum (generates runtime code)
+    enum Status {
+      Active = "active",
+      Inactive = "inactive"
+    }
+    
+    // ✅ Good: Const object with as const (zero runtime cost)
+    const Status = {
+      Active: "active",
+      Inactive: "inactive"
+    } as const;
+    type Status = typeof Status[keyof typeof Status];
+    ```
 - Prefer type inference when obvious
 - Use discriminated unions for complex types
 - Define interfaces for data structures

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,17 @@ Turborepo monorepo with `apps/web/` (Next.js 16), `packages/` (shared code), and
   1. **Preferred:** Replace with proper types (union types, generics, or specific interfaces)
   2. **If proper typing is not feasible:** Use `@ts-expect-error` with a descriptive comment explaining why
   3. **Never use `@ts-ignore`:** Always use `@ts-expect-error` to ensure the error still exists
+- **No TypeScript enums:** Enums are disallowed for performance and bundle-size optimization
+  - **Instead:** Use const objects with `as const` assertion
+  - **Example:**
+    ```typescript
+    // ❌ Avoid: TypeScript enum
+    enum Status { Active, Inactive }
+    
+    // ✅ Good: Const object with as const
+    const Status = { Active: "active", Inactive: "inactive" } as const;
+    type Status = typeof Status[keyof typeof Status];
+    ```
 
 ### Functional Programming Principles
 Where possible, prefer functional programming patterns:

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -20,6 +20,13 @@ export const config = [
     rules: {
       "turbo/no-undeclared-env-vars": "warn",
       "@typescript-eslint/no-explicit-any": "error",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "TSEnumDeclaration",
+          message: "Enums are not allowed. Use const objects with 'as const' instead for better performance and smaller bundle size.",
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
- Added no-restricted-syntax rule to disallow TSEnumDeclaration
- Updated AGENTS.md and CLAUDE.md with enum restriction guidelines
- Use const objects with 'as const' instead for better performance and a smaller bundle size

Close #457 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TypeScript best practices to recommend const objects with `as const` over enums
  * Added guidance on using `readonly` for immutability

* **Chores**
  * Implemented ESLint rule to enforce new TypeScript enum guidelines

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->