### PR TITLE
refactor(packages/eg-walker): remove re-exports from non-index files

### DIFF
--- a/packages/eg-walker/src/core/replay.ts
+++ b/packages/eg-walker/src/core/replay.ts
@@ -4,7 +4,8 @@
  */
 
 import type { EventId, Version } from "../types";
-import type { GraphEvent, EventGraph } from "../graph/event-graph";
+import type { GraphEvent } from "../types";
+import type { EventGraph } from "../graph/event-graph";
 import type { InternalCRDTState } from "../crdt/internal-state";
 
 /**

--- a/packages/eg-walker/src/core/walker.ts
+++ b/packages/eg-walker/src/core/walker.ts
@@ -4,7 +4,7 @@
  */
 
 import type { EventId } from "../types";
-import type { GraphEvent } from "../graph/event-graph";
+import type { GraphEvent } from "../types";
 import type { EventGraphWalker } from "../graph/topological-walker";
 import type { InternalCRDTState } from "../crdt/retreat-advance-stubs";
 import type { ClearableCRDTState } from "./critical-version";

--- a/packages/eg-walker/src/crdt/retreat-advance-stubs.ts
+++ b/packages/eg-walker/src/crdt/retreat-advance-stubs.ts
@@ -5,7 +5,7 @@
  */
 
 import type { EventId } from "../types";
-import type { GraphEvent } from "../graph/event-graph";
+import type { GraphEvent } from "../types";
 
 /**
  * Internal CRDT state manager (stub)

--- a/packages/eg-walker/src/crdt/retreat-advance.ts
+++ b/packages/eg-walker/src/crdt/retreat-advance.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EventId } from "../types";
-import type { GraphEvent } from "../graph/event-graph";
+import type { GraphEvent } from "../types";
 import { InternalCRDTState } from "./internal-state";
 import { OPERATION_TYPE } from "../constants/operation-types";
 import type { InternalCRDTState as ICRDTStateInterface } from "./retreat-advance-stubs";

--- a/packages/eg-walker/src/graph/event-graph.ts
+++ b/packages/eg-walker/src/graph/event-graph.ts
@@ -7,9 +7,6 @@
 
 import type { GraphEvent, EventId, SerializedGraph } from "../types";
 
-// Re-export GraphEvent for use by other modules
-export type { GraphEvent } from "../types";
-
 /**
  * Event graph for storing operation history
  * This is what gets persisted to disk

--- a/packages/eg-walker/src/graph/index.ts
+++ b/packages/eg-walker/src/graph/index.ts
@@ -5,7 +5,7 @@
  * causal relationships between editing operations.
  */
 
-export { EventGraph, type GraphEvent } from "./event-graph";
+export { EventGraph } from "./event-graph";
 export {
   DefaultEventGraphWalker,
   type EventGraphWalker,

--- a/packages/eg-walker/src/graph/topological-walker.ts
+++ b/packages/eg-walker/src/graph/topological-walker.ts
@@ -4,7 +4,7 @@
  */
 
 import type { EventId } from "../types";
-import type { GraphEvent } from "../graph/event-graph";
+import type { GraphEvent } from "../types";
 
 export interface EventGraphWalker {
   /**

--- a/packages/eg-walker/src/test/replay.test.ts
+++ b/packages/eg-walker/src/test/replay.test.ts
@@ -11,7 +11,7 @@ import {
 import { EventGraph } from "../graph/event-graph";
 import { InternalCRDTState } from "../crdt/internal-state";
 import { OPERATION_TYPE } from "../constants/operation-types";
-import type { GraphEvent } from "../graph/event-graph";
+import type { GraphEvent } from "../types";
 import type { Version } from "../types";
 
 describe("Section 3.6: Partial Replay", () => {

--- a/packages/eg-walker/src/test/walker-graph.test.ts
+++ b/packages/eg-walker/src/test/walker-graph.test.ts
@@ -6,7 +6,7 @@ import { OPERATION_TYPE } from "../constants/operation-types";
 
 import { describe, it, expect } from "vitest";
 import { DefaultEventGraphWalker } from "../graph/topological-walker";
-import type { GraphEvent } from "../graph/event-graph";
+import type { GraphEvent } from "../types";
 
 describe("Section 3.2: EventGraphWalker", () => {
   describe("topologicalOrder", () => {

--- a/packages/eg-walker/src/test/walker-integration.test.ts
+++ b/packages/eg-walker/src/test/walker-integration.test.ts
@@ -6,7 +6,7 @@ import { OPERATION_TYPE } from "../constants/operation-types";
 
 import { describe, it, expect } from "vitest";
 import { EgWalker } from "../core/walker";
-import type { GraphEvent } from "../graph/event-graph";
+import type { GraphEvent } from "../types";
 import { StubInternalCRDT } from "../crdt/retreat-advance-stubs";
 import type { InternalCRDTState } from "../crdt/retreat-advance-stubs";
 import type { EventId } from "../types";

--- a/packages/eg-walker/src/types/compat.ts
+++ b/packages/eg-walker/src/types/compat.ts
@@ -11,6 +11,3 @@ export type SerializedEventGraph = {
   readonly events: ReadonlyArray<GraphEvent>;
   readonly metadata?: Record<string, unknown>;
 };
-
-// Re-export all types from index
-export * from "./index";


### PR DESCRIPTION
- Remove GraphEvent re-export from event-graph.ts
- Remove wildcard re-export from compat.ts
- Update all imports to reference original source (../types)
- Update graph/index.ts to match removed exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized type import paths to consolidate from a central types module.
  * Adjusted public API surface by removing type re-exports from the graph module to reduce unnecessary coupling between internal modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->