### PR TITLE
fix(apps/playground): correct CSS path to reference shared UI package

### DIFF
--- a/apps/playground/components.json
+++ b/apps/playground/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "config": "",
-    "css": "src/styles.css",
+    "css": "../../packages/ui/src/styles/globals.css",
     "baseColor": "neutral",
     "cssVariables": true,
     "prefix": ""


### PR DESCRIPTION
- Update css path from src/styles.css to ../../packages/ui/src/styles/globals.css
- Ensures playground uses shared styles from @softmaple/ui package
