### PR TITLE
chore: group TanStack ecosystem updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,13 @@
       "schedule": ["before 10am on monday"]
     },
     {
+      "description": "Group TanStack ecosystem updates",
+      "groupName": "TanStack",
+      "matchPackageNames": ["/^@tanstack\\//"],
+      "automerge": false,
+      "schedule": ["before 10am on monday"]
+    },
+    {
       "description": "Group Lexical editor updates",
       "groupName": "Lexical",
       "matchPackageNames": ["lexical", "/^@lexical\\//"],


### PR DESCRIPTION
- Add TanStack group to renovate.json
- Groups all @tanstack/* packages (Router, Query, Start, devtools)
- Scheduled for Monday mornings with manual review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management to group TanStack ecosystem package updates with a scheduled weekly review process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->