### PR TITLE
refactor(apps/web): replace 'as any' with type guard in email OTP validation

### DIFF
--- a/apps/web/app/auth/confirm/route.ts
+++ b/apps/web/app/auth/confirm/route.ts
@@ -14,41 +14,50 @@ const VALID_EMAIL_OTP_TYPES = [
   "email",
 ] as const;
 
+type ValidEmailOtpType = (typeof VALID_EMAIL_OTP_TYPES)[number];
+
+function isValidEmailOtpType(value: string): value is ValidEmailOtpType {
+  return VALID_EMAIL_OTP_TYPES.includes(value as ValidEmailOtpType);
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const token_hash = searchParams.get("token_hash");
-  const type = searchParams.get("type") as EmailOtpType;
+  const type = searchParams.get("type");
   const nextParam = searchParams.get("next");
   const safeNext = sanitizeRedirectUrl(nextParam);
 
   // Return 400 error for missing parameters
   if (!token_hash || !type) {
     return NextResponse.json(
-      { error: "Invalid request parameters. Please provide a valid token_hash and type." },
-      { status: 400 }
+      {
+        error:
+          "Invalid request parameters. Please provide a valid token_hash and type.",
+      },
+      { status: 400 },
     );
   }
 
   // Validate that type is a valid EmailOtpType
-  if (!VALID_EMAIL_OTP_TYPES.includes(type as any)) {
+  if (!type || !isValidEmailOtpType(type)) {
     return NextResponse.json(
       { error: "Invalid type parameter. Must be a valid EmailOtpType." },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   const supabase = await createClient();
 
   const { error } = await supabase.auth.verifyOtp({
-    type,
+    type: type as EmailOtpType,
     token_hash,
   });
-  
+
   if (error) {
     // Return error response instead of throwing
     return NextResponse.json(
       { error: error.message },
-      { status: error.status || 400 }
+      { status: error.status || 400 },
     );
   }
 


### PR DESCRIPTION
- Add ValidEmailOtpType derived from VALID_EMAIL_OTP_TYPES
- Create isValidEmailOtpType type guard function
- Remove unsafe 'as any' cast in type validation
- Use proper type narrowing before EmailOtpType cast
- Maintain runtime behavior while improving type safety

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced email verification validation to properly handle invalid requests and improve error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->