### PR TITLE
chore: improve renovate grouping for eslint-config-next

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
     {
       "description": "Group Next.js updates",
       "groupName": "Next.js",
-      "matchPackageNames": ["next", "/^eslint-config-next/", "/^@next/"],
+      "matchPackageNames": ["next", "eslint-config-next", "/^@next/"],
       "automerge": false,
       "schedule": ["before 10am on monday"]
     },
@@ -59,7 +59,11 @@
     {
       "description": "Group ESLint ecosystem",
       "groupName": "ESLint",
-      "matchPackageNames": ["eslint", "/^eslint-/", "/^@eslint\\//"],
+      "matchPackageNames": [
+        "eslint",
+        "/^eslint-(?!config-next)/",
+        "/^@eslint\\//"
+      ],
       "automerge": true,
       "automergeType": "pr",
       "schedule": ["before 10am on monday"]


### PR DESCRIPTION
- Move eslint-config-next to Next.js group (more logical)
- Add negative lookahead to ESLint pattern to avoid duplicates
- Ensure clearer dependency grouping in Renovate PRs