### PR TITLE
test(apps/playground): fix E2E selector for CardTitle elements

### DIFF
--- a/apps/playground/e2e/collaborative-editor.spec.ts
+++ b/apps/playground/e2e/collaborative-editor.spec.ts
@@ -11,15 +11,11 @@ test.describe("Collaborative Text Editor", () => {
   });
 
   test("should display two replica editors", async ({ page }) => {
-    // Check for Replica 1
-    await expect(
-      page.getByRole("heading", { name: /Replica 1/i }),
-    ).toBeVisible();
+    // Check for Replica 1 - CardTitle renders as div, not heading
+    await expect(page.getByText("Replica 1")).toBeVisible();
 
     // Check for Replica 2
-    await expect(
-      page.getByRole("heading", { name: /Replica 2/i }),
-    ).toBeVisible();
+    await expect(page.getByText("Replica 2")).toBeVisible();
 
     // Check for textareas
     const textareas = page.getByRole("textbox");


### PR DESCRIPTION
CardTitle component renders as div, not heading element. Changed from getByRole('heading') to getByText() for Replica labels.

Fixes 1 of 9 collaborative editor E2E tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test selectors for collaborative editor validation to improve test reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->