### PR TITLE
fix(renovate): replace invalid regex with excludePackageNames

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -61,9 +61,10 @@
       "groupName": "ESLint",
       "matchPackageNames": [
         "eslint",
-        "/^eslint-(?!config-next)/",
+        "/^eslint-/",
         "/^@eslint\\//"
       ],
+      "excludePackageNames": ["eslint-config-next"],
       "automerge": true,
       "automergeType": "pr",
       "schedule": ["before 10am on monday"]


### PR DESCRIPTION
Renovate doesn't support negative lookaheads in matchPackageNames. Replaced `/^eslint-(?!config-next)/` with `/^eslint-/` and added `excludePackageNames: ["eslint-config-next"]` to achieve the same effect.

Fixes validation error: Invalid regExp for packageRules[6].matchPackageNames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation configuration to refine package matching rules for ESLint updates and exclude specific packages from automatic merging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->