### PR TITLE
[codex] Disable E2E CI workflows

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -2,24 +2,6 @@ name: Smoke Tests (Fast)
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main, next ]
-    paths:
-      - 'apps/web/**'
-      - 'packages/**'
-      - '.github/workflows/playwright-smoke.yml'
-      - 'pnpm-lock.yaml'
-      - 'turbo.json'
-      - '!**/*.md'
-  pull_request:
-    branches: [ main, next ]
-    paths:
-      - 'apps/web/**'
-      - 'packages/**'
-      - '.github/workflows/playwright-smoke.yml'
-      - 'pnpm-lock.yaml'
-      - 'turbo.json'
-      - '!**/*.md'
 
 # Concurrency control - cancel old runs within the same PR when new commits arrive
 # Different PRs and branches can run in parallel

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,24 +2,6 @@ name: Playwright Tests
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main, next ]
-    paths:
-      - 'apps/web/**'
-      - 'packages/**'
-      - '.github/workflows/playwright.yml'
-      - 'pnpm-lock.yaml'
-      - 'turbo.json'
-      - '!**/*.md'
-  pull_request:
-    branches: [ main, next ]
-    paths:
-      - 'apps/web/**'
-      - 'packages/**'
-      - '.github/workflows/playwright.yml'
-      - 'pnpm-lock.yaml'
-      - 'turbo.json'
-      - '!**/*.md'
 
 # Concurrency control - cancel old runs within the same PR when new commits arrive
 # Different PRs and branches can run in parallel

--- a/.github/workflows/test-playground-e2e.yml
+++ b/.github/workflows/test-playground-e2e.yml
@@ -1,18 +1,7 @@
 name: E2E Tests "@softmaple/playground" app
 
 on:
-  pull_request:
-    paths:
-      - 'apps/playground/**/*.ts'
-      - 'apps/playground/**/*.tsx'
-      - 'apps/playground/e2e/**'
-      - 'apps/playground/package.json'
-      - 'apps/playground/vite.config.*'
-      - 'apps/playground/playwright.config.ts'
-      - 'packages/eg-walker/**'
-      - 'packages/ui/**'
-      - '.github/workflows/test-playground-e2e.yml'
-      - '!**/*.md'
+  workflow_dispatch:
 
 # Concurrency control - cancel old runs within the same PR when new commits arrive
 # Different PRs can run in parallel


### PR DESCRIPTION
## Summary

- Disable automatic CI triggers for the full web Playwright workflow.
- Disable automatic CI triggers for the web Playwright smoke workflow.
- Disable automatic PR runs for the playground E2E workflow.

The workflows remain available for manual execution through `workflow_dispatch`.

## Validation

- Checked the workflow trigger blocks with `rg` to confirm each affected workflow now only exposes `workflow_dispatch`.
- Committed through the repository hooks without `--no-verify`.

## Impact

Pushes and pull requests will no longer start these Playwright/E2E workflows automatically. Maintainers can still run them manually from GitHub Actions when needed.