### PR TITLE
feat(packages/awareness): close design-doc gaps in presence components

### DIFF
--- a/packages/awareness/package.json
+++ b/packages/awareness/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/components/activity-indicator.d.ts",
       "import": "./dist/components/activity-indicator.js"
     },
+    "./components/block-activity-indicator": {
+      "types": "./dist/components/block-activity-indicator.d.ts",
+      "import": "./dist/components/block-activity-indicator.js"
+    },
     "./components/live-cursor": {
       "types": "./dist/components/live-cursor.d.ts",
       "import": "./dist/components/live-cursor.js"

--- a/packages/awareness/src/components/block-activity-indicator.tsx
+++ b/packages/awareness/src/components/block-activity-indicator.tsx
@@ -1,0 +1,118 @@
+/**
+ * BlockActivityIndicator - per-block aggregated presence indicator.
+ *
+ * Implements design doc §5.4 ("Activity Indicator / Action Awareness"):
+ *   - "Adam is editing this paragraph"
+ *   - "2 people editing here"
+ *
+ * Unlike `ActivityIndicator` (a recent-event log), this component answers the
+ * question "who is in *this* block right now?" by filtering active/idle peers
+ * whose cursor or selection lives in the given `blockId`.
+ */
+
+import { type ContextType, type ReactNode, useContext, useMemo } from "react";
+import { PresenceContext } from "../providers/presence-context";
+import type { PresenceUser } from "../types/presence";
+import { cx } from "./utils";
+
+export interface BlockActivityIndicatorProps {
+  /** The block this indicator is anchored to. */
+  readonly blockId: string;
+  /**
+   * Override the user list. Defaults to the users provided by
+   * `PresenceContext` (excluding `self`).
+   */
+  readonly users?: ReadonlyArray<PresenceUser>;
+  /** Whether to count the current user. Defaults to `false`. */
+  readonly includeSelf?: boolean;
+  /**
+   * Whether to count offline users. Defaults to `false` — offline peers are
+   * irrelevant for "who is editing here right now".
+   */
+  readonly includeOffline?: boolean;
+  /**
+   * Render the indicator even when nobody is in the block. Defaults to
+   * `false` (component renders `null`).
+   */
+  readonly renderWhenEmpty?: boolean;
+  /** Label when nobody is in the block (only used with `renderWhenEmpty`). */
+  readonly emptyLabel?: string;
+  /**
+   * Custom label formatter. Receives users currently in the block.
+   * Defaults to the §5.4 phrasing.
+   */
+  readonly formatLabel?: (users: ReadonlyArray<PresenceUser>) => string;
+  readonly className?: string;
+  readonly "aria-label"?: string;
+}
+
+const getUsersFromContext = (
+  context: ContextType<typeof PresenceContext>,
+  includeSelf: boolean,
+): ReadonlyArray<PresenceUser> => {
+  if (context === null) return [];
+  if (includeSelf) return Array.from(context.presence.values());
+  return context.others;
+};
+
+const isUserInBlock = (user: PresenceUser, blockId: string): boolean =>
+  user.cursor?.blockId === blockId || user.selection?.blockId === blockId;
+
+const defaultFormatLabel = (users: ReadonlyArray<PresenceUser>): string => {
+  if (users.length === 0) return "";
+  if (users.length === 1) {
+    const [user] = users;
+    return user ? `${user.name} is editing this block` : "";
+  }
+  return `${users.length} people editing here`;
+};
+
+export const BlockActivityIndicator = ({
+  blockId,
+  users,
+  includeSelf = false,
+  includeOffline = false,
+  renderWhenEmpty = false,
+  emptyLabel = "No one editing here",
+  formatLabel = defaultFormatLabel,
+  className,
+  "aria-label": ariaLabel,
+}: BlockActivityIndicatorProps): ReactNode => {
+  const context = useContext(PresenceContext);
+
+  const activeUsers = useMemo(() => {
+    const source = users ?? getUsersFromContext(context, includeSelf);
+    return source.filter((user) => {
+      if (!includeOffline && user.status === "offline") return false;
+      return isUserInBlock(user, blockId);
+    });
+  }, [blockId, context, includeOffline, includeSelf, users]);
+
+  if (activeUsers.length === 0 && !renderWhenEmpty) return null;
+
+  const label =
+    activeUsers.length === 0 ? emptyLabel : formatLabel(activeUsers);
+  const primaryColor = activeUsers[0]?.color;
+
+  return (
+    <output
+      aria-label={ariaLabel ?? label}
+      aria-live="polite"
+      className={cx("awareness-block-activity-indicator", className)}
+      style={
+        primaryColor
+          ? ({ "--awareness-user-color": primaryColor } as Record<
+              string,
+              string
+            >)
+          : undefined
+      }
+    >
+      <span
+        aria-hidden="true"
+        className="awareness-block-activity-indicator__dot"
+      />
+      <span className="awareness-block-activity-indicator__text">{label}</span>
+    </output>
+  );
+};

--- a/packages/awareness/src/components/block-activity-indicator.tsx
+++ b/packages/awareness/src/components/block-activity-indicator.tsx
@@ -10,7 +10,7 @@
  * whose cursor or selection lives in the given `blockId`.
  */
 
-import { type ContextType, type ReactNode, useContext, useMemo } from "react";
+import { type ReactNode, useContext, useMemo } from "react";
 import { PresenceContext } from "../providers/presence-context";
 import type { PresenceUser } from "../types/presence";
 import { cx } from "./utils";
@@ -19,8 +19,9 @@ export interface BlockActivityIndicatorProps {
   /** The block this indicator is anchored to. */
   readonly blockId: string;
   /**
-   * Override the user list. Defaults to the users provided by
-   * `PresenceContext` (excluding `self`).
+   * Override the user list. Defaults to `PresenceContext.others` when
+   * `includeSelf` is false (the default), or `PresenceContext.presence`
+   * otherwise.
    */
   readonly users?: ReadonlyArray<PresenceUser>;
   /** Whether to count the current user. Defaults to `false`. */
@@ -35,7 +36,10 @@ export interface BlockActivityIndicatorProps {
    * `false` (component renders `null`).
    */
   readonly renderWhenEmpty?: boolean;
-  /** Label when nobody is in the block (only used with `renderWhenEmpty`). */
+  /**
+   * Label rendered when `renderWhenEmpty` is true and nobody is currently
+   * editing the block.
+   */
   readonly emptyLabel?: string;
   /**
    * Custom label formatter. Receives users currently in the block.
@@ -45,15 +49,6 @@ export interface BlockActivityIndicatorProps {
   readonly className?: string;
   readonly "aria-label"?: string;
 }
-
-const getUsersFromContext = (
-  context: ContextType<typeof PresenceContext>,
-  includeSelf: boolean,
-): ReadonlyArray<PresenceUser> => {
-  if (context === null) return [];
-  if (includeSelf) return Array.from(context.presence.values());
-  return context.others;
-};
 
 const isUserInBlock = (user: PresenceUser, blockId: string): boolean =>
   user.cursor?.blockId === blockId || user.selection?.blockId === blockId;
@@ -79,14 +74,25 @@ export const BlockActivityIndicator = ({
   "aria-label": ariaLabel,
 }: BlockActivityIndicatorProps): ReactNode => {
   const context = useContext(PresenceContext);
+  // Narrow the memo deps so unrelated context churn (e.g. a new
+  // `recentActivity` entry) does not re-filter the users list.
+  const ctxOthers = context?.others;
+  const ctxPresence = context?.presence;
 
   const activeUsers = useMemo(() => {
-    const source = users ?? getUsersFromContext(context, includeSelf);
+    let source: ReadonlyArray<PresenceUser>;
+    if (users !== undefined) {
+      source = users;
+    } else if (includeSelf) {
+      source = ctxPresence ? Array.from(ctxPresence.values()) : [];
+    } else {
+      source = ctxOthers ?? [];
+    }
     return source.filter((user) => {
       if (!includeOffline && user.status === "offline") return false;
       return isUserInBlock(user, blockId);
     });
-  }, [blockId, context, includeOffline, includeSelf, users]);
+  }, [blockId, ctxOthers, ctxPresence, includeOffline, includeSelf, users]);
 
   if (activeUsers.length === 0 && !renderWhenEmpty) return null;
 
@@ -95,10 +101,12 @@ export const BlockActivityIndicator = ({
   const primaryColor = activeUsers[0]?.color;
 
   return (
-    <output
+    // biome-ignore lint/a11y/useSemanticElements: <output> is for form-calculated values; this is presence telemetry, so a div with role="status" is the semantically appropriate live region.
+    <div
       aria-label={ariaLabel ?? label}
       aria-live="polite"
       className={cx("awareness-block-activity-indicator", className)}
+      role="status"
       style={
         primaryColor
           ? ({ "--awareness-user-color": primaryColor } as Record<
@@ -113,6 +121,6 @@ export const BlockActivityIndicator = ({
         className="awareness-block-activity-indicator__dot"
       />
       <span className="awareness-block-activity-indicator__text">{label}</span>
-    </output>
+    </div>
   );
 };

--- a/packages/awareness/src/components/design-gaps.test.tsx
+++ b/packages/awareness/src/components/design-gaps.test.tsx
@@ -1,0 +1,350 @@
+/**
+ * Tests covering the design-doc gaps fixed in this change:
+ *   - LiveCursor off-screen culling (§7)
+ *   - LiveCursor default fade ≈ 3000 ms (§6)
+ *   - SelectionHighlight hover-to-reveal label (§5.3)
+ *   - BlockActivityIndicator per-block aggregation (§5.4)
+ *   - PresenceProvider local idle/offline status sweep (§4.2)
+ */
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  AdapterConnectionState,
+  ConnectionCallback,
+  ErrorCallback,
+  EventCallback,
+  PresenceAdapter,
+  PresenceCallback,
+  Unsubscribe,
+} from "../adapters/types";
+import { PresenceContext } from "../providers/presence-context";
+import { PresenceProvider } from "../providers/presence-provider";
+import type { PresenceUser } from "../types/presence";
+import { BlockActivityIndicator } from "./block-activity-indicator";
+import { LiveCursor } from "./live-cursor";
+import { SelectionHighlight } from "./selection-highlight";
+
+const reactActGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+const user = (
+  id: string,
+  overrides: Partial<Omit<PresenceUser, "userId">> = {},
+): PresenceUser => ({
+  userId: id,
+  name: `User ${id}`,
+  color: "#2563eb",
+  status: "active",
+  lastActiveAt: 1000,
+  ...overrides,
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
+
+describe("LiveCursor off-screen culling (design §7)", () => {
+  it("renders when point is inside the window viewport", () => {
+    const html = renderToStaticMarkup(
+      <LiveCursor point={{ x: 100, y: 100 }} user={user("a")} />,
+    );
+    expect(html).toContain("awareness-live-cursor");
+  });
+
+  it("returns null when point is far outside the window viewport", () => {
+    const html = renderToStaticMarkup(
+      <LiveCursor point={{ x: 999_999, y: 999_999 }} user={user("a")} />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("honors an explicit viewport rect", () => {
+    const inside = renderToStaticMarkup(
+      <LiveCursor
+        point={{ x: 50, y: 50 }}
+        user={user("a")}
+        viewport={{ x: 0, y: 0, width: 200, height: 200 }}
+      />,
+    );
+    const outside = renderToStaticMarkup(
+      <LiveCursor
+        point={{ x: 500, y: 500 }}
+        user={user("a")}
+        cullMargin={0}
+        viewport={{ x: 0, y: 0, width: 200, height: 200 }}
+      />,
+    );
+    expect(inside).toContain("awareness-live-cursor");
+    expect(outside).toBe("");
+  });
+
+  it('never culls when viewport="none"', () => {
+    const html = renderToStaticMarkup(
+      <LiveCursor
+        point={{ x: 999_999, y: 999_999 }}
+        user={user("a")}
+        viewport="none"
+      />,
+    );
+    expect(html).toContain("awareness-live-cursor");
+  });
+});
+
+describe("SelectionHighlight hover-to-reveal label (design §5.3)", () => {
+  it('adds hoverable class when showLabel="hover"', () => {
+    const html = renderToStaticMarkup(
+      <SelectionHighlight
+        rect={{ x: 0, y: 0, width: 10, height: 10 }}
+        showLabel="hover"
+        user={user("a", { name: "Hover" })}
+      />,
+    );
+    expect(html).toContain("awareness-selection-highlight--hoverable");
+    expect(html).toContain("Hover");
+    expect(html).toContain('tabindex="0"');
+  });
+
+  it("does not add hoverable class for boolean showLabel", () => {
+    const truthy = renderToStaticMarkup(
+      <SelectionHighlight
+        rect={{ x: 0, y: 0, width: 10, height: 10 }}
+        showLabel
+        user={user("a", { name: "Vis" })}
+      />,
+    );
+    expect(truthy).not.toContain("awareness-selection-highlight--hoverable");
+    expect(truthy).toContain("Vis");
+  });
+});
+
+describe("BlockActivityIndicator (design §5.4)", () => {
+  const a = user("a", {
+    name: "Ada",
+    cursor: { blockId: "b1", offset: 0 },
+  });
+  const b = user("b", {
+    name: "Bea",
+    selection: { blockId: "b1", from: 0, to: 5 },
+  });
+  const c = user("c", { name: "Cam", cursor: { blockId: "other", offset: 0 } });
+
+  it("renders nothing when no one is in the block", () => {
+    const html = renderToStaticMarkup(
+      <BlockActivityIndicator blockId="b1" users={[c]} />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders single-user phrasing", () => {
+    const html = renderToStaticMarkup(
+      <BlockActivityIndicator blockId="b1" users={[a, c]} />,
+    );
+    expect(html).toContain("Ada is editing this block");
+  });
+
+  it("renders multi-user count", () => {
+    const html = renderToStaticMarkup(
+      <BlockActivityIndicator blockId="b1" users={[a, b, c]} />,
+    );
+    expect(html).toContain("2 people editing here");
+  });
+
+  it("excludes offline users by default", () => {
+    const offline = user("d", {
+      name: "Dee",
+      status: "offline",
+      cursor: { blockId: "b1", offset: 0 },
+    });
+    const html = renderToStaticMarkup(
+      <BlockActivityIndicator blockId="b1" users={[offline]} />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders empty label when renderWhenEmpty is set", () => {
+    const html = renderToStaticMarkup(
+      <BlockActivityIndicator
+        blockId="b1"
+        emptyLabel="Quiet here"
+        renderWhenEmpty
+        users={[]}
+      />,
+    );
+    expect(html).toContain("Quiet here");
+  });
+
+  it("reads from PresenceContext when no users prop is provided", () => {
+    const ctxValue = {
+      connectionState: "connected" as const,
+      self: null,
+      presence: new Map([
+        [a.userId, a],
+        [b.userId, b],
+      ]),
+      others: [a, b],
+      recentActivity: [],
+      updatePresence: vi.fn(),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(async () => {}),
+      adapter: null,
+    };
+
+    const html = renderToStaticMarkup(
+      <PresenceContext.Provider value={ctxValue}>
+        <BlockActivityIndicator blockId="b1" />
+      </PresenceContext.Provider>,
+    );
+    expect(html).toContain("2 people editing here");
+  });
+});
+
+class StatusSweepAdapter implements PresenceAdapter {
+  presenceCallbacks = new Set<PresenceCallback>();
+  eventCallbacks = new Set<EventCallback>();
+  connectionCallbacks = new Set<ConnectionCallback>();
+  errorCallbacks = new Set<ErrorCallback>();
+
+  state: AdapterConnectionState = "disconnected";
+  presence: ReadonlyMap<string, PresenceUser> = new Map();
+  self: PresenceUser | null = null;
+
+  connect = vi.fn(async (): Promise<void> => {});
+  disconnect = vi.fn(async (): Promise<void> => {});
+  getConnectionState = (): AdapterConnectionState => this.state;
+  updatePresence = vi.fn();
+  broadcast = vi.fn();
+  getPresence = (): ReadonlyMap<string, PresenceUser> => this.presence;
+  getSelf = (): PresenceUser | null => this.self;
+
+  onPresenceChange = (cb: PresenceCallback): Unsubscribe => {
+    this.presenceCallbacks.add(cb);
+    return () => {
+      this.presenceCallbacks.delete(cb);
+    };
+  };
+  onEvent = (cb: EventCallback): Unsubscribe => {
+    this.eventCallbacks.add(cb);
+    return () => {
+      this.eventCallbacks.delete(cb);
+    };
+  };
+  onConnectionChange = (cb: ConnectionCallback): Unsubscribe => {
+    this.connectionCallbacks.add(cb);
+    return () => {
+      this.connectionCallbacks.delete(cb);
+    };
+  };
+  onError = (cb: ErrorCallback): Unsubscribe => {
+    this.errorCallbacks.add(cb);
+    return () => {
+      this.errorCallbacks.delete(cb);
+    };
+  };
+
+  pushPresence = (next: ReadonlyMap<string, PresenceUser>): void => {
+    this.presence = next;
+    for (const cb of this.presenceCallbacks) cb(next);
+  };
+}
+
+describe("PresenceProvider status sweep (design §4.2)", () => {
+  it("demotes stale users from active to idle to offline over time", async () => {
+    vi.useFakeTimers();
+    const adapter = new StatusSweepAdapter();
+
+    let observedStatus: string | undefined;
+    const Probe = (): null => {
+      // Read from context via a ref-y consumer
+      return null;
+    };
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PresenceProvider
+          adapter={adapter}
+          autoConnect={false}
+          statusConfig={{
+            maxActivities: 10,
+            idleTimeoutMs: 1_000,
+            offlineTimeoutMs: 2_000,
+            cursorThrottleMs: 50,
+          }}
+          statusSweepMs={500}
+        >
+          <PresenceContext.Consumer>
+            {(value) => {
+              observedStatus = value?.presence.get("stale")?.status;
+              return <Probe />;
+            }}
+          </PresenceContext.Consumer>
+        </PresenceProvider>,
+      );
+    });
+
+    const stale = user("stale", {
+      name: "Stale",
+      lastActiveAt: Date.now() - 1_500, // older than idle threshold
+      status: "active",
+    });
+
+    act(() => {
+      adapter.pushPresence(new Map([[stale.userId, stale]]));
+    });
+    expect(observedStatus).toBe("active");
+
+    // First sweep should mark them idle (elapsed > 1s).
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(observedStatus).toBe("idle");
+
+    // After more time passes, they should go offline (elapsed > 2s).
+    await act(async () => {
+      vi.advanceTimersByTime(1_500);
+    });
+    expect(observedStatus).toBe("offline");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("skips the sweep interval when statusSweepMs=0", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const adapter = new StatusSweepAdapter();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PresenceProvider
+          adapter={adapter}
+          autoConnect={false}
+          statusSweepMs={0}
+        >
+          {null}
+        </PresenceProvider>,
+      );
+    });
+
+    // No sweep timer should be installed when disabled.
+    const sweepCall = setIntervalSpy.mock.calls.find((call) => call[1] === 0);
+    expect(sweepCall).toBeUndefined();
+
+    await act(async () => {
+      root.unmount();
+    });
+    setIntervalSpy.mockRestore();
+  });
+});

--- a/packages/awareness/src/components/design-gaps.test.tsx
+++ b/packages/awareness/src/components/design-gaps.test.tsx
@@ -319,9 +319,11 @@ describe("PresenceProvider status sweep (design §4.2)", () => {
     });
   });
 
-  it("skips the sweep interval when statusSweepMs=0", async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+  it("does not demote stale users when statusSweepMs=0", async () => {
+    vi.useFakeTimers();
     const adapter = new StatusSweepAdapter();
+    let observedStatus: string | undefined;
+
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -331,20 +333,43 @@ describe("PresenceProvider status sweep (design §4.2)", () => {
         <PresenceProvider
           adapter={adapter}
           autoConnect={false}
+          statusConfig={{
+            maxActivities: 10,
+            idleTimeoutMs: 1_000,
+            offlineTimeoutMs: 2_000,
+            cursorThrottleMs: 50,
+          }}
           statusSweepMs={0}
         >
-          {null}
+          <PresenceContext.Consumer>
+            {(value) => {
+              observedStatus = value?.presence.get("stale")?.status;
+              return null;
+            }}
+          </PresenceContext.Consumer>
         </PresenceProvider>,
       );
     });
 
-    // No sweep timer should be installed when disabled.
-    const sweepCall = setIntervalSpy.mock.calls.find((call) => call[1] === 0);
-    expect(sweepCall).toBeUndefined();
+    const stale = user("stale", {
+      name: "Stale",
+      lastActiveAt: Date.now() - 10_000,
+      status: "active",
+    });
+
+    act(() => {
+      adapter.pushPresence(new Map([[stale.userId, stale]]));
+    });
+
+    // Advance well past both thresholds — without a sweep timer, the
+    // status should remain "active" because no sweep ever runs.
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(observedStatus).toBe("active");
 
     await act(async () => {
       root.unmount();
     });
-    setIntervalSpy.mockRestore();
   });
 });

--- a/packages/awareness/src/components/design-gaps.test.tsx
+++ b/packages/awareness/src/components/design-gaps.test.tsx
@@ -94,6 +94,55 @@ describe("LiveCursor off-screen culling (design §7)", () => {
     );
     expect(html).toContain("awareness-live-cursor");
   });
+
+  it("re-evaluates window-based culling on resize", async () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <LiveCursor
+          cullMargin={0}
+          point={{ x: 400, y: 400 }}
+          user={user("a")}
+        />,
+      );
+    });
+    expect(container.querySelector(".awareness-live-cursor")).not.toBeNull();
+
+    // Shrink the window and dispatch resize — cursor should re-evaluate
+    // and cull itself without any pointer movement.
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 100,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 100,
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(container.querySelector(".awareness-live-cursor")).toBeNull();
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });
 
 describe("SelectionHighlight hover-to-reveal label (design §5.3)", () => {
@@ -177,6 +226,57 @@ describe("BlockActivityIndicator (design §5.4)", () => {
       />,
     );
     expect(html).toContain("Quiet here");
+  });
+
+  it("includes self when includeSelf=true and reads from context.presence", () => {
+    const self = user("self", {
+      name: "Self",
+      cursor: { blockId: "b1", offset: 0 },
+    });
+    const ctxValue = {
+      connectionState: "connected" as const,
+      self,
+      presence: new Map([
+        [self.userId, self],
+        [a.userId, a],
+      ]),
+      others: [a],
+      recentActivity: [],
+      updatePresence: vi.fn(),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(async () => {}),
+      adapter: null,
+    };
+
+    const html = renderToStaticMarkup(
+      <PresenceContext.Provider value={ctxValue}>
+        <BlockActivityIndicator blockId="b1" includeSelf />
+      </PresenceContext.Provider>,
+    );
+    // Both self + ada are in block b1.
+    expect(html).toContain("2 people editing here");
+  });
+
+  it("falls back to an empty list when context has no presence map", () => {
+    const ctxValue = {
+      connectionState: "connected" as const,
+      self: null,
+      // Force the `ctxPresence ? ... : []` else branch to exercise.
+      presence: undefined as unknown as ReadonlyMap<string, PresenceUser>,
+      others: [] as ReadonlyArray<PresenceUser>,
+      recentActivity: [],
+      updatePresence: vi.fn(),
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(async () => {}),
+      adapter: null,
+    };
+
+    const html = renderToStaticMarkup(
+      <PresenceContext.Provider value={ctxValue}>
+        <BlockActivityIndicator blockId="b1" includeSelf />
+      </PresenceContext.Provider>,
+    );
+    expect(html).toBe("");
   });
 
   it("reads from PresenceContext when no users prop is provided", () => {
@@ -313,6 +413,60 @@ describe("PresenceProvider status sweep (design §4.2)", () => {
       vi.advanceTimersByTime(1_500);
     });
     expect(observedStatus).toBe("offline");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("demotes self when self goes stale", async () => {
+    vi.useFakeTimers();
+    const adapter = new StatusSweepAdapter();
+    let observedSelfStatus: string | undefined;
+
+    const selfUser = user("self", {
+      name: "Self",
+      lastActiveAt: Date.now() - 1_500,
+      status: "active",
+    });
+    adapter.self = selfUser;
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PresenceProvider
+          adapter={adapter}
+          autoConnect={false}
+          statusConfig={{
+            maxActivities: 10,
+            idleTimeoutMs: 1_000,
+            offlineTimeoutMs: 2_000,
+            cursorThrottleMs: 50,
+          }}
+          statusSweepMs={500}
+        >
+          <PresenceContext.Consumer>
+            {(value) => {
+              observedSelfStatus = value?.self?.status;
+              return null;
+            }}
+          </PresenceContext.Consumer>
+        </PresenceProvider>,
+      );
+    });
+
+    act(() => {
+      adapter.pushPresence(new Map([[selfUser.userId, selfUser]]));
+    });
+    expect(observedSelfStatus).toBe("active");
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(observedSelfStatus).toBe("idle");
 
     await act(async () => {
       root.unmount();

--- a/packages/awareness/src/components/index.ts
+++ b/packages/awareness/src/components/index.ts
@@ -3,9 +3,14 @@ export {
   type ActivityIndicatorProps,
 } from "./activity-indicator";
 export {
+  BlockActivityIndicator,
+  type BlockActivityIndicatorProps,
+} from "./block-activity-indicator";
+export {
   LiveCursor,
   type LiveCursorPoint,
   type LiveCursorProps,
+  type LiveCursorViewport,
 } from "./live-cursor";
 export {
   PresenceAvatar,

--- a/packages/awareness/src/components/live-cursor.tsx
+++ b/packages/awareness/src/components/live-cursor.tsx
@@ -7,20 +7,79 @@ export interface LiveCursorPoint {
   readonly y: number;
 }
 
+/**
+ * Rectangle the cursor must intersect to be rendered. Cursors fully outside
+ * are culled per design doc §7 ("Off-screen cursors not rendered").
+ *
+ * `"window"` (default) uses `window.innerWidth`/`innerHeight` at the time the
+ * point updates; `"none"` disables culling; or pass an explicit rect.
+ */
+export type LiveCursorViewport =
+  | "window"
+  | "none"
+  | {
+      readonly x: number;
+      readonly y: number;
+      readonly width: number;
+      readonly height: number;
+    };
+
 export interface LiveCursorProps {
   readonly user: PresenceUser;
   readonly point: LiveCursorPoint;
   readonly labelVisibleMs?: number;
   readonly showLabel?: boolean;
   readonly className?: string;
+  /**
+   * Bounds used for off-screen culling. Defaults to the current window.
+   * Set to `"none"` to always render (e.g. inside a virtualized scroller
+   * where you've already culled upstream).
+   */
+  readonly viewport?: LiveCursorViewport;
+  /**
+   * Extra margin in pixels added to the viewport so cursors just outside
+   * the edge are still rendered (avoids flicker at the boundary).
+   * Defaults to 32.
+   */
+  readonly cullMargin?: number;
 }
+
+const isPointInViewport = (
+  point: LiveCursorPoint,
+  viewport: LiveCursorViewport,
+  margin: number,
+): boolean => {
+  if (viewport === "none") return true;
+
+  let bounds: { x: number; y: number; width: number; height: number };
+  if (viewport === "window") {
+    if (typeof window === "undefined") return true;
+    bounds = {
+      x: 0,
+      y: 0,
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+  } else {
+    bounds = viewport;
+  }
+
+  return (
+    point.x >= bounds.x - margin &&
+    point.x <= bounds.x + bounds.width + margin &&
+    point.y >= bounds.y - margin &&
+    point.y <= bounds.y + bounds.height + margin
+  );
+};
 
 export const LiveCursor = ({
   user,
   point,
-  labelVisibleMs = 2800,
+  labelVisibleMs = 3000,
   showLabel = true,
   className,
+  viewport = "window",
+  cullMargin = 32,
 }: LiveCursorProps): ReactNode => {
   const [isLabelVisible, setIsLabelVisible] = useState(showLabel);
   const previousPointRef = useRef(point);
@@ -47,6 +106,10 @@ export const LiveCursor = ({
       clearTimeout(timeoutId);
     };
   }, [labelVisibleMs, point.x, point.y, showLabel]);
+
+  if (!isPointInViewport(point, viewport, cullMargin)) {
+    return null;
+  }
 
   return (
     <div

--- a/packages/awareness/src/components/live-cursor.tsx
+++ b/packages/awareness/src/components/live-cursor.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useReducer, useRef, useState } from "react";
 import type { PresenceUser } from "../types/presence";
 import { cx, toUserColorStyle } from "./utils";
 
@@ -11,8 +11,10 @@ export interface LiveCursorPoint {
  * Rectangle the cursor must intersect to be rendered. Cursors fully outside
  * are culled per design doc §7 ("Off-screen cursors not rendered").
  *
- * `"window"` (default) uses `window.innerWidth`/`innerHeight` at the time the
- * point updates; `"none"` disables culling; or pass an explicit rect.
+ * `"window"` (default) reads `window.innerWidth`/`innerHeight` and re-evaluates
+ * on `resize` so cursors at the edge cull/uncull correctly. `"none"` disables
+ * culling (useful inside virtualized scrollers that cull upstream); or pass an
+ * explicit rect.
  */
 export type LiveCursorViewport =
   | "window"
@@ -83,6 +85,20 @@ export const LiveCursor = ({
 }: LiveCursorProps): ReactNode => {
   const [isLabelVisible, setIsLabelVisible] = useState(showLabel);
   const previousPointRef = useRef(point);
+
+  // Re-evaluate window-based culling on resize so cursors near the edge
+  // cull/uncull correctly without waiting for the next pointer move.
+  const [, bumpResize] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    if (viewport !== "window" || typeof window === "undefined") return;
+    const handler = (): void => {
+      bumpResize();
+    };
+    window.addEventListener("resize", handler, { passive: true });
+    return () => {
+      window.removeEventListener("resize", handler);
+    };
+  }, [viewport]);
 
   useEffect(() => {
     if (!showLabel) {

--- a/packages/awareness/src/components/selection-highlight.tsx
+++ b/packages/awareness/src/components/selection-highlight.tsx
@@ -13,7 +13,13 @@ export interface SelectionHighlightProps {
   readonly user: PresenceUser;
   readonly rect: HighlightRect;
   readonly selectedText?: string;
-  readonly showLabel?: boolean;
+  /**
+   * When `true`, the user badge is always visible.
+   * When `false` (default), the badge is hidden.
+   * When `"hover"`, the badge is hidden until the highlight is hovered or
+   * keyboard-focused — matches design doc §5.3 ("Hover reveals user badge").
+   */
+  readonly showLabel?: boolean | "hover";
   readonly className?: string;
   readonly style?: CSSProperties;
 }
@@ -41,21 +47,33 @@ export const SelectionHighlight = ({
   showLabel = false,
   className,
   style,
-}: SelectionHighlightProps): ReactNode => (
-  <div
-    aria-label={getSelectionLabel(user, selectedText)}
-    className={cx("awareness-selection-highlight", className)}
-    role="img"
-    style={{
-      ...toUserColorStyle(user.color),
-      height: rect.height,
-      transform: `translate3d(${rect.x}px, ${rect.y}px, 0)`,
-      width: rect.width,
-      ...style,
-    }}
-  >
-    {showLabel ? (
-      <span className="awareness-selection-highlight__label">{user.name}</span>
-    ) : null}
-  </div>
-);
+}: SelectionHighlightProps): ReactNode => {
+  const isHoverLabel = showLabel === "hover";
+  const renderLabel = showLabel === true || isHoverLabel;
+
+  return (
+    <div
+      aria-label={getSelectionLabel(user, selectedText)}
+      className={cx(
+        "awareness-selection-highlight",
+        isHoverLabel && "awareness-selection-highlight--hoverable",
+        className,
+      )}
+      role="img"
+      style={{
+        ...toUserColorStyle(user.color),
+        height: rect.height,
+        transform: `translate3d(${rect.x}px, ${rect.y}px, 0)`,
+        width: rect.width,
+        ...style,
+      }}
+      tabIndex={isHoverLabel ? 0 : undefined}
+    >
+      {renderLabel ? (
+        <span className="awareness-selection-highlight__label">
+          {user.name}
+        </span>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -265,6 +265,25 @@
   @apply absolute -top-6 left-0 max-w-56 overflow-hidden px-[7px] py-[3px] rounded-md text-white font-awareness text-[11px] tracking-normal leading-[1.2] text-ellipsis whitespace-nowrap;
 }
 
+.awareness-selection-highlight--hoverable {
+  pointer-events: auto;
+}
+
+.awareness-selection-highlight--hoverable
+  .awareness-selection-highlight__label {
+  opacity: 0;
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.awareness-selection-highlight--hoverable:hover
+  .awareness-selection-highlight__label,
+.awareness-selection-highlight--hoverable:focus-visible
+  .awareness-selection-highlight__label {
+  opacity: 1;
+}
+
 .awareness-activity-indicator {
   box-sizing: border-box;
   inline-size: min(320px, 100%);
@@ -335,6 +354,56 @@
   --awareness-activity-color: var(--color-awareness-activity-leave);
 }
 
+.awareness-block-activity-indicator {
+  background: color-mix(in srgb, Canvas 92%, transparent);
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--awareness-user-color, var(--color-awareness-border)) 32%,
+      transparent
+    );
+  box-shadow: var(--shadow-awareness-close);
+  max-width: 100%;
+  min-width: 0;
+  @apply inline-flex items-center gap-2 rounded-full px-2.5 py-[3px] text-awareness-text font-awareness text-[12px] leading-[1.2];
+}
+
+.awareness-block-activity-indicator__dot {
+  background: var(--awareness-user-color, var(--color-awareness-muted));
+  box-shadow: 0 0 0 3px
+    color-mix(
+      in srgb,
+      var(--awareness-user-color, var(--color-awareness-muted)) 18%,
+      transparent
+    );
+  animation: awareness-block-activity-pulse 2.4s ease-in-out infinite;
+  @apply block h-1.5 w-1.5 rounded-full flex-none;
+}
+
+.awareness-block-activity-indicator__text {
+  @apply min-w-0 truncate;
+}
+
+@keyframes awareness-block-activity-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0
+      color-mix(
+        in srgb,
+        var(--awareness-user-color, var(--color-awareness-muted)) 20%,
+        transparent
+      );
+  }
+  50% {
+    box-shadow: 0 0 0 4px
+      color-mix(
+        in srgb,
+        var(--awareness-user-color, var(--color-awareness-muted)) 0%,
+        transparent
+      );
+  }
+}
+
 @keyframes awareness-status-pulse {
   0%,
   100% {
@@ -355,11 +424,14 @@
   .awareness-avatar::after,
   .awareness-live-cursor,
   .awareness-live-cursor__label,
-  .awareness-presence-bar__item {
+  .awareness-presence-bar__item,
+  .awareness-selection-highlight--hoverable
+    .awareness-selection-highlight__label {
     transition: none;
   }
 
-  .awareness-avatar--active .awareness-avatar__status {
+  .awareness-avatar--active .awareness-avatar__status,
+  .awareness-block-activity-indicator__dot {
     animation: none;
   }
 }

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -221,7 +221,7 @@
     opacity 160ms ease,
     transform 160ms ease;
   box-shadow: var(--shadow-awareness);
-  @apply absolute -top-7 right-2 max-w-64 overflow-hidden px-2 py-[3px] rounded-md text-white font-awareness text-xs tracking-normal leading-[1.2] opacity-0 text-ellipsis whitespace-nowrap shadow-awareness;
+  @apply absolute bottom-full left-0 mb-[2px] max-w-64 overflow-hidden px-2 py-[3px] rounded-md text-white font-awareness text-xs tracking-normal leading-[1.2] opacity-0 text-ellipsis whitespace-nowrap shadow-awareness;
 }
 
 .awareness-live-cursor--label-visible .awareness-live-cursor__label {
@@ -262,7 +262,7 @@
     var(--awareness-selection-label-y)
   );
   box-shadow: var(--shadow-awareness-close);
-  @apply absolute -top-6 left-0 max-w-56 overflow-hidden px-[7px] py-[3px] rounded-md text-white font-awareness text-[11px] tracking-normal leading-[1.2] text-ellipsis whitespace-nowrap;
+  @apply absolute bottom-full left-0 mb-[2px] max-w-56 overflow-hidden px-[7px] py-[3px] rounded-md text-white font-awareness text-[11px] tracking-normal leading-[1.2] text-ellipsis whitespace-nowrap;
 }
 
 .awareness-selection-highlight--hoverable {

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -368,6 +368,10 @@
   @apply inline-flex items-center gap-2 rounded-full px-2.5 py-[3px] text-awareness-text font-awareness text-[12px] leading-[1.2];
 }
 
+/*
+ * Static dot — design doc §6 says "No persistent animation", so the dot
+ * communicates liveness via color/halo rather than a continuous pulse.
+ */
 .awareness-block-activity-indicator__dot {
   background: var(--awareness-user-color, var(--color-awareness-muted));
   box-shadow: 0 0 0 3px
@@ -376,32 +380,11 @@
       var(--awareness-user-color, var(--color-awareness-muted)) 18%,
       transparent
     );
-  animation: awareness-block-activity-pulse 2.4s ease-in-out infinite;
   @apply block h-1.5 w-1.5 rounded-full flex-none;
 }
 
 .awareness-block-activity-indicator__text {
   @apply min-w-0 truncate;
-}
-
-@keyframes awareness-block-activity-pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0
-      color-mix(
-        in srgb,
-        var(--awareness-user-color, var(--color-awareness-muted)) 20%,
-        transparent
-      );
-  }
-  50% {
-    box-shadow: 0 0 0 4px
-      color-mix(
-        in srgb,
-        var(--awareness-user-color, var(--color-awareness-muted)) 0%,
-        transparent
-      );
-  }
 }
 
 @keyframes awareness-status-pulse {
@@ -430,8 +413,7 @@
     transition: none;
   }
 
-  .awareness-avatar--active .awareness-avatar__status,
-  .awareness-block-activity-indicator__dot {
+  .awareness-avatar--active .awareness-avatar__status {
     animation: none;
   }
 }

--- a/packages/awareness/src/index.ts
+++ b/packages/awareness/src/index.ts
@@ -1,10 +1,13 @@
 export {
   ActivityIndicator,
   type ActivityIndicatorProps,
+  BlockActivityIndicator,
+  type BlockActivityIndicatorProps,
   type HighlightRect,
   LiveCursor,
   type LiveCursorPoint,
   type LiveCursorProps,
+  type LiveCursorViewport,
   PresenceAvatar,
   type PresenceAvatarProps,
   type PresenceAvatarSize,

--- a/packages/awareness/src/providers/presence-provider.tsx
+++ b/packages/awareness/src/providers/presence-provider.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import type {
@@ -15,12 +16,20 @@ import type {
   PresenceAdapter,
 } from "../adapters/types";
 import { ACTIVITY_TYPE, PRESENCE_EVENT } from "../constants/presence-events";
+import { determineUserStatus } from "../state/status-operations";
 import type { ActivityEvent, PresenceEvent } from "../types/events";
 import type { PresenceUser } from "../types/presence";
+import {
+  DEFAULT_PRESENCE_CONFIG,
+  type PresenceStateConfig,
+} from "../types/state";
 import { PresenceContext, type PresenceContextValue } from "./presence-context";
 
 /** Maximum number of recent activity events to track */
 const MAX_ACTIVITY_EVENTS = 50;
+
+/** Default interval (ms) between idle/offline status sweeps */
+const DEFAULT_STATUS_SWEEP_MS = 5_000;
 
 /**
  * Props for PresenceProvider
@@ -30,6 +39,17 @@ export interface PresenceProviderProps {
   readonly adapter: PresenceAdapter;
   /** Whether to auto-connect on mount (default: true) */
   readonly autoConnect?: boolean;
+  /**
+   * Idle/offline thresholds used by the local status sweep. Defaults to
+   * `DEFAULT_PRESENCE_CONFIG`.
+   */
+  readonly statusConfig?: PresenceStateConfig;
+  /**
+   * Interval (ms) between local status sweeps that demote stale users to
+   * `idle`/`offline`. Pass `0` to disable sweeping entirely (e.g. if the
+   * adapter already authoritatively manages status). Defaults to 5000.
+   */
+  readonly statusSweepMs?: number;
   /** Children to render */
   readonly children: ReactNode;
 }
@@ -139,11 +159,33 @@ const addActivityEvent = (
 };
 
 /**
+ * Apply local status demotion (active → idle → offline) based on lastActiveAt.
+ * Returns the same map reference if no user's status changed (lets memoization
+ * short-circuit downstream).
+ */
+const applyStatusSweep = (
+  presence: ReadonlyMap<string, PresenceUser>,
+  config: PresenceStateConfig,
+): ReadonlyMap<string, PresenceUser> => {
+  let next: Map<string, PresenceUser> | null = null;
+  for (const [userId, user] of presence) {
+    const newStatus = determineUserStatus(user, config);
+    if (newStatus !== user.status) {
+      if (next === null) next = new Map(presence);
+      next.set(userId, { ...user, status: newStatus });
+    }
+  }
+  return next ?? presence;
+};
+
+/**
  * PresenceProvider component - manages adapter lifecycle and provides context
  */
 export const PresenceProvider = ({
   adapter,
   autoConnect = true,
+  statusConfig = DEFAULT_PRESENCE_CONFIG,
+  statusSweepMs = DEFAULT_STATUS_SWEEP_MS,
   children,
 }: PresenceProviderProps): ReactNode => {
   // Use lazy initializers to get real adapter state on first render
@@ -203,6 +245,33 @@ export const PresenceProvider = ({
       });
     };
   }, [adapter, autoConnect]);
+
+  // Local status sweep — demotes stale users to `idle`/`offline` so the
+  // displayed status reflects time since `lastActiveAt` even if the adapter
+  // hasn't pushed a status update. Stays a no-op if every user's status
+  // already matches the threshold-derived value.
+  const presenceRef = useRef(presence);
+  presenceRef.current = presence;
+
+  useEffect(() => {
+    if (statusSweepMs <= 0) return;
+
+    const tick = () => {
+      const current = presenceRef.current;
+      const swept = applyStatusSweep(current, statusConfig);
+      if (swept !== current) {
+        setPresence(swept);
+        const selfId = adapter.getSelf()?.userId;
+        if (selfId !== undefined) {
+          const updated = swept.get(selfId);
+          if (updated !== undefined) setSelf(updated);
+        }
+      }
+    };
+
+    const id = setInterval(tick, statusSweepMs);
+    return () => clearInterval(id);
+  }, [adapter, statusConfig, statusSweepMs]);
 
   // Use adapter directly in callbacks (no ref needed)
   const connect = useCallback(async (): Promise<void> => {

--- a/packages/awareness/src/providers/presence-provider.tsx
+++ b/packages/awareness/src/providers/presence-provider.tsx
@@ -251,14 +251,29 @@ export const PresenceProvider = ({
   // hasn't pushed a status update. Stays a no-op if every user's status
   // already matches the threshold-derived value.
   const presenceRef = useRef(presence);
-  presenceRef.current = presence;
+  // Sync the ref in an effect (not during render) so concurrent-mode
+  // discarded renders cannot leave the ref pointing at unmounted state.
+  useEffect(() => {
+    presenceRef.current = presence;
+  }, [presence]);
+
+  // Destructure to primitive deps so a consumer passing an inline
+  // `statusConfig` literal does not tear down/recreate the interval on
+  // every render.
+  const { idleTimeoutMs, offlineTimeoutMs } = statusConfig;
 
   useEffect(() => {
     if (statusSweepMs <= 0) return;
 
+    const sweepConfig: PresenceStateConfig = {
+      ...DEFAULT_PRESENCE_CONFIG,
+      idleTimeoutMs,
+      offlineTimeoutMs,
+    };
+
     const tick = () => {
       const current = presenceRef.current;
-      const swept = applyStatusSweep(current, statusConfig);
+      const swept = applyStatusSweep(current, sweepConfig);
       if (swept !== current) {
         setPresence(swept);
         const selfId = adapter.getSelf()?.userId;
@@ -271,7 +286,7 @@ export const PresenceProvider = ({
 
     const id = setInterval(tick, statusSweepMs);
     return () => clearInterval(id);
-  }, [adapter, statusConfig, statusSweepMs]);
+  }, [adapter, idleTimeoutMs, offlineTimeoutMs, statusSweepMs]);
 
   // Use adapter directly in callbacks (no ref needed)
   const connect = useCallback(async (): Promise<void> => {

--- a/packages/awareness/src/stories/BlockActivityIndicator.stories.tsx
+++ b/packages/awareness/src/stories/BlockActivityIndicator.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import { BlockActivityIndicator } from "../components/block-activity-indicator";
+import type { PresenceUser } from "../types/presence";
+import { ada, grace, katherine } from "./awareness-fixtures";
+import { StoryFrame } from "./story-layout";
+
+// `ada.cursor.blockId === "abstract"` — single user in this block.
+const SINGLE_BLOCK_ID = "abstract";
+
+// Two users sharing the same block, derived from fixtures so colors stay on-brand.
+const SHARED_BLOCK_ID = "shared-paragraph";
+const sharedBlockUsers: ReadonlyArray<PresenceUser> = [
+  { ...grace, cursor: { blockId: SHARED_BLOCK_ID, offset: 0 } },
+  { ...katherine, selection: { blockId: SHARED_BLOCK_ID, from: 0, to: 12 } },
+];
+
+const meta = {
+  title: "Awareness/BlockActivityIndicator",
+  component: BlockActivityIndicator,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    blockId: SINGLE_BLOCK_ID,
+    users: [ada],
+  },
+  render: (args) => (
+    <StoryFrame>
+      <BlockActivityIndicator {...args} />
+    </StoryFrame>
+  ),
+} satisfies Meta<typeof BlockActivityIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SingleEditor: Story = {
+  play: async ({ canvas }) => {
+    const indicator = canvas.getByLabelText(
+      "Ada Lovelace is editing this block",
+    );
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toHaveTextContent(
+      "Ada Lovelace is editing this block",
+    );
+  },
+};
+
+export const MultipleEditors: Story = {
+  args: {
+    blockId: SHARED_BLOCK_ID,
+    users: sharedBlockUsers,
+  },
+  play: async ({ canvas }) => {
+    const indicator = canvas.getByLabelText("2 people editing here");
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toHaveTextContent("2 people editing here");
+  },
+};
+
+export const ExcludesOfflineUsers: Story = {
+  args: {
+    blockId: SINGLE_BLOCK_ID,
+    users: [
+      {
+        ...ada,
+        status: "offline",
+      },
+    ],
+  },
+  play: async ({ canvas }) => {
+    // Offline peers do not count toward "who is editing here right now".
+    await expect(canvas.queryByLabelText(/editing/i)).not.toBeInTheDocument();
+  },
+};
+
+export const EmptyWithFallback: Story = {
+  args: {
+    blockId: "no-one-here",
+    users: [ada, grace, katherine],
+    renderWhenEmpty: true,
+    emptyLabel: "No one editing here",
+  },
+  play: async ({ canvas }) => {
+    const indicator = canvas.getByLabelText("No one editing here");
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toHaveTextContent("No one editing here");
+  },
+};
+
+export const CustomFormatter: Story = {
+  args: {
+    blockId: SHARED_BLOCK_ID,
+    users: sharedBlockUsers,
+    formatLabel: (users) =>
+      users.length === 1
+        ? `${users[0]?.name} is drafting`
+        : `${users.length} collaborators here`,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByLabelText("2 collaborators here")).toBeVisible();
+  },
+};

--- a/packages/awareness/src/stories/LiveCursor.stories.tsx
+++ b/packages/awareness/src/stories/LiveCursor.stories.tsx
@@ -111,3 +111,53 @@ export const MultipleCursors: Story = {
     ).not.toBeInTheDocument();
   },
 };
+
+// Design §7: "Off-screen cursors not rendered."
+// Two cursors share the same viewport — one inside, one outside — to make the
+// culling decision visible side-by-side.
+export const OffScreenCulled: Story = {
+  render: () => (
+    <CollaborationSurface>
+      <LiveCursor
+        cullMargin={0}
+        labelVisibleMs={60_000}
+        point={{ x: 60, y: 80 }}
+        user={ada}
+        viewport={{ x: 0, y: 0, width: 240, height: 200 }}
+      />
+      <LiveCursor
+        cullMargin={0}
+        labelVisibleMs={60_000}
+        point={{ x: 9999, y: 9999 }}
+        user={katherine}
+        viewport={{ x: 0, y: 0, width: 240, height: 200 }}
+      />
+    </CollaborationSurface>
+  ),
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("img", { name: "Ada Lovelace cursor" }),
+    ).toBeVisible();
+    // The katherine cursor is well outside the bounded viewport and the
+    // component returns null — it should not be in the DOM at all.
+    await expect(
+      canvas.queryByRole("img", { name: "Katherine Johnson cursor" }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+// Same component, opt-out of culling via `viewport="none"`. The point is far
+// outside the window but still rendered — useful for virtualized scrollers
+// that have already culled upstream.
+export const CullingDisabled: Story = {
+  args: {
+    point: { x: 4000, y: 4000 },
+    user: ada,
+    viewport: "none",
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("img", { name: "Ada Lovelace cursor" }),
+    ).toBeVisible();
+  },
+};

--- a/packages/awareness/src/stories/SelectionHighlight.stories.tsx
+++ b/packages/awareness/src/stories/SelectionHighlight.stories.tsx
@@ -89,6 +89,44 @@ export const InlineSelection: Story = {
   },
 };
 
+// Design §5.3: "Hover reveals user badge."
+// `showLabel="hover"` keeps the badge hidden until pointer hover or keyboard
+// focus — so the highlight stays low-noise while still letting collaborators
+// inspect attribution on demand.
+//
+// We assert the structural wiring (hoverable class, tabindex, label rendered
+// but hidden by default) rather than the post-:hover computed style: synthetic
+// hover events do not reliably trigger the CSS `:hover` pseudo-class across
+// test browsers, so this story serves as the visual reference for Chromatic.
+export const HoverableLabel: Story = {
+  args: {
+    showLabel: "hover",
+    user: ada,
+    selectedText: focusSelection.text,
+  },
+  play: async ({ canvas }) => {
+    const selection = canvas.getByRole("img", {
+      name: `Ada Lovelace selection: ${focusSelection.text}`,
+    });
+
+    await expect(selection).toHaveClass(
+      "awareness-selection-highlight--hoverable",
+    );
+    await expect(selection).toHaveAttribute("tabindex", "0");
+
+    // The label is rendered into the DOM but hidden (opacity:0) until the
+    // `:hover` / `:focus-visible` pseudo-class applies.
+    const label = canvas.getByText("Ada Lovelace");
+    await expect(label).toBeInTheDocument();
+    await expect(label).not.toBeVisible();
+
+    // The selection is keyboard-focusable so screen-reader / keyboard users
+    // can also surface the attribution.
+    selection.focus();
+    await expect(selection).toHaveFocus();
+  },
+};
+
 export const OverlappingSelections: Story = {
   render: () => (
     <CollaborationSurface>


### PR DESCRIPTION
## Summary

Brings `packages/awareness` in line with `docs/design/awareness-and-presence.md`. Surfaced via a design-vs-implementation audit; all changes are additive — no breaking API changes.

| Gap | Section | Fix |
|---|---|---|
| Off-screen cursors render anyway | §7 | `LiveCursor` `viewport` prop (defaults to `"window"` and re-evaluates on `resize`); `"none"` to disable; or explicit rect. New `cullMargin` (default 32). |
| Cursor label fade was 2800 ms | §6 | Default bumped to 3000 ms. |
| Selection highlight had no hover-reveal | §5.3 | `showLabel` now accepts `"hover"`; element becomes pointer/keyboard focusable, badge revealed via `:hover` / `:focus-visible`. |
| `PresenceStatus` was cosmetic | §4.2 | `PresenceProvider` runs a local sweep that demotes stale users to `idle`/`offline` based on `lastActiveAt`. New `statusConfig` and `statusSweepMs` props (`0` disables). |
| No per-block aggregated indicator | §5.4 | New `BlockActivityIndicator` component: "Adam is editing this block" / "N people editing here". Reads from `PresenceContext`, filters users whose cursor or selection is in the given block. |
| Cursor + selection labels drifted on font scaling | §5.3 / §6 | Anchor labels with `bottom-full` instead of fixed `-top-7` / `-top-6`; left-align cursor label with the caret. |

### New / changed public API (all additive)

- `BlockActivityIndicator` + `BlockActivityIndicatorProps` (new)
- `LiveCursorViewport`, `LiveCursorProps#viewport`, `LiveCursorProps#cullMargin` (new)
- `SelectionHighlightProps#showLabel`: `boolean` → `boolean | "hover"`
- `PresenceProviderProps#statusConfig`, `PresenceProviderProps#statusSweepMs` (new)
- `package.json` exports: new `./components/block-activity-indicator` subpath

## Commits

1. `feat`: implement the five gaps above (source + CSS + types + subpath export).
2. `test`: Storybook coverage — `BlockActivityIndicator` (5 variants), `LiveCursor` `OffScreenCulled` + `CullingDisabled`, `SelectionHighlight` `HoverableLabel`.
3. `fix`: review-feedback round —
   - Move `presenceRef` write into a sync effect (concurrent-mode safety).
   - Destructure `idleTimeoutMs` / `offlineTimeoutMs` so an inline `statusConfig` literal does not tear down the sweep interval every render.
   - Drop the persistent dot pulse animation (design §6 — "No persistent animation"); static colored halo is enough.
   - `BlockActivityIndicator`: switch back to `<div role="status">` (with scoped `useSemanticElements` suppression and rationale) since `<output>` is for form-calculated values; narrow `useMemo` deps from the whole context object to `context?.others` / `context?.presence` so unrelated context churn does not re-filter.
   - `LiveCursor`: subscribe to passive `resize` so window-based culling re-evaluates without waiting for the next pointer move.
   - JSDoc tightening on `users?` and `emptyLabel`.
   - Replace the indirect `setInterval`-spy assertion with a behavioral check (advance fake timers past the offline threshold and assert status stays `active` when sweep is disabled).
4. `test`: coverage top-up to clear the 90% branch threshold (89.02% → 90.01%) — adds tests for the resize handler, `includeSelf=true`, the `ctxPresence` undefined fallback, and the self-demotion path inside the sweep tick.
5. `fix`: anchor cursor + selection labels with `bottom-full` (CSS-only) — replaces the fixed `-top-7` / `-top-6` offsets so labels reflow with their own height instead of clipping or floating away from the anchor; cursor label switches from `right-2` to `left-0` so it left-aligns with the caret.

## Test plan

- [x] `pnpm --filter @softmaple/awareness typecheck`
- [x] `pnpm --filter @softmaple/awareness check` (biome lint + format)
- [x] `pnpm --filter @softmaple/awareness test --run` — **244 / 244 pass** (218 baseline + 18 new unit tests + 8 new story tests)
- [x] `pnpm --filter @softmaple/awareness test:coverage --run` — all four metrics clear the 90% global threshold:
  - Statements 98.00%, Branches 90.01%, Functions 99.21%, Lines 98.84%
- [x] `pnpm --filter @softmaple/awareness build` — produces `dist/components/block-activity-indicator.{js,d.ts}` matching the new subpath export.
- [x] All 26 Storybook stories pass via `run-story-tests` (pre-merge sanity).
- [ ] Visual review of new stories in Chromatic:
  - `awareness-blockactivityindicator--single-editor`
  - `awareness-blockactivityindicator--multiple-editors`
  - `awareness-blockactivityindicator--excludes-offline-users`
  - `awareness-blockactivityindicator--empty-with-fallback`
  - `awareness-blockactivityindicator--custom-formatter`
  - `awareness-livecursor--off-screen-culled`
  - `awareness-livecursor--culling-disabled`
  - `awareness-selectionhighlight--hoverable-label`
- [ ] Visual review in Chromatic that the relabeled cursor / selection badges still render flush against the caret/selection top edge across the existing stories.

## Notes

- The `HoverableLabel` story play function asserts structural wiring (hoverable class, `tabindex="0"`, hidden-by-default label, keyboard focusability) rather than the post-`:hover` computed style — synthetic hover events do not reliably fire `:hover` across test browsers. Chromatic snapshots cover the visual reveal.
- The pulse animation on the new block indicator was removed deliberately to honor §6. The existing avatar-status pulse was left as-is for consistency with prior visuals; a separate pass on §6 conformance is out of scope here.
- `package.json` keeps the alias-style export convention used elsewhere in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)