### PR TITLE
refactor(packages/eg-walker): rename public API + trim export surface

### DIFF
--- a/apps/playground/src/modules/collab-editor/room-manager.ts
+++ b/apps/playground/src/modules/collab-editor/room-manager.ts
@@ -1,4 +1,4 @@
-import { EgWalkerAPI } from "@softmaple/eg-walker";
+import { EgWalkerReplica } from "@softmaple/eg-walker";
 import { storage } from "./storage";
 import { SyncAdapter } from "./sync-adapter";
 import type { Document, Room, SyncMessage, User } from "./types";
@@ -7,7 +7,7 @@ import type { Document, Room, SyncMessage, User } from "./types";
  * Manages room state and synchronization
  */
 export class RoomManager {
-  private api: EgWalkerAPI | null = null;
+  private api: EgWalkerReplica | null = null;
   private syncAdapter: SyncAdapter | null = null;
   private currentRoom: Room | null = null;
   private currentUser: User | null = null;
@@ -58,7 +58,7 @@ export class RoomManager {
     this.currentUser = user;
 
     // Initialize CRDT
-    this.api = new EgWalkerAPI(user.id);
+    this.api = new EgWalkerReplica(user.id);
 
     // Load existing document
     const doc = await storage.getDocument(roomId);

--- a/apps/playground/src/routes/demo/collaborative-editor.tsx
+++ b/apps/playground/src/routes/demo/collaborative-editor.tsx
@@ -1,4 +1,4 @@
-import { EgWalkerAPI } from "@softmaple/eg-walker";
+import { EgWalkerReplica } from "@softmaple/eg-walker";
 import {
   Card,
   CardContent,
@@ -21,8 +21,8 @@ export const Route = createFileRoute("/demo/collaborative-editor")({
 function CollaborativeEditor() {
   const [replica1Text, setReplica1Text] = useState("");
   const [replica2Text, setReplica2Text] = useState("");
-  const [api1] = useState(() => new EgWalkerAPI("replica-1"));
-  const [api2] = useState(() => new EgWalkerAPI("replica-2"));
+  const [api1] = useState(() => new EgWalkerReplica("replica-1"));
+  const [api2] = useState(() => new EgWalkerReplica("replica-2"));
   const replica1Ref = useRef<HTMLTextAreaElement>(null);
   const replica2Ref = useRef<HTMLTextAreaElement>(null);
 

--- a/apps/playground/src/test/collaborative-editor.test.ts
+++ b/apps/playground/src/test/collaborative-editor.test.ts
@@ -1,4 +1,4 @@
-import { EgWalkerAPI } from "@softmaple/eg-walker";
+import { EgWalkerReplica } from "@softmaple/eg-walker";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   findDeletePosition,
@@ -6,7 +6,7 @@ import {
   findInsertPosition,
 } from "../lib/text-diff";
 
-interface MockEgWalkerAPI {
+interface MockEgWalkerReplica {
   insert: (position: number, text: string) => void;
   delete: (position: number, count: number) => void;
   getText: () => string;
@@ -14,11 +14,11 @@ interface MockEgWalkerAPI {
   applyRemoteEvent: (event: unknown) => void;
 }
 
-// Mock EgWalkerAPI
+// Mock EgWalkerReplica
 vi.mock("@softmaple/eg-walker", () => {
   return {
     // biome-ignore lint/complexity/useArrowFunction: Vitest 4 requires function keyword for constructor mocks
-    EgWalkerAPI: vi.fn().mockImplementation(function () {
+    EgWalkerReplica: vi.fn().mockImplementation(function () {
       return {
         insert: vi.fn(),
         delete: vi.fn(),
@@ -31,12 +31,12 @@ vi.mock("@softmaple/eg-walker", () => {
 });
 
 describe("Collaborative Editor Integration", () => {
-  let api: MockEgWalkerAPI;
+  let api: MockEgWalkerReplica;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // @ts-expect-error - EgWalkerAPI is mocked as MockEgWalkerAPI
-    api = new EgWalkerAPI("test-replica") as MockEgWalkerAPI;
+    // @ts-expect-error - EgWalkerReplica is mocked as MockEgWalkerReplica
+    api = new EgWalkerReplica("test-replica") as MockEgWalkerReplica;
   });
 
   describe("Insertion operations", () => {

--- a/packages/eg-walker/AGENTS.md
+++ b/packages/eg-walker/AGENTS.md
@@ -78,7 +78,7 @@ Events are stored in compressed columnar format:
   surrogates; users must align operations to code-point boundaries.
 - Multi-character inserts are stored as a sequence of per-character
   events under a single insert event.
-- Remote events with unknown parents are buffered by `EgWalkerAPI` and
+- Remote events with unknown parents are buffered by `EgWalkerReplica` and
   flushed once their causal predecessors arrive; direct `EventGraph.addEvent`
   callers still need to deliver in causal order (or use `EventGraph.deserialize`
   for buffered topological loading).

--- a/packages/eg-walker/IMPLEMENTATION_GUIDE.md
+++ b/packages/eg-walker/IMPLEMENTATION_GUIDE.md
@@ -51,7 +51,7 @@ Temporary state:
 - Ranked B-tree leaves with prepare/effect/count aggregates for index mapping.
 
 The temporary replay state is not exported, serialized, or retained by
-`EgWalkerAPI`.
+`EgWalkerReplica`.
 
 ## Storage Model
 

--- a/packages/eg-walker/README.md
+++ b/packages/eg-walker/README.md
@@ -40,13 +40,20 @@ const serialized = replica.serialize();
 
 ## Main APIs
 
-- `EgWalkerReplica`: public index-based editing API.
-- `EgWalker`: graph replay coordinator.
-- `EgWalkerEngine`: prepare/effect replay engine.
+Stable surface (`@softmaple/eg-walker`):
+
+- `EgWalkerReplica` / `createEgWalkerReplica`: public index-based editing API.
+- `ReplayWalker`: one-shot graph replay coordinator.
 - `EventGraph`: persistent event DAG.
+- `OPERATION_TYPE` and TypeScript types.
+
+Internal replay primitives (`@softmaple/eg-walker/internal`, not covered by semver):
+
+- `EgWalkerEngine`: prepare/effect replay engine.
 - `ColumnarEventGraphCodec`: run-length encoded columns with varints and LZ4-compressed inserted content.
 - `CriticalVersionAnalyzer`: critical checkpoint detection.
 - `PartialReplayManager`: replay from checkpoint text/version.
+- `IndexedSequence`: ranked B-tree backing the engine.
 
 ## Development
 

--- a/packages/eg-walker/README.md
+++ b/packages/eg-walker/README.md
@@ -17,30 +17,30 @@ No CRDT metadata is persisted or exposed through the public API.
 ## Usage
 
 ```typescript
-import { createEgWalker, OPERATION_TYPE } from "@softmaple/eg-walker";
+import { createEgWalkerReplica, OPERATION_TYPE } from "@softmaple/eg-walker";
 
-const walker = createEgWalker("replica-1");
+const replica = createEgWalkerReplica("replica-1");
 
-walker.applyLocalOperation({
+replica.applyLocalOperation({
   type: OPERATION_TYPE.INSERT,
   index: 0,
   text: "Hello, World!",
 });
 
-walker.applyLocalOperation({
+replica.applyLocalOperation({
   type: OPERATION_TYPE.DELETE,
   index: 7,
   length: 6,
 });
 
-console.log(walker.getDocumentState()); // "Hello, !"
+console.log(replica.getText()); // "Hello, !"
 
-const serialized = walker.serialize();
+const serialized = replica.serialize();
 ```
 
 ## Main APIs
 
-- `EgWalkerAPI`: public index-based editing API.
+- `EgWalkerReplica`: public index-based editing API.
 - `EgWalker`: graph replay coordinator.
 - `EgWalkerEngine`: prepare/effect replay engine.
 - `EventGraph`: persistent event DAG.

--- a/packages/eg-walker/package.json
+++ b/packages/eg-walker/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "import": "./dist/internal.js"
     }
   },
   "files": [

--- a/packages/eg-walker/src/core/index.ts
+++ b/packages/eg-walker/src/core/index.ts
@@ -1,11 +1,11 @@
 /**
- * Core module - External API and invariants
+ * Core module - Public replica and invariants
  *
  * This module provides the public-facing API that maintains
  * index-based operations and enforces strong list specification.
  */
 
-export { EgWalkerAPI, createEgWalker } from "./external-api";
+export { EgWalkerReplica, createEgWalkerReplica } from "./replica";
 
 export {
   verifyStrongListSpecification,

--- a/packages/eg-walker/src/core/index.ts
+++ b/packages/eg-walker/src/core/index.ts
@@ -18,6 +18,10 @@ export {
   StrongListInvariant,
 } from "./invariants";
 
-export { EgWalker, type WalkerConfig, type WalkResult } from "./walker";
+export {
+  ReplayWalker,
+  type WalkerConfig,
+  type WalkResult,
+} from "./replay-walker";
 
 export type { ExternalOperation, DocumentState } from "../types";

--- a/packages/eg-walker/src/core/replay-walker.ts
+++ b/packages/eg-walker/src/core/replay-walker.ts
@@ -14,12 +14,14 @@ export interface WalkResult {
 }
 
 /**
- * High-level event graph walker.
+ * One-shot event-graph replay coordinator.
  *
- * This is intentionally thin: graph ordering and causal diffs live in
- * EventGraph, while prepare/effect replay lives in EgWalkerEngine.
+ * Intentionally thin: graph ordering and causal diffs live in EventGraph,
+ * prepare/effect replay lives in EgWalkerEngine, and the stateful editing
+ * surface lives in EgWalkerReplica. Use this for batch "given these events,
+ * what's the resulting text" computations.
  */
-export class EgWalker {
+export class ReplayWalker {
   private prepareVersion: Version = new Set();
   private effectVersion: Version = new Set();
 

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -1,5 +1,5 @@
 /**
- * External API for Section 3.1 - Index-based operations only
+ * Public replica for Section 3.1 - Index-based operations only
  *
  * This module provides the public interface that:
  * - Only accepts index-based operations
@@ -26,10 +26,10 @@ import {
 import { EgWalkerEngine } from "../engine/eg-walker-engine";
 
 /**
- * Public API for Eg-walker
- * Strictly index-based, no CRDT exposure
+ * Public replica for Eg-walker.
+ * Strictly index-based, no CRDT exposure.
  */
-export class EgWalkerAPI {
+export class EgWalkerReplica {
   private document: string = "";
   private readonly initialText: string;
   private readonly eventGraph: EventGraph;
@@ -113,9 +113,9 @@ export class EgWalkerAPI {
       eventGraph: SerializedGraphInput | null;
     },
     replicaId: string = "deserialized-replica",
-  ): EgWalkerAPI {
+  ): EgWalkerReplica {
     if (!serialized.eventGraph) {
-      return new EgWalkerAPI(replicaId, serialized.text);
+      return new EgWalkerReplica(replicaId, serialized.text);
     }
 
     const graph = EventGraph.deserialize(serialized.eventGraph);
@@ -126,13 +126,13 @@ export class EgWalkerAPI {
         : graph.getAllEvents().length === 0
           ? serialized.text
           : "";
-    const api = new EgWalkerAPI(replicaId, initialText, graph);
+    const replica = new EgWalkerReplica(replicaId, initialText, graph);
 
     if (typeof metadata.nextSequenceNumber === "number") {
-      api.nextSequenceNumber = metadata.nextSequenceNumber;
+      replica.nextSequenceNumber = metadata.nextSequenceNumber;
     }
 
-    return api;
+    return replica;
   }
 
   /**
@@ -253,13 +253,6 @@ export class EgWalkerAPI {
   }
 
   /**
-   * Get current document text using the README-compatible API name.
-   */
-  getDocumentState(): string {
-    return this.document;
-  }
-
-  /**
    * Export event graph for persistence
    * This is what gets saved to disk - no CRDT metadata
    */
@@ -274,14 +267,14 @@ export class EgWalkerAPI {
     replicaId: string,
     events: ReadonlyArray<GraphEvent>,
     initialText: string = "",
-  ): EgWalkerAPI {
-    const api = new EgWalkerAPI(replicaId, initialText);
+  ): EgWalkerReplica {
+    const replica = new EgWalkerReplica(replicaId, initialText);
 
     for (const event of events) {
-      api.applyRemoteEvent(event);
+      replica.applyRemoteEvent(event);
     }
 
-    return api;
+    return replica;
   }
 
   private fullReplay(): void {
@@ -395,11 +388,11 @@ export class EgWalkerAPI {
 }
 
 /**
- * Factory function for creating API instances
+ * Factory function for creating replica instances.
  */
-export function createEgWalker(
+export function createEgWalkerReplica(
   replicaId: string,
   initialText?: string,
-): EgWalkerAPI {
-  return new EgWalkerAPI(replicaId, initialText);
+): EgWalkerReplica {
+  return new EgWalkerReplica(replicaId, initialText);
 }

--- a/packages/eg-walker/src/graph/index.ts
+++ b/packages/eg-walker/src/graph/index.ts
@@ -14,4 +14,4 @@ export {
   type ParentOverride,
 } from "./columnar-codec";
 
-export type { EventId, Version, GraphEvent as Event } from "../types";
+export type { EventId, Version, GraphEvent } from "../types";

--- a/packages/eg-walker/src/index.ts
+++ b/packages/eg-walker/src/index.ts
@@ -1,25 +1,16 @@
 /**
  * @softmaple/eg-walker - Eg-walker algorithm for collaborative editing
  *
- * Implementation of the Eg-walker algorithm for collaborative text editing
+ * Public, stable surface. For internal replay primitives
+ * (engine, codec, ranked B-tree, critical-version, partial-replay) import
+ * from `@softmaple/eg-walker/internal` — those names are not covered by
+ * semver guarantees.
  */
 
-export { EgWalker } from "./core/walker";
-export { EgWalkerEngine } from "./engine/eg-walker-engine";
-export {
-  IndexedSequence,
-  CriticalVersionAnalyzer,
-  PartialReplayManager,
-} from "./engine";
-export { ColumnarEventGraphCodec } from "./graph";
 export { EgWalkerReplica, createEgWalkerReplica } from "./core/replica";
+export { ReplayWalker } from "./core/replay-walker";
+export type { WalkerConfig, WalkResult } from "./core/replay-walker";
 export { EventGraph } from "./graph/event-graph";
-
-// Constants exports
 export { OPERATION_TYPE } from "./constants/operation-types";
 
-// Type exports
 export * from "./types";
-
-// Default export
-export { EgWalker as default } from "./core/walker";

--- a/packages/eg-walker/src/index.ts
+++ b/packages/eg-walker/src/index.ts
@@ -12,7 +12,7 @@ export {
   PartialReplayManager,
 } from "./engine";
 export { ColumnarEventGraphCodec } from "./graph";
-export { EgWalkerAPI, createEgWalker } from "./core/external-api";
+export { EgWalkerReplica, createEgWalkerReplica } from "./core/replica";
 export { EventGraph } from "./graph/event-graph";
 
 // Constants exports

--- a/packages/eg-walker/src/internal.ts
+++ b/packages/eg-walker/src/internal.ts
@@ -1,0 +1,30 @@
+/**
+ * Internal replay primitives.
+ *
+ * These exports are intentionally outside the package's stable `.` entry.
+ * Names, signatures, and presence here may change between minor versions
+ * without notice — depend on them only for tests, diagnostics, or
+ * advanced integrations that already pin a specific version.
+ */
+
+export {
+  EgWalkerEngine,
+  type GeneratedDocument,
+} from "./engine/eg-walker-engine";
+export { IndexedSequence } from "./engine/indexed-sequence";
+export {
+  CriticalVersionAnalyzer,
+  type CriticalCheckpoint,
+} from "./engine/critical-version";
+export {
+  PartialReplayManager,
+  type PartialReplayResult,
+  type ReplayCheckpoint,
+} from "./engine/partial-replay";
+export {
+  ColumnarEventGraphCodec,
+  type ColumnarEventGraph,
+  type IdRun,
+  type OperationRun,
+  type ParentOverride,
+} from "./graph/columnar-codec";

--- a/packages/eg-walker/src/test/algorithm-characteristics.test.ts
+++ b/packages/eg-walker/src/test/algorithm-characteristics.test.ts
@@ -12,15 +12,15 @@ import { OPERATION_TYPE } from "../constants/operation-types";
  */
 
 import { describe, it, expect } from "vitest";
-import { EgWalkerAPI } from "../core/external-api";
+import { EgWalkerReplica } from "../core/replica";
 import { EventGraph } from "../graph/event-graph";
-import type { Event } from "../types";
+import type { GraphEvent } from "../types";
 
 describe("Eg-walker Algorithm Characteristics", () => {
   describe("Characteristic 1: Strong list specification", () => {
     it("should preserve sequential semantics of text editing", () => {
-      const api1 = new EgWalkerAPI("replica1");
-      const api2 = new EgWalkerAPI("replica2");
+      const api1 = new EgWalkerReplica("replica1");
+      const api2 = new EgWalkerReplica("replica2");
 
       // Apply same operations to both replicas
       api1.insert(0, "Hello");
@@ -38,11 +38,11 @@ describe("Eg-walker Algorithm Characteristics", () => {
     });
 
     it("should produce deterministic output independent of delivery order", async () => {
-      const api1 = new EgWalkerAPI("replica1");
-      const api2 = new EgWalkerAPI("replica2");
+      const api1 = new EgWalkerReplica("replica1");
+      const api2 = new EgWalkerReplica("replica2");
 
       // Simulate concurrent edits with different delivery orders
-      const event1: Event = {
+      const event1: GraphEvent = {
         id: "alice-1",
         parentVersion: new Set<string>(),
         timestamp: Date.now(),
@@ -53,7 +53,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
         },
       };
 
-      const event2: Event = {
+      const event2: GraphEvent = {
         id: "bob-1",
         parentVersion: new Set<string>(),
         timestamp: Date.now(),
@@ -78,10 +78,10 @@ describe("Eg-walker Algorithm Characteristics", () => {
 
   describe("Characteristic 2: Maximally non-interleaving behavior", () => {
     it("should never produce character-by-character interleaving", async () => {
-      const api = new EgWalkerAPI("replica1");
+      const api = new EgWalkerReplica("replica1");
 
       // Alice inserts "Hello" as a single operation
-      const aliceEvent: Event = {
+      const aliceEvent: GraphEvent = {
         id: "alice-1",
         parentVersion: new Set<string>(),
         timestamp: Date.now(),
@@ -93,7 +93,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
       };
 
       // Bob concurrently inserts "World" as a single operation
-      const bobEvent: Event = {
+      const bobEvent: GraphEvent = {
         id: "bob-1",
         parentVersion: new Set<string>(),
         timestamp: Date.now(),
@@ -115,10 +115,10 @@ describe("Eg-walker Algorithm Characteristics", () => {
     });
 
     it("should group multi-character insertions as blocks", async () => {
-      const api = new EgWalkerAPI("replica1");
+      const api = new EgWalkerReplica("replica1");
 
       // Alice inserts "Hello" as one operation
-      const aliceEvent: Event = {
+      const aliceEvent: GraphEvent = {
         id: "alice-1",
         parentVersion: new Set<string>(),
         timestamp: Date.now(),
@@ -130,7 +130,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
       };
 
       // Bob inserts "World" as one operation
-      const bobEvent: Event = {
+      const bobEvent: GraphEvent = {
         id: "bob-1",
         parentVersion: new Set<string>(),
         timestamp: Date.now(),
@@ -157,7 +157,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
 
   describe("Characteristic 3: Minimal and temporary internal metadata", () => {
     it("should not expose CRDT internals through public API", () => {
-      const api = new EgWalkerAPI("replica1");
+      const api = new EgWalkerReplica("replica1");
 
       api.insert(0, "Test");
 
@@ -172,7 +172,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
 
   describe("Characteristic 4: Index-based external API", () => {
     it("should only accept numeric indices in public API", () => {
-      const api = new EgWalkerAPI("replica1");
+      const api = new EgWalkerReplica("replica1");
 
       // These should work with numeric indices
       expect(() => api.insert(0, "Hello")).not.toThrow();
@@ -186,7 +186,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
     });
 
     it("should validate index bounds", () => {
-      const api = new EgWalkerAPI("replica1");
+      const api = new EgWalkerReplica("replica1");
 
       api.insert(0, "Hello");
 
@@ -202,7 +202,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
     });
 
     it("should provide simple text-based getters", () => {
-      const api = new EgWalkerAPI("replica1");
+      const api = new EgWalkerReplica("replica1");
 
       api.insert(0, "Hello World");
 
@@ -218,7 +218,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
 
   describe("Characteristic 5: No persistent CRDT tombstones or per-character IDs", () => {
     it("should serialize only text and event graph", () => {
-      const api = new EgWalkerAPI("replica1");
+      const api = new EgWalkerReplica("replica1");
 
       api.insert(0, "Hello");
       api.delete(2, 2); // Delete 'll'
@@ -239,14 +239,14 @@ describe("Eg-walker Algorithm Characteristics", () => {
     });
 
     it("should deserialize without restoring CRDT state", () => {
-      const api1 = new EgWalkerAPI("replica1");
+      const api1 = new EgWalkerReplica("replica1");
 
       api1.insert(0, "Original");
       api1.delete(0, 8);
       api1.insert(0, "New");
 
       const serialized = api1.serialize();
-      const api2 = EgWalkerAPI.deserialize(serialized);
+      const api2 = EgWalkerReplica.deserialize(serialized);
 
       // Should restore text correctly
       expect(api2.getText()).toBe("New");
@@ -267,7 +267,7 @@ describe("Eg-walker Algorithm Characteristics", () => {
       const graph = new EventGraph();
 
       // Add multi-character insertion as single event
-      const event: Event = {
+      const event: GraphEvent = {
         id: "event-1",
         parentVersion: new Set<string>(),
         timestamp: Date.now(),

--- a/packages/eg-walker/src/test/eg-walker-engine.test.ts
+++ b/packages/eg-walker/src/test/eg-walker-engine.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { OPERATION_TYPE } from "../constants/operation-types";
 import lz4 from "lz4js";
 import { CriticalVersionAnalyzer } from "../engine/critical-version";
-import { EgWalker } from "../core/walker";
+import { ReplayWalker } from "../core/replay-walker";
 import { EgWalkerReplica } from "../core/replica";
 import { EgWalkerEngine } from "../engine/eg-walker-engine";
 import { EventGraph } from "../graph/event-graph";
@@ -227,9 +227,9 @@ describe("EgWalkerEngine", () => {
   });
 });
 
-describe("EgWalker", () => {
+describe("ReplayWalker", () => {
   it("walks events through the engine and exposes final versions", () => {
-    const walker = new EgWalker({ initialText: "Hi" });
+    const walker = new ReplayWalker({ initialText: "Hi" });
     const result = walker.walk([
       {
         id: "alice:0",
@@ -252,7 +252,7 @@ describe("EgWalker", () => {
   });
 
   it("walks unordered complete event batches", () => {
-    const walker = new EgWalker();
+    const walker = new ReplayWalker();
     const result = walker.walk([
       {
         id: "alice:1",
@@ -274,7 +274,7 @@ describe("EgWalker", () => {
   });
 
   it("walks an empty event list without changing initial text", () => {
-    const walker = new EgWalker({ initialText: "seed" });
+    const walker = new ReplayWalker({ initialText: "seed" });
 
     expect(walker.walk([])).toEqual({
       finalText: "seed",
@@ -287,7 +287,7 @@ describe("EgWalker", () => {
   });
 
   it("defaults walker initial text to an empty string", () => {
-    const result = new EgWalker().walk([
+    const result = new ReplayWalker().walk([
       {
         id: "alice:0",
         parentVersion: new Set(),

--- a/packages/eg-walker/src/test/eg-walker-engine.test.ts
+++ b/packages/eg-walker/src/test/eg-walker-engine.test.ts
@@ -3,7 +3,7 @@ import { OPERATION_TYPE } from "../constants/operation-types";
 import lz4 from "lz4js";
 import { CriticalVersionAnalyzer } from "../engine/critical-version";
 import { EgWalker } from "../core/walker";
-import { EgWalkerAPI } from "../core/external-api";
+import { EgWalkerReplica } from "../core/replica";
 import { EgWalkerEngine } from "../engine/eg-walker-engine";
 import { EventGraph } from "../graph/event-graph";
 import { PartialReplayManager } from "../engine/partial-replay";
@@ -206,11 +206,11 @@ describe("EgWalkerEngine", () => {
   });
 
   it("round-trips persisted event graph state through the public API", () => {
-    const api = new EgWalkerAPI("alice", "Hello");
+    const api = new EgWalkerReplica("alice", "Hello");
     api.insert(5, " world");
     api.delete(0, 1);
 
-    const restored = EgWalkerAPI.deserialize(api.serialize(), "alice");
+    const restored = EgWalkerReplica.deserialize(api.serialize(), "alice");
     restored.insert(10, "!");
 
     expect(restored.getText()).toBe("ello world!");
@@ -218,7 +218,7 @@ describe("EgWalkerEngine", () => {
   });
 
   it("keeps public string indexes aligned with JS code units", () => {
-    const api = new EgWalkerAPI("alice", "");
+    const api = new EgWalkerReplica("alice", "");
 
     api.insert(0, "😀");
     api.insert(api.getText().length, "!");

--- a/packages/eg-walker/src/test/event-graph.test.ts
+++ b/packages/eg-walker/src/test/event-graph.test.ts
@@ -1,6 +1,6 @@
 import { OPERATION_TYPE } from "../constants/operation-types";
 import { describe, it, expect } from "vitest";
-import type { GraphEvent, EventId, SerializedEventGraph } from "../types";
+import type { GraphEvent, EventId, SerializedGraphInput } from "../types";
 import { EventGraph } from "../graph/event-graph";
 
 describe("EventGraph", () => {
@@ -382,7 +382,7 @@ describe("EventGraph", () => {
 
       const parsed = JSON.parse(
         JSON.stringify(graph.serialize()),
-      ) as unknown as SerializedEventGraph;
+      ) as unknown as SerializedGraphInput;
       const newGraph = EventGraph.deserialize(parsed);
 
       expect(parsed.version).toEqual(["event-2"]);
@@ -393,7 +393,7 @@ describe("EventGraph", () => {
     });
 
     it("should validate version during deserialization", () => {
-      const invalidData: SerializedEventGraph = {
+      const invalidData: SerializedGraphInput = {
         version: new Set<EventId>(), // Empty version
         events: [],
         metadata: {},
@@ -433,7 +433,7 @@ describe("EventGraph", () => {
     });
 
     it("should reject serialized graphs whose parents cannot be resolved", () => {
-      const invalidData: SerializedEventGraph = {
+      const invalidData: SerializedGraphInput = {
         version: new Set<EventId>(["event-2"]),
         events: [
           {

--- a/packages/eg-walker/src/test/replica.test.ts
+++ b/packages/eg-walker/src/test/replica.test.ts
@@ -1,66 +1,66 @@
 import { describe, it, expect } from "vitest";
-import { EgWalkerAPI, createEgWalker } from "../core/external-api";
+import { EgWalkerReplica, createEgWalkerReplica } from "../core/replica";
 import { OPERATION_TYPE } from "../constants/operation-types";
 import { EventAlreadyExistsError } from "../graph/event-graph";
-import type { GraphEvent, SerializedGraph } from "../types";
+import type { GraphEvent, SerializedGraphInput } from "../types";
 
-describe("EgWalkerAPI", () => {
+describe("EgWalkerReplica", () => {
   describe("insert", () => {
     it("should insert text at valid index", () => {
-      const api = new EgWalkerAPI("r1", "");
+      const api = new EgWalkerReplica("r1", "");
       api.insert(0, "Hello");
       expect(api.getText()).toBe("Hello");
     });
 
     it("should insert text in middle of document", () => {
-      const api = new EgWalkerAPI("r1", "Hello World");
+      const api = new EgWalkerReplica("r1", "Hello World");
       api.insert(5, " Beautiful");
       expect(api.getText()).toBe("Hello Beautiful World");
     });
 
     it("should handle empty insert as no-op", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       api.insert(2, "");
       expect(api.getText()).toBe("Hello");
     });
 
     it("should throw error for negative index", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       expect(() => api.insert(-1, "x")).toThrow("Index -1 out of bounds");
     });
 
     it("should throw error for index beyond document length", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       expect(() => api.insert(10, "x")).toThrow("Index 10 out of bounds");
     });
   });
 
   describe("delete", () => {
     it("should delete text at valid index", () => {
-      const api = new EgWalkerAPI("r1", "Hello World");
+      const api = new EgWalkerReplica("r1", "Hello World");
       api.delete(5, 6);
       expect(api.getText()).toBe("Hello");
     });
 
     it("should handle zero-length delete as no-op", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       api.delete(2, 0);
       expect(api.getText()).toBe("Hello");
     });
 
     it("should handle negative length delete as no-op", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       api.delete(2, -1);
       expect(api.getText()).toBe("Hello");
     });
 
     it("should throw error for negative index", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       expect(() => api.delete(-1, 2)).toThrow("Index -1 out of bounds");
     });
 
     it("should throw error when delete range exceeds document length", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       expect(() => api.delete(3, 5)).toThrow(
         "Delete range [3, 8) exceeds document length 5",
       );
@@ -69,7 +69,7 @@ describe("EgWalkerAPI", () => {
 
   describe("getDocument", () => {
     it("should return document state with text", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       const state = api.getDocument();
       expect(state.text).toBe("Hello");
     });
@@ -77,19 +77,14 @@ describe("EgWalkerAPI", () => {
 
   describe("getText", () => {
     it("should return current text", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       expect(api.getText()).toBe("Hello");
-    });
-
-    it("should return README-compatible document state text", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
-      expect(api.getDocumentState()).toBe("Hello");
     });
   });
 
   describe("serialize/deserialize", () => {
     it("should serialize document state", () => {
-      const api = new EgWalkerAPI("r1", "Hello");
+      const api = new EgWalkerReplica("r1", "Hello");
       api.insert(5, " World");
       const serialized = api.serialize();
       expect(serialized.text).toBe("Hello World");
@@ -97,9 +92,9 @@ describe("EgWalkerAPI", () => {
     });
 
     it("should deserialize document state", () => {
-      const api = EgWalkerAPI.deserialize({
+      const api = EgWalkerReplica.deserialize({
         text: "Hello",
-        eventGraph: null as unknown as SerializedGraph,
+        eventGraph: null as unknown as SerializedGraphInput,
       });
       expect(api.getText()).toBe("Hello");
     });
@@ -107,7 +102,7 @@ describe("EgWalkerAPI", () => {
 
   describe("duplicate event handling", () => {
     it("ignores duplicate local events without throwing", () => {
-      const api = new EgWalkerAPI("r1", "");
+      const api = new EgWalkerReplica("r1", "");
       // @ts-expect-error - swap eventGraph.addEvent for the duplicate branch
       const originalAddEvent = api.eventGraph.addEvent.bind(api.eventGraph);
       // @ts-expect-error - same
@@ -123,7 +118,7 @@ describe("EgWalkerAPI", () => {
     });
 
     it("ignores duplicate remote events without throwing", () => {
-      const api = new EgWalkerAPI("r1", "");
+      const api = new EgWalkerReplica("r1", "");
       const event: GraphEvent = {
         id: "remote:1",
         parentVersion: new Set(),
@@ -141,7 +136,7 @@ describe("EgWalkerAPI", () => {
 
   describe("exportEventGraph", () => {
     it("should export all events", () => {
-      const api = new EgWalkerAPI("r1", "");
+      const api = new EgWalkerReplica("r1", "");
       api.insert(0, "Hello");
       api.insert(5, " World");
       const events = api.exportEventGraph();
@@ -166,14 +161,14 @@ describe("EgWalkerAPI", () => {
         },
       ];
 
-      const api = EgWalkerAPI.fromEventGraph("r2", events);
+      const api = EgWalkerReplica.fromEventGraph("r2", events);
       expect(api.getText()).toBe("Hello World");
     });
   });
 
   describe("out-of-order remote delivery", () => {
     it("buffers events whose parents have not yet arrived", () => {
-      const api = new EgWalkerAPI("r1", "");
+      const api = new EgWalkerReplica("r1", "");
       const root: GraphEvent = {
         id: "alice:0",
         parentVersion: new Set(),
@@ -197,7 +192,7 @@ describe("EgWalkerAPI", () => {
     });
 
     it("flushes a chain of pending events when the root finally arrives", () => {
-      const api = new EgWalkerAPI("r1", "");
+      const api = new EgWalkerReplica("r1", "");
       const events: GraphEvent[] = [
         {
           id: "a:0",
@@ -231,21 +226,21 @@ describe("EgWalkerAPI", () => {
   });
 });
 
-describe("createEgWalker", () => {
+describe("createEgWalkerReplica", () => {
   it("should create API instance", () => {
-    const api = createEgWalker("r1", "Hello");
+    const api = createEgWalkerReplica("r1", "Hello");
     expect(api.getText()).toBe("Hello");
   });
 
   it("should create API with empty text by default", () => {
-    const api = createEgWalker("r1");
+    const api = createEgWalkerReplica("r1");
     expect(api.getText()).toBe("");
   });
 });
 
-describe("EgWalkerAPI - Edge cases and error handling", () => {
+describe("EgWalkerReplica - Edge cases and error handling", () => {
   it("should propagate non-duplicate errors in applyLocalOperation", () => {
-    const api = new EgWalkerAPI("r1");
+    const api = new EgWalkerReplica("r1");
     // @ts-expect-error - swap eventGraph.addEvent for the failing branch
     const originalAddEvent = api.eventGraph.addEvent.bind(api.eventGraph);
     // @ts-expect-error - same
@@ -260,7 +255,7 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
   });
 
   it("should propagate non-duplicate errors in applyRemoteEvent", () => {
-    const api = new EgWalkerAPI("r1");
+    const api = new EgWalkerReplica("r1");
 
     const event: GraphEvent = {
       id: "r2:0",
@@ -283,29 +278,29 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
   });
 
   it("should handle deserialize with eventGraph data", () => {
-    const api = new EgWalkerAPI("r1", "Test");
+    const api = new EgWalkerReplica("r1", "Test");
     const serialized = api.serialize();
 
-    const deserialized = EgWalkerAPI.deserialize(serialized);
+    const deserialized = EgWalkerReplica.deserialize(serialized);
     expect(deserialized.getText()).toBe("Test");
   });
 
   it("should deserialize JSON-persisted serialized API data", () => {
-    const api = new EgWalkerAPI("r1", "");
+    const api = new EgWalkerReplica("r1", "");
     api.insert(0, "A");
     api.insert(1, "B");
 
     const parsed = JSON.parse(JSON.stringify(api.serialize())) as unknown as {
       text: string;
-      eventGraph: SerializedGraph;
+      eventGraph: SerializedGraphInput;
     };
-    const deserialized = EgWalkerAPI.deserialize(parsed);
+    const deserialized = EgWalkerReplica.deserialize(parsed);
 
     expect(deserialized.getText()).toBe("AB");
   });
 
   it("should reject invalid direct local operations before committing", () => {
-    const api = new EgWalkerAPI("r1", "Hello");
+    const api = new EgWalkerReplica("r1", "Hello");
     const readSeq = (): number =>
       // @ts-expect-error - read private nextSequenceNumber for regression coverage
       api.nextSequenceNumber as number;
@@ -343,7 +338,7 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
   });
 
   it("should deserialize empty graph state without stored initial text metadata", () => {
-    const deserialized = EgWalkerAPI.deserialize({
+    const deserialized = EgWalkerReplica.deserialize({
       text: "Fallback",
       eventGraph: {
         version: new Set(),
@@ -357,7 +352,7 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
 
   it("ignores non-numeric sequence suffixes when inferring nextSequenceNumber", () => {
     // Hits the Number.isInteger=false branch in inferNextSequenceNumber.
-    const api = new EgWalkerAPI("r1");
+    const api = new EgWalkerReplica("r1");
     api.applyRemoteEvent({
       id: "r1:notanumber",
       parentVersion: new Set(),
@@ -365,7 +360,7 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
       timestamp: 1,
     });
 
-    const restored = EgWalkerAPI.deserialize(
+    const restored = EgWalkerReplica.deserialize(
       // Drop persisted nextSequenceNumber metadata so the API has to infer it.
       {
         ...api.serialize(),
@@ -384,7 +379,7 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
 
   it("falls back to full replay when concurrent remote parents differ from current", () => {
     // Hits the parentsMatchCurrent !has branch (size matches, contents differ).
-    const api = new EgWalkerAPI("r1");
+    const api = new EgWalkerReplica("r1");
     api.applyRemoteEvent({
       id: "alice:0",
       parentVersion: new Set(),
@@ -416,7 +411,7 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
 
   describe("surrogate pair boundaries", () => {
     it("rejects inserts that land between surrogate halves", () => {
-      const api = new EgWalkerAPI("r1", "😀");
+      const api = new EgWalkerReplica("r1", "😀");
       // "😀".length === 2 (high + low surrogate). Index 1 falls mid-pair.
       expect(() => api.insert(1, "X")).toThrow(
         /falls between surrogate halves/,
@@ -429,7 +424,7 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
     });
 
     it("keeps concurrent emoji operations from splitting surrogate pairs", () => {
-      const api = new EgWalkerAPI("alice", "ab");
+      const api = new EgWalkerReplica("alice", "ab");
 
       // Insert emoji between a and b.
       api.insert(1, "😀");
@@ -466,7 +461,7 @@ describe("EgWalkerAPI - Edge cases and error handling", () => {
   it("ignores already-buffered remote events on re-delivery", () => {
     // Hits the bufferedEventIds.has(event.id) early-return branch in
     // tryAcceptRemoteEvent.
-    const api = new EgWalkerAPI("r1");
+    const api = new EgWalkerReplica("r1");
     const child: GraphEvent = {
       id: "alice:1",
       parentVersion: new Set(["alice:0"]),

--- a/packages/eg-walker/src/types/index.ts
+++ b/packages/eg-walker/src/types/index.ts
@@ -74,12 +74,6 @@ export type SerializedVersionInput =
   | Iterable<EventId>
   | Record<string, unknown>;
 
-/**
- * @deprecated Use {@link SerializedVersionOutput} for serialize results and
- * {@link SerializedVersionInput} for deserialize inputs.
- */
-export type SerializedVersion = SerializedVersionInput;
-
 export interface SerializedGraphEventOutput {
   readonly id: EventId;
   readonly operation: ExternalOperation;
@@ -93,9 +87,6 @@ export interface SerializedGraphEventInput {
   readonly parentVersion: SerializedVersionInput;
   readonly timestamp: number;
 }
-
-/** @deprecated Use {@link SerializedGraphEventInput}. */
-export type SerializedGraphEvent = SerializedGraphEventInput;
 
 // ============================================================================
 // Invariant Types
@@ -116,12 +107,6 @@ export interface ListInvariant {
   equivalent(state1: DocumentState, state2: DocumentState): boolean;
 }
 
-// ============================================================================
-// Type Aliases
-// ============================================================================
-
-export type Event = GraphEvent;
-
 /**
  * Shape produced by {@link EventGraph.serialize} — always JSON-safe.
  */
@@ -140,10 +125,3 @@ export interface SerializedGraphInput {
   readonly events: ReadonlyArray<SerializedGraphEventInput>;
   readonly metadata?: Record<string, unknown>;
 }
-
-/**
- * Combined serialize/deserialize type. `serialize()` returns the narrow output
- * shape; `deserialize()` accepts the wider input shape.
- */
-export type SerializedGraph = SerializedGraphInput;
-export type SerializedEventGraph = SerializedGraph;

--- a/packages/eg-walker/tsup.config.ts
+++ b/packages/eg-walker/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/internal.ts"],
   format: ["esm"],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
## Summary

Naming + export-surface cleanup for `@softmaple/eg-walker`. Two commits, no behavior change.

**Commit 1 — `be4b891` rename public API + drop deprecated type aliases**
- `EgWalkerAPI` → `EgWalkerReplica`; `createEgWalker` → `createEgWalkerReplica`. File rename `core/external-api.ts` → `core/replica.ts`.
- Remove redundant `getDocumentState(): string` (was named like the struct getter but returned a string). `getText()` / `getDocument()` remain.
- Delete `@deprecated` type aliases: `SerializedVersion`, `SerializedGraphEvent`, `SerializedGraph`, `SerializedEventGraph`, and the generic `Event = GraphEvent` alias (which clashed with DOM `Event`). Canonical names: `GraphEvent`, `SerializedGraphInput`/`Output`.
- Updates `apps/playground` consumer + docs.

**Commit 2 — `7876a88` trim public exports + rename replay coordinator**
- `EgWalker` → `ReplayWalker` (`core/walker.ts` → `core/replay-walker.ts`). The thin one-shot coordinator no longer shares its name with the package itself, and is visibly distinct from the stateful `EgWalkerReplica`.
- Drop the `EgWalker as default` re-export. The default pointed at the *less*-prominent of the two user-facing classes; nothing depended on it.
- Move replay internals (`EgWalkerEngine`, `IndexedSequence`, `CriticalVersionAnalyzer`, `PartialReplayManager`, `ColumnarEventGraphCodec`) off the root barrel and onto a new `@softmaple/eg-walker/internal` subpath export.

### Public surface after this PR

Root `@softmaple/eg-walker`: `EgWalkerReplica`, `createEgWalkerReplica`, `ReplayWalker`, `EventGraph`, `OPERATION_TYPE`, + types.

`@softmaple/eg-walker/internal` (no semver guarantees): `EgWalkerEngine`, `IndexedSequence`, `CriticalVersionAnalyzer`, `PartialReplayManager`, `ColumnarEventGraphCodec`.

`dist/index.js`: **55KB → 10KB**. Internals live in `dist/internal.js` (~16KB).

## Test plan

- [x] `pnpm --filter @softmaple/eg-walker typecheck`
- [x] `pnpm --filter @softmaple/eg-walker test` — 138/138 pass
- [x] `pnpm --filter @softmaple/eg-walker build` — emits `dist/index.js` + `dist/internal.js` + shared chunk
- [x] `pnpm --filter @softmaple/eg-walker lint`
- [x] `pnpm --filter playground typecheck` (consumer)
- [x] `pnpm --filter playground test` — 39/39 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stabilized public API surface with improved naming conventions.
  * Added dedicated internal APIs export for advanced customization.

* **Documentation**
  * Updated documentation, README examples, and implementation guides.
  * Clarified API categorization distinguishing stable surface from internal components.

* **Refactor**
  * Restructured package exports for better maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/642)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->