### PR TITLE
refactor(packages/awareness): use pokemonFlavor accents as fixture colors

### DIFF
--- a/packages/awareness/src/stories/PresenceAvatar.stories.tsx
+++ b/packages/awareness/src/stories/PresenceAvatar.stories.tsx
@@ -82,7 +82,7 @@ export const Active: Story = {
 
     await expect(avatar).toBeVisible();
     await expect(avatar).toHaveClass("awareness-avatar--active");
-    await expect(avatar).toHaveStyle({ "--awareness-user-color": "#854d0e" });
+    await expect(avatar).toHaveStyle({ "--awareness-user-color": "#facc15" });
   },
 };
 

--- a/packages/awareness/src/stories/PresenceAvatar.stories.tsx
+++ b/packages/awareness/src/stories/PresenceAvatar.stories.tsx
@@ -82,7 +82,7 @@ export const Active: Story = {
 
     await expect(avatar).toBeVisible();
     await expect(avatar).toHaveClass("awareness-avatar--active");
-    await expect(avatar).toHaveStyle({ "--awareness-user-color": "#facc15" });
+    await expect(avatar).toHaveStyle({ "--awareness-user-color": "#854d0e" });
   },
 };
 

--- a/packages/awareness/src/stories/awareness-fixtures.ts
+++ b/packages/awareness/src/stories/awareness-fixtures.ts
@@ -11,23 +11,27 @@ const baseTime = Date.UTC(2026, 4, 10, 9, 30);
 
 export interface PokemonFlavor {
   readonly type: string;
+  // Bright tint for chips/badges; mixed down with Canvas before rendering.
   readonly accent: string;
+  // Darker tint used as the PresenceUser color — drives the avatar gradient,
+  // caret, and selection at high opacity, so it needs contrast on light bgs.
+  readonly userColor: string;
 }
 
 export const pokemonFlavor = {
-  pikachu: { type: "Electric", accent: "#facc15" },
-  bulbasaur: { type: "Grass", accent: "#22c55e" },
-  charmander: { type: "Fire", accent: "#f97316" },
-  squirtle: { type: "Water", accent: "#38bdf8" },
-  eevee: { type: "Normal", accent: "#a78bfa" },
-  psyduck: { type: "Water", accent: "#fcd34d" },
+  pikachu: { type: "Electric", accent: "#facc15", userColor: "#854d0e" },
+  bulbasaur: { type: "Grass", accent: "#22c55e", userColor: "#166534" },
+  charmander: { type: "Fire", accent: "#f97316", userColor: "#9a3412" },
+  squirtle: { type: "Water", accent: "#38bdf8", userColor: "#0369a1" },
+  eevee: { type: "Normal", accent: "#a78bfa", userColor: "#92400e" },
+  psyduck: { type: "Water", accent: "#fcd34d", userColor: "#0e7490" },
 } as const satisfies Record<string, PokemonFlavor>;
 
 export const pikachu = {
   userId: "pikachu",
   name: "Pikachu",
   avatarUrl: pikachuSprite,
-  color: pokemonFlavor.pikachu.accent,
+  color: pokemonFlavor.pikachu.userColor,
   status: "active",
   lastActiveAt: baseTime + 4000,
   cursor: { blockId: "abstract", offset: 42 },
@@ -39,7 +43,7 @@ export const bulbasaur = {
   userId: "bulbasaur",
   name: "Bulbasaur",
   avatarUrl: bulbasaurSprite,
-  color: pokemonFlavor.bulbasaur.accent,
+  color: pokemonFlavor.bulbasaur.userColor,
   status: "active",
   lastActiveAt: baseTime + 3000,
   cursor: { blockId: "methods", offset: 18 },
@@ -49,7 +53,7 @@ export const charmander = {
   userId: "charmander",
   name: "Charmander",
   avatarUrl: charmanderSprite,
-  color: pokemonFlavor.charmander.accent,
+  color: pokemonFlavor.charmander.userColor,
   status: "idle",
   lastActiveAt: baseTime + 2000,
   selection: { blockId: "results", from: 4, to: 27 },
@@ -59,7 +63,7 @@ export const squirtle = {
   userId: "squirtle",
   name: "Squirtle",
   avatarUrl: squirtleSprite,
-  color: pokemonFlavor.squirtle.accent,
+  color: pokemonFlavor.squirtle.userColor,
   status: "idle",
   lastActiveAt: baseTime + 1000,
 } satisfies PresenceUser;
@@ -68,7 +72,7 @@ export const eevee = {
   userId: "eevee",
   name: "Eevee",
   avatarUrl: eeveeSprite,
-  color: pokemonFlavor.eevee.accent,
+  color: pokemonFlavor.eevee.userColor,
   status: "offline",
   lastActiveAt: baseTime,
 } satisfies PresenceUser;
@@ -77,7 +81,7 @@ export const psyduck = {
   userId: "psyduck",
   name: "Psyduck",
   avatarUrl: psyduckSprite,
-  color: pokemonFlavor.psyduck.accent,
+  color: pokemonFlavor.psyduck.userColor,
   status: "active",
   lastActiveAt: baseTime + 5000,
 } satisfies PresenceUser;

--- a/packages/awareness/src/stories/awareness-fixtures.ts
+++ b/packages/awareness/src/stories/awareness-fixtures.ts
@@ -9,11 +9,25 @@ import eeveeSprite from "./assets/pokemon-133.png";
 
 const baseTime = Date.UTC(2026, 4, 10, 9, 30);
 
+export interface PokemonFlavor {
+  readonly type: string;
+  readonly accent: string;
+}
+
+export const pokemonFlavor = {
+  pikachu: { type: "Electric", accent: "#facc15" },
+  bulbasaur: { type: "Grass", accent: "#22c55e" },
+  charmander: { type: "Fire", accent: "#f97316" },
+  squirtle: { type: "Water", accent: "#38bdf8" },
+  eevee: { type: "Normal", accent: "#a78bfa" },
+  psyduck: { type: "Water", accent: "#fcd34d" },
+} as const satisfies Record<string, PokemonFlavor>;
+
 export const pikachu = {
   userId: "pikachu",
   name: "Pikachu",
   avatarUrl: pikachuSprite,
-  color: "#854d0e",
+  color: pokemonFlavor.pikachu.accent,
   status: "active",
   lastActiveAt: baseTime + 4000,
   cursor: { blockId: "abstract", offset: 42 },
@@ -25,7 +39,7 @@ export const bulbasaur = {
   userId: "bulbasaur",
   name: "Bulbasaur",
   avatarUrl: bulbasaurSprite,
-  color: "#166534",
+  color: pokemonFlavor.bulbasaur.accent,
   status: "active",
   lastActiveAt: baseTime + 3000,
   cursor: { blockId: "methods", offset: 18 },
@@ -35,7 +49,7 @@ export const charmander = {
   userId: "charmander",
   name: "Charmander",
   avatarUrl: charmanderSprite,
-  color: "#9a3412",
+  color: pokemonFlavor.charmander.accent,
   status: "idle",
   lastActiveAt: baseTime + 2000,
   selection: { blockId: "results", from: 4, to: 27 },
@@ -45,7 +59,7 @@ export const squirtle = {
   userId: "squirtle",
   name: "Squirtle",
   avatarUrl: squirtleSprite,
-  color: "#0369a1",
+  color: pokemonFlavor.squirtle.accent,
   status: "idle",
   lastActiveAt: baseTime + 1000,
 } satisfies PresenceUser;
@@ -54,7 +68,7 @@ export const eevee = {
   userId: "eevee",
   name: "Eevee",
   avatarUrl: eeveeSprite,
-  color: "#92400e",
+  color: pokemonFlavor.eevee.accent,
   status: "offline",
   lastActiveAt: baseTime,
 } satisfies PresenceUser;
@@ -63,7 +77,7 @@ export const psyduck = {
   userId: "psyduck",
   name: "Psyduck",
   avatarUrl: psyduckSprite,
-  color: "#0e7490",
+  color: pokemonFlavor.psyduck.accent,
   status: "active",
   lastActiveAt: baseTime + 5000,
 } satisfies PresenceUser;
@@ -80,20 +94,6 @@ export const collaborators = [
 export const usersById = new Map(
   collaborators.map((user) => [user.userId, user]),
 ) satisfies ReadonlyMap<string, PresenceUser>;
-
-export interface PokemonFlavor {
-  readonly type: string;
-  readonly accent: string;
-}
-
-export const pokemonFlavor = {
-  pikachu: { type: "Electric", accent: "#facc15" },
-  bulbasaur: { type: "Grass", accent: "#22c55e" },
-  charmander: { type: "Fire", accent: "#f97316" },
-  squirtle: { type: "Water", accent: "#38bdf8" },
-  eevee: { type: "Normal", accent: "#a78bfa" },
-  psyduck: { type: "Water", accent: "#fcd34d" },
-} as const satisfies Record<string, PokemonFlavor>;
 
 export const recentActivities = [
   {


### PR DESCRIPTION
## Summary
Refactor the awareness-package story fixtures so `pokemonFlavor` is the single source of truth for per-trainer visual identity. Each entry now has two fields:

- `accent` — bright tint used by type chips/badges (always mixed down with Canvas before rendering).
- `userColor` — darker tint used as the `PresenceUser` `color`. Drives the avatar gradient (`global.css:47-51`), ring/shadow, cursor caret, and selection highlight — all of which paint the raw value at high opacity on light backgrounds and therefore need contrast.

Each `PresenceUser` fixture now reads its `color` from `pokemonFlavor.X.userColor`. The hex values themselves are unchanged from prior to this branch, so there is **no visible palette shift** — the change is structural only.

## Why two fields
Chips render the accent inside `color-mix(... 18%, Canvas)`, so saturation matters more than darkness. Avatars/caret/selection render the raw color at full opacity, so darkness matters more than saturation. One field can't satisfy both roles, but they belong on the same record per Pokémon.

## Test plan
- [x] `pnpm --filter @softmaple/awareness typecheck`
- [x] `pnpm --filter @softmaple/awareness test` (250/250 pass, including Storybook chromium runs)
- [ ] Chromatic visual review — no avatar/caret diff expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)