### PR TITLE
ci: bump pnpm/action-setup to v6

### DIFF
--- a/.github/workflows/_chromatic-reusable.yml
+++ b/.github/workflows/_chromatic-reusable.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/_chromatic-reusable.yml
+++ b/.github/workflows/_chromatic-reusable.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/awareness-stories-tests.yml
+++ b/.github/workflows/awareness-stories-tests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/awareness-stories-tests.yml
+++ b/.github/workflows/awareness-stories-tests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/awareness-tests.yml
+++ b/.github/workflows/awareness-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/awareness-tests.yml
+++ b/.github/workflows/awareness-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/eg-walker-tests.yml
+++ b/.github/workflows/eg-walker-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/eg-walker-tests.yml
+++ b/.github/workflows/eg-walker-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/prisma-migrate.yml
+++ b/.github/workflows/prisma-migrate.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/prisma-migrate.yml
+++ b/.github/workflows/prisma-migrate.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/test-md2latex.yml
+++ b/.github/workflows/test-md2latex.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/test-md2latex.yml
+++ b/.github/workflows/test-md2latex.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/test-playground-e2e.yml
+++ b/.github/workflows/test-playground-e2e.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/test-playground-e2e.yml
+++ b/.github/workflows/test-playground-e2e.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/test-playground.yml
+++ b/.github/workflows/test-playground.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/test-playground.yml
+++ b/.github/workflows/test-playground.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false

--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.8
         name: Install pnpm
         with:
           run_install: false


### PR DESCRIPTION
## Summary
- Bump `pnpm/action-setup` from `v4` to `v6` across all 12 workflows in `.github/workflows/`.

## Test plan
- [x] CI workflows run successfully on this PR (pnpm install + downstream jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)