### PR TITLE
chore: remove redundant packageManager from sub-packages

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,7 +19,6 @@
  "exports": {
     ".": "./src/index.ts"
   },
-  "packageManager": "pnpm@10.33.0",
   "devDependencies": {
     "prisma": "^6.13.0"
   },

--- a/packages/md2latex/package.json
+++ b/packages/md2latex/package.json
@@ -21,7 +21,6 @@
     "url": "https://github.com/zhyd1997"
   },
   "license": "MIT",
-  "packageManager": "pnpm@10.33.0",
   "devDependencies": {
     "@softmaple/eslint-config": "workspace:*",
     "@softmaple/typescript-config": "workspace:*",


### PR DESCRIPTION
## Summary
- Remove stale `packageManager: pnpm@10.33.0` entries from `packages/db/package.json` and `packages/md2latex/package.json`
- The root `package.json` already pins `pnpm@11.1.1`, which Corepack uses for the whole workspace — the sub-package entries were redundant and out of sync

## Test plan
- [x] CI passes (lint, typecheck, tests)
- [x] `pnpm install` at the root still resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `packageManager` field from package metadata in db and md2latex packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/658)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->