### PR TITLE
refactor(editor): clean up Lexical 0.44 usage, ship code-block toggle + safe Link button

### DIFF
--- a/apps/web/modules/docs/collab-doc-editor.tsx
+++ b/apps/web/modules/docs/collab-doc-editor.tsx
@@ -8,7 +8,7 @@ import {
 } from "@liveblocks/react-lexical";
 import { Threads } from "@/modules/docs/threads";
 import { CoreEditor } from "@softmaple/editor/components/core/CoreEditor";
-import { LEXIAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
+import { LEXICAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer";
 
 import "@liveblocks/react-ui/styles.css";
@@ -26,7 +26,7 @@ export const CollabDocEditor: FC<CollabDocEditorProps> = (props) => {
   const { commonEditorConfig, activeEditor, setActiveEditor } = props;
 
   const lexicalConfig: InitialConfigType = liveblocksConfig({
-    ...LEXIAL_PLAYGROUND_CONFIG,
+    ...LEXICAL_PLAYGROUND_CONFIG,
     ...commonEditorConfig,
   });
 

--- a/apps/web/modules/docs/doc-editor.tsx
+++ b/apps/web/modules/docs/doc-editor.tsx
@@ -4,7 +4,7 @@ import type { FC } from "react";
 
 import { memo, useState, useEffect } from "react";
 
-import { LEXIAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
+import { LEXICAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
 import { useEditorState } from "@/contexts/EditorStateContext";
 
 import { CoreEditor } from "@softmaple/editor/components/core/CoreEditor";
@@ -38,7 +38,7 @@ const UnMemoizedDocEditor: FC<DocEditorProps> = (props) => {
   }
 
   const commonConfig: CollabDocEditorProps["commonEditorConfig"] = {
-    ...LEXIAL_PLAYGROUND_CONFIG,
+    ...LEXICAL_PLAYGROUND_CONFIG,
     namespace: "DocEditor",
     onError: (error: unknown) => {
       console.error(error);

--- a/packages/editor/src/components/core/CoreEditor.tsx
+++ b/packages/editor/src/components/core/CoreEditor.tsx
@@ -3,7 +3,7 @@ import type { InitialConfigType } from "@lexical/react/LexicalComposer";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { Providers } from "@softmaple/editor/components/core/Providers";
 import { Editor } from "@softmaple/editor/components/core/Editor";
-import { LEXIAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
+import { LEXICAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
 import type { EditorProps } from "@softmaple/editor/components/core/Editor";
 
 export type CoreEditorProps = Pick<
@@ -16,7 +16,7 @@ export type CoreEditorProps = Pick<
 
 export const CoreEditor: FC<CoreEditorProps> = (props) => {
   const {
-    lexicalConfig = LEXIAL_PLAYGROUND_CONFIG,
+    lexicalConfig = LEXICAL_PLAYGROUND_CONFIG,
     children,
     activeEditor,
     setActiveEditor,

--- a/packages/editor/src/components/core/Editor.tsx
+++ b/packages/editor/src/components/core/Editor.tsx
@@ -13,6 +13,7 @@ import { useSharedHistoryContext } from "@softmaple/editor/context/SharedHistory
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { ShortcutsPlugin } from "@softmaple/editor/components/core/plugins/ShortcutsPlugin/ShortcutsPlugin";
 import { MarkdownPlugin } from "@softmaple/editor/components/core/plugins/MarkdownShortcutPlugin/MarkdownShortcutPlugin";
+import { isSafeUrl } from "@softmaple/editor/utils/sanitizeUrl";
 import type { LexicalEditor } from "lexical";
 
 export type EditorProps = {
@@ -97,7 +98,7 @@ export const Editor: FC<EditorProps> = (props) => {
         <MarkdownPlugin />
         <ListPlugin hasStrictIndent />
         <CheckListPlugin />
-        <LinkPlugin />
+        <LinkPlugin validateUrl={isSafeUrl} />
       </div>
     </>
   );

--- a/packages/editor/src/components/core/Editor.tsx
+++ b/packages/editor/src/components/core/Editor.tsx
@@ -8,6 +8,7 @@ import { ToolbarPlugin } from "@softmaple/editor/components/core/plugins/Toolbar
 import { LexicalContentEditable } from "@softmaple/editor/components/core/LexicalContentEditable";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { CheckListPlugin } from "@lexical/react/LexicalCheckListPlugin";
+import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { useSharedHistoryContext } from "@softmaple/editor/context/SharedHistoryContext";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { ShortcutsPlugin } from "@softmaple/editor/components/core/plugins/ShortcutsPlugin/ShortcutsPlugin";
@@ -96,6 +97,7 @@ export const Editor: FC<EditorProps> = (props) => {
         <MarkdownPlugin />
         <ListPlugin hasStrictIndent />
         <CheckListPlugin />
+        <LinkPlugin />
       </div>
     </>
   );

--- a/packages/editor/src/components/core/plugins/ShortcutsPlugin/ShortcutsPlugin.tsx
+++ b/packages/editor/src/components/core/plugins/ShortcutsPlugin/ShortcutsPlugin.tsx
@@ -35,7 +35,7 @@ import {
   isFormatParagraph,
   isFormatQuote,
   isIndent,
-  isInsertCodeBlock,
+  isInlineCode,
   isInsertLink,
   isJustifyAlign,
   isLeftAlign,
@@ -103,7 +103,7 @@ export const ShortcutsPlugin = ({
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, "subscript");
       } else if (isSuperscript(event)) {
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, "superscript");
-      } else if (isInsertCodeBlock(event)) {
+      } else if (isInlineCode(event)) {
         editor.dispatchCommand(FORMAT_TEXT_COMMAND, "code");
       } else if (isClearFormatting(event)) {
         // clearFormatting(editor);

--- a/packages/editor/src/components/core/plugins/ShortcutsPlugin/ShortcutsPlugin.tsx
+++ b/packages/editor/src/components/core/plugins/ShortcutsPlugin/ShortcutsPlugin.tsx
@@ -17,7 +17,7 @@ import {
   // clearFormatting,
   formatBulletList,
   formatCheckList,
-  // formatCode,
+  formatCode,
   formatHeading,
   formatNumberedList,
   formatParagraph,
@@ -76,7 +76,7 @@ export const ShortcutsPlugin = ({
       } else if (isFormatCheckList(event)) {
         formatCheckList(editor, toolbarState.blockType);
       } else if (isFormatCode(event)) {
-        // formatCode(editor, toolbarState.blockType);
+        formatCode(editor, toolbarState.blockType);
       } else if (isFormatQuote(event)) {
         formatQuote(editor, toolbarState.blockType);
       } else if (isStrikeThrough(event)) {

--- a/packages/editor/src/components/core/plugins/ShortcutsPlugin/shortcuts.ts
+++ b/packages/editor/src/components/core/plugins/ShortcutsPlugin/shortcuts.ts
@@ -17,7 +17,7 @@ export const SHORTCUTS = Object.freeze({
   // (Ctrl|⌘) + Shift + <key> shortcuts
   INCREASE_FONT_SIZE: IS_APPLE ? "⌘+Shift+." : "Ctrl+Shift+.",
   DECREASE_FONT_SIZE: IS_APPLE ? "⌘+Shift+," : "Ctrl+Shift+,",
-  INSERT_CODE_BLOCK: IS_APPLE ? "⌘+Shift+C" : "Ctrl+Shift+C",
+  INLINE_CODE: IS_APPLE ? "⌘+Shift+C" : "Ctrl+Shift+C",
   STRIKETHROUGH: IS_APPLE ? "⌘+Shift+X" : "Ctrl+Shift+X",
   LOWERCASE: IS_APPLE ? "⌃+Shift+1" : "Ctrl+Shift+1",
   UPPERCASE: IS_APPLE ? "⌃+Shift+2" : "Ctrl+Shift+2",
@@ -197,7 +197,7 @@ export const isSuperscript = (event: KeyboardEvent): boolean => {
   return code === "Period" && isModifierMatch(event, CONTROL_OR_META);
 };
 
-export const isInsertCodeBlock = (event: KeyboardEvent): boolean => {
+export const isInlineCode = (event: KeyboardEvent): boolean => {
   const { code } = event;
   return (
     code === "KeyC" &&

--- a/packages/editor/src/components/core/plugins/ToolbarPlugin/BlockFormatDropdown.tsx
+++ b/packages/editor/src/components/core/plugins/ToolbarPlugin/BlockFormatDropdown.tsx
@@ -16,6 +16,7 @@ import {
   List,
   ListTodo,
   Quote,
+  Code,
 } from "lucide-react";
 import { SHORTCUTS } from "@softmaple/editor/components/core/plugins/ShortcutsPlugin/shortcuts";
 import type { LexicalEditor } from "lexical";
@@ -26,6 +27,7 @@ import {
   formatBulletList,
   formatCheckList,
   formatQuote,
+  formatCode,
 } from "@softmaple/editor/components/core/plugins/ToolbarPlugin/utils";
 import type { blockTypeToBlockName } from "@softmaple/editor/constants/toolbar";
 
@@ -94,6 +96,13 @@ const ITEMS: BlockFormatType[] = [
     icon: <Quote className="size-4 md:size-4.5" />,
     shortcut: SHORTCUTS.QUOTE,
   },
+  {
+    key: "code",
+    value: "code",
+    label: "Code Block",
+    icon: <Code className="size-4 md:size-4.5" />,
+    shortcut: SHORTCUTS.CODE_BLOCK,
+  },
 ];
 
 type BlockFormatDropdownProps = {
@@ -129,6 +138,9 @@ export const BlockFormatDropdown: FC<BlockFormatDropdownProps> = (props) => {
         break;
       case "quote":
         formatQuote(editor, blockType);
+        break;
+      case "code":
+        formatCode(editor, blockType);
         break;
       default:
         break;

--- a/packages/editor/src/components/core/plugins/ToolbarPlugin/FormatButtonGroup.tsx
+++ b/packages/editor/src/components/core/plugins/ToolbarPlugin/FormatButtonGroup.tsx
@@ -67,7 +67,7 @@ export const FormatButtonGroup: FC<FormatButtonGroupProps> = (props) => {
       key: "code",
       icon: Code,
       label: "Inline Code",
-      shortcut: SHORTCUTS.INSERT_CODE_BLOCK,
+      shortcut: SHORTCUTS.INLINE_CODE,
       isActive: toolbarState.isCode,
     },
   ];

--- a/packages/editor/src/components/core/plugins/ToolbarPlugin/LinkButton.tsx
+++ b/packages/editor/src/components/core/plugins/ToolbarPlugin/LinkButton.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@softmaple/ui/components/button";
 import { SHORTCUTS } from "@softmaple/editor/components/core/plugins/ShortcutsPlugin/shortcuts";
 import type { ToolbarState } from "@softmaple/editor/context/ToolbarContext";
+import { isSafeUrl } from "@softmaple/editor/utils/sanitizeUrl";
 
 type LinkButtonProps = {
   editor: LexicalEditor;
@@ -33,7 +34,11 @@ export const LinkButton: FC<LinkButtonProps> = ({ editor, toolbarState }) => {
     if (trimmed === "") {
       return;
     }
-    editor.dispatchCommand(TOGGLE_LINK_COMMAND, formatUrl(trimmed));
+    const formatted = formatUrl(trimmed);
+    if (!isSafeUrl(formatted)) {
+      return;
+    }
+    editor.dispatchCommand(TOGGLE_LINK_COMMAND, formatted);
   };
 
   return (

--- a/packages/editor/src/components/core/plugins/ToolbarPlugin/LinkButton.tsx
+++ b/packages/editor/src/components/core/plugins/ToolbarPlugin/LinkButton.tsx
@@ -1,0 +1,62 @@
+import type { FC } from "react";
+import { TOGGLE_LINK_COMMAND, formatUrl } from "@lexical/link";
+import { Link as LinkIcon } from "lucide-react";
+import type { LexicalEditor } from "lexical";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@softmaple/ui/components/tooltip";
+import { Button } from "@softmaple/ui/components/button";
+import { SHORTCUTS } from "@softmaple/editor/components/core/plugins/ShortcutsPlugin/shortcuts";
+import type { ToolbarState } from "@softmaple/editor/context/ToolbarContext";
+
+type LinkButtonProps = {
+  editor: LexicalEditor;
+  toolbarState: ToolbarState;
+};
+
+export const LinkButton: FC<LinkButtonProps> = ({ editor, toolbarState }) => {
+  const isActive = toolbarState.isLink;
+
+  const handleClick = () => {
+    if (isActive) {
+      editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
+      return;
+    }
+    const input = window.prompt("Enter URL", "https://");
+    if (input === null) {
+      return;
+    }
+    const trimmed = input.trim();
+    if (trimmed === "") {
+      return;
+    }
+    editor.dispatchCommand(TOGGLE_LINK_COMMAND, formatUrl(trimmed));
+  };
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={isActive ? "secondary" : "ghost"}
+            size="icon"
+            className="h-8 w-8"
+            title={`Link (${SHORTCUTS.INSERT_LINK})`}
+            onClick={handleClick}
+            aria-pressed={isActive}
+          >
+            <LinkIcon className="h-4 w-4" />
+            <span className="sr-only">Link</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <span>{isActive ? "Remove link" : "Insert link"}</span>
+          <span className="hidden md:inline"> ({SHORTCUTS.INSERT_LINK})</span>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/packages/editor/src/components/core/plugins/ToolbarPlugin/ToolbarPlugin.tsx
+++ b/packages/editor/src/components/core/plugins/ToolbarPlugin/ToolbarPlugin.tsx
@@ -21,11 +21,13 @@ import { BlockFormatDropdown } from "@softmaple/editor/components/core/plugins/T
 import { useToolbarState } from "@softmaple/editor/context/ToolbarContext";
 import { $isTableNode, $isTableSelection } from "@lexical/table";
 import { getSelectedNode } from "@softmaple/editor/utils/getSelectedNode";
-// import { $isLinkNode } from "@lexical/link";
+import { $isLinkNode } from "@lexical/link";
 import { $isListNode, ListNode } from "@lexical/list";
 import { $isHeadingNode } from "@lexical/rich-text";
+import { $isCodeNode } from "@lexical/code";
 import { FormatButtonGroup } from "@softmaple/editor/components/core/plugins/ToolbarPlugin/FormatButtonGroup";
 import { HistoryButtonGroup } from "@softmaple/editor/components/core/plugins/ToolbarPlugin/HistoryButtonGroup";
+import { LinkButton } from "@softmaple/editor/components/core/plugins/ToolbarPlugin/LinkButton";
 import { blockTypeToBlockName } from "@softmaple/editor/constants/toolbar";
 
 type ToolbarPluginProps = {
@@ -77,9 +79,9 @@ export const ToolbarPlugin: FC<ToolbarPluginProps> = (props) => {
 
       // Update links
       const node = getSelectedNode(selection);
-      // const parent = node.getParent();
-      // const isLink = $isLinkNode(parent) || $isLinkNode(node);
-      // updateToolbarState('isLink', isLink);
+      const parent = node.getParent();
+      const isLink = $isLinkNode(parent) || $isLinkNode(node);
+      updateToolbarState("isLink", isLink);
 
       const tableNode = $findMatchingParent(node, $isTableNode);
       if ($isTableNode(tableNode)) {
@@ -103,22 +105,15 @@ export const ToolbarPlugin: FC<ToolbarPluginProps> = (props) => {
         } else {
           const type = $isHeadingNode(element)
             ? element.getTag()
-            : element.getType();
+            : $isCodeNode(element)
+              ? "code"
+              : element.getType();
           if (type in blockTypeToBlockName) {
             updateToolbarState(
               "blockType",
               type as keyof typeof blockTypeToBlockName,
             );
           }
-          // if ($isCodeNode(element)) {
-          // const language =
-          //   element.getLanguage() as keyof typeof CODE_LANGUAGE_MAP;
-          // updateToolbarState(
-          //   "codeLanguage",
-          //   language ? CODE_LANGUAGE_MAP[language] || language : ""
-          // );
-          //   return;
-          // }
         }
       }
       // Handle buttons
@@ -228,6 +223,9 @@ export const ToolbarPlugin: FC<ToolbarPluginProps> = (props) => {
         )}
 
       <FormatButtonGroup editor={activeEditor} toolbarState={toolbarState} />
+      <Separator orientation="vertical" className="h-6" />
+
+      <LinkButton editor={activeEditor} toolbarState={toolbarState} />
       <Separator orientation="vertical" className="h-6" />
     </div>
   );

--- a/packages/editor/src/components/core/plugins/ToolbarPlugin/utils.ts
+++ b/packages/editor/src/components/core/plugins/ToolbarPlugin/utils.ts
@@ -1,9 +1,10 @@
 import { $createHeadingNode, $createQuoteNode } from "@lexical/rich-text";
 import type { HeadingTagType } from "@lexical/rich-text";
+import { $createCodeNode } from "@lexical/code";
 import {
   $createParagraphNode,
   $getSelection,
-  // $isRangeSelection,
+  $isRangeSelection,
   FORMAT_TEXT_COMMAND,
   REDO_COMMAND,
   UNDO_COMMAND,
@@ -81,27 +82,29 @@ export const formatQuote = (editor: LexicalEditor, blockType: string) => {
   }
 };
 
-// export const formatCode = (editor: LexicalEditor, blockType: string) => {
-//   if (blockType !== 'code') {
-//     editor.update(() => {
-//       let selection = $getSelection();
-//       if (!selection) {
-//         return;
-//       }
-//       if (!$isRangeSelection(selection) || selection.isCollapsed()) {
-//         $setBlocksType(selection, () => $createCodeNode());
-//       } else {
-//         const textContent = selection.getTextContent();
-//         const codeNode = $createCodeNode();
-//         selection.insertNodes([codeNode]);
-//         selection = $getSelection();
-//         if ($isRangeSelection(selection)) {
-//           selection.insertRawText(textContent);
-//         }
-//       }
-//     });
-//   }
-// };
+export const formatCode = (editor: LexicalEditor, blockType: string) => {
+  if (blockType === "code") {
+    formatParagraph(editor);
+    return;
+  }
+  editor.update(() => {
+    let selection = $getSelection();
+    if (!selection) {
+      return;
+    }
+    if (!$isRangeSelection(selection) || selection.isCollapsed()) {
+      $setBlocksType(selection, () => $createCodeNode());
+      return;
+    }
+    const textContent = selection.getTextContent();
+    const codeNode = $createCodeNode();
+    selection.insertNodes([codeNode]);
+    selection = $getSelection();
+    if ($isRangeSelection(selection)) {
+      selection.insertRawText(textContent);
+    }
+  });
+};
 
 export const formatText = (
   editor: LexicalEditor,

--- a/packages/editor/src/config/lexical.tsx
+++ b/packages/editor/src/config/lexical.tsx
@@ -44,7 +44,7 @@ const onError = (error: Error) => {
   throw error;
 };
 
-export const LEXIAL_PLAYGROUND_CONFIG: InitialConfigType = {
+export const LEXICAL_PLAYGROUND_CONFIG: InitialConfigType = {
   namespace: "Playground",
   theme: LEXICAL_PLAYGROUND_THEME,
   onError,

--- a/packages/editor/src/constants/toolbar.ts
+++ b/packages/editor/src/constants/toolbar.ts
@@ -20,7 +20,7 @@ export const INITIAL_TOOLBAR_STATE = {
 export const blockTypeToBlockName = {
   bullet: "Bulleted List",
   check: "Check List",
-  // code: "Code Block",
+  code: "Code Block",
   h1: "Heading 1",
   h2: "Heading 2",
   h3: "Heading 3",

--- a/packages/editor/src/utils/sanitizeUrl.ts
+++ b/packages/editor/src/utils/sanitizeUrl.ts
@@ -1,0 +1,12 @@
+const SAFE_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+export const isSafeUrl = (raw: string): boolean => {
+  try {
+    const base =
+      typeof window === "undefined" ? "http://localhost" : window.location.href;
+    const { protocol } = new URL(raw, base);
+    return SAFE_PROTOCOLS.has(protocol);
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary

Three focused commits cleaning up Lexical 0.44 usage in `@softmaple/editor`:

1. **`refactor(editor)!`** — Fix `LEXIAL` → `LEXICAL` typo on the exported playground config and rename `INSERT_CODE_BLOCK` → `INLINE_CODE` / `isInsertCodeBlock` → `isInlineCode` to match the handler's actual behavior (it dispatches `FORMAT_TEXT_COMMAND, "code"` — inline text format, not a `CodeNode`).
2. **`feat(editor)`** — Implement a real code-block toggle (`$createCodeNode` + `$setBlocksType`), wire it into `Ctrl+Alt+C` and the block-format dropdown, detect `$isCodeNode` for toolbar state, and add a Link toolbar button that consumes the previously-dead `toolbarState.isLink`. Register `LinkPlugin` so `TOGGLE_LINK_COMMAND` actually has a handler.
3. **`fix(editor)`** — Reject unsafe URL protocols in link insertion. `@lexical/link`'s `formatUrl` does not block `javascript:` / `data:`, so a user typing `javascript:alert(1)` into the link prompt would produce a clickable XSS vector. New `isSafeUrl` allowlist (`http`/`https`/`mailto`/`tel`) gates both the button dispatch and `LinkPlugin`'s `validateUrl` (covers paste/auto-link too).

## Breaking change

The first commit renames public exports of `@softmaple/editor`:

- `LEXIAL_PLAYGROUND_CONFIG` → `LEXICAL_PLAYGROUND_CONFIG`
- `SHORTCUTS.INSERT_CODE_BLOCK` → `SHORTCUTS.INLINE_CODE`
- `isInsertCodeBlock` → `isInlineCode`

In-repo consumers in `apps/web/modules/docs/{doc,collab-doc}-editor.tsx` are updated in the same commit.

## Test plan

- [ ] `pnpm --filter @softmaple/editor exec tsc -b` passes (verified locally)
- [ ] `pnpm --filter web exec tsc --noEmit` passes (verified locally)
- [ ] `pnpm --filter @softmaple/editor lint` shows no new warnings (verified locally — 4 pre-existing warnings unchanged)
- [ ] Manually: `Ctrl+Alt+C` toggles a code block; the block dropdown shows "Code Block" and round-trips paragraph ↔ code
- [ ] Manually: with a text selection, clicking the Link button prompts; entering `https://example.com` creates a link; clicking the now-active button removes it
- [ ] Manually: entering `javascript:alert(1)` into the link prompt is silently rejected — no link node created
- [ ] Manually: pasting `javascript:alert(1)` as a URL via the LinkPlugin paste path is rejected by `validateUrl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)