### PR TITLE
refactor(awareness): rename storybook MCP to softmaple-awareness-storybook-mcp

### DIFF
--- a/packages/awareness/.cursor/mcp.json
+++ b/packages/awareness/.cursor/mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "softmaple-storybook-mcp": {
+    "softmaple-awareness-storybook-mcp": {
       "url": "http://localhost:6006/mcp"
     }
   }

--- a/packages/awareness/.gemini/settings.json
+++ b/packages/awareness/.gemini/settings.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "softmaple-storybook-mcp": {
+    "softmaple-awareness-storybook-mcp": {
       "httpUrl": "http://localhost:6006/mcp"
     }
   }

--- a/packages/awareness/.mcp.json
+++ b/packages/awareness/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "softmaple-storybook-mcp": {
+    "softmaple-awareness-storybook-mcp": {
       "url": "http://localhost:6006/mcp",
       "type": "http"
     }

--- a/packages/awareness/.vscode/mcp.json
+++ b/packages/awareness/.vscode/mcp.json
@@ -1,6 +1,6 @@
 {
   "servers": {
-    "softmaple-storybook-mcp": {
+    "softmaple-awareness-storybook-mcp": {
       "type": "http",
       "url": "http://localhost:6006/mcp"
     }

--- a/packages/awareness/AGENTS.md
+++ b/packages/awareness/AGENTS.md
@@ -1,4 +1,4 @@
-When working on UI components, always use the `softmaple-storybook-mcp` MCP tools to access Storybook's component and documentation knowledge before answering or taking any action.
+When working on UI components, always use the `softmaple-awareness-storybook-mcp` MCP tools to access Storybook's component and documentation knowledge before answering or taking any action.
 
 - **CRITICAL: Never hallucinate component properties!** Before using ANY property on a component from a design system (including common-sounding ones like `shadow`, etc.), you MUST use the MCP tools to check if the property is actually documented for that component.
 - Query `list-all-documentation` to get a list of all components

--- a/packages/awareness/CLAUDE.md
+++ b/packages/awareness/CLAUDE.md
@@ -1,4 +1,4 @@
-When working on UI components, always use the `softmaple-storybook-mcp` MCP tools to access Storybook's component and documentation knowledge before answering or taking any action.
+When working on UI components, always use the `softmaple-awareness-storybook-mcp` MCP tools to access Storybook's component and documentation knowledge before answering or taking any action.
 
 - **CRITICAL: Never hallucinate component properties!** Before using ANY property on a component from a design system (including common-sounding ones like `shadow`, etc.), you MUST use the MCP tools to check if the property is actually documented for that component.
 - Query `list-all-documentation` to get a list of all components

--- a/packages/awareness/package.json
+++ b/packages/awareness/package.json
@@ -178,7 +178,7 @@
   },
   "lint-staged": {
     "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
-      "biome check --files-ignore-unknown=true",
+      "biome check --files-ignore-unknown=true --no-errors-on-unmatched",
       "biome check --write --no-errors-on-unmatched",
       "biome check --write --unsafe --no-errors-on-unmatched",
       "biome format --write --no-errors-on-unmatched",


### PR DESCRIPTION
## Summary
- Rename the Storybook MCP server from `softmaple-storybook-mcp` to `softmaple-awareness-storybook-mcp` so it's scoped to this package and won't collide once other packages register their own Storybook MCP.
- Update all four MCP client configs (`.mcp.json`, `.cursor/mcp.json`, `.gemini/settings.json`, `.vscode/mcp.json`) and both agent guides (`CLAUDE.md`, `AGENTS.md`).
- Add `--no-errors-on-unmatched` to the first lint-staged `biome check` in `packages/awareness/package.json` so JSON dotfiles outside biome's `includes` allowlist don't fail pre-commit (matches the other four biome commands in the chain).

## Test plan
- [x] Reload your MCP client (Claude Code / Cursor / Gemini / VS Code) and confirm the server registers under the new name and responds at `http://localhost:6006/mcp`.
- [x] `grep -r "softmaple-storybook-mcp" packages/awareness` returns nothing.
- [x] Stage a `.json` dotfile change in `packages/awareness/` and confirm the pre-commit hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized MCP server naming conventions across awareness package configuration files for consistency.
  * Updated developer documentation to reference the updated Storybook MCP tool name.
  * Adjusted build tooling configuration settings for improved code checking behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/663)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->