### PR TITLE
refactor(eg-walker): bounded replay via critical-version checkpoints

### DIFF
--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -38,6 +38,8 @@ export class EgWalkerReplica {
   private engine: EgWalkerEngine | null = null;
   private readonly pendingByMissingParent = new Map<EventId, GraphEvent[]>();
   private readonly bufferedEventIds = new Set<EventId>();
+  private fullReplayCount = 0;
+  private incrementalApplyCount = 0;
 
   constructor(
     private readonly replicaId: string,
@@ -183,6 +185,32 @@ export class EgWalkerReplica {
   }
 
   /**
+   * Replay scope counters. Exposed for tests and diagnostics to verify the
+   * incremental retreat/advance path is taken instead of full replay.
+   *
+   * - `fullReplays` increments each time the entire event graph is replayed
+   *   from scratch (engine cold-start or recovery path).
+   * - `incrementalApplies` increments each time a single event is applied on
+   *   top of existing engine state via retreat/advance.
+   * - `engineRetreats` / `engineAdvances` are the cumulative engine counters,
+   *   useful for proving replay work stays bounded to the divergent suffix.
+   */
+  getReplayStats(): {
+    readonly fullReplays: number;
+    readonly incrementalApplies: number;
+    readonly engineRetreats: number;
+    readonly engineAdvances: number;
+  } {
+    const engineStats = this.engine?.getStats();
+    return {
+      fullReplays: this.fullReplayCount,
+      incrementalApplies: this.incrementalApplyCount,
+      engineRetreats: engineStats?.retreatCount ?? 0,
+      engineAdvances: engineStats?.advanceCount ?? 0,
+    };
+  }
+
+  /**
    * Generate unique event ID
    */
   private generateEventId(): EventId {
@@ -286,13 +314,32 @@ export class EgWalkerReplica {
     this.document = generated.text;
     this.currentVersion = this.eventGraph.getFrontier();
     this.engine = engine;
+    this.fullReplayCount++;
   }
 
+  /**
+   * Apply a single event on top of existing engine state.
+   *
+   * For events that only advance the engine forward (no retreat needed) we
+   * take the cheap incremental path through {@link EgWalkerEngine.applyEvent}.
+   * That covers local edits and remote events that descend from the engine's
+   * current version — including the long-tail of sequential collaboration
+   * where every new event extends the latest frontier.
+   *
+   * Events that would require retreating already-applied events (concurrent
+   * merges) still go through a replay. The current implementation replays
+   * from initial state because the bucket-based integration in
+   * {@link EgWalkerEngine} is sensitive to apply order for concurrent items;
+   * see issues #665 and #668 for the path to bounded partial replay from a
+   * critical-version checkpoint without losing per-replica convergence.
+   */
   private advanceWithEvent(event: GraphEvent): void {
-    if (!this.engine || !this.parentsMatchCurrent(event.parentVersion)) {
-      // Remote/concurrent events would be processed in arrival order on the
-      // incremental path, which diverges from the deterministic topological
-      // order each replica needs to converge. Replay from scratch instead.
+    if (!this.engine) {
+      this.fullReplay();
+      return;
+    }
+
+    if (!this.canIncrementallyAdvance(event)) {
       this.fullReplay();
       return;
     }
@@ -300,14 +347,25 @@ export class EgWalkerReplica {
     this.engine.applyEvent(event, this.eventGraph);
     this.document = this.engine.getText();
     this.currentVersion = this.eventGraph.getFrontier();
+    this.incrementalApplyCount++;
   }
 
-  private parentsMatchCurrent(parents: ReadonlySet<EventId>): boolean {
-    if (parents.size !== this.currentVersion.size) {
-      return false;
+  /**
+   * Incremental apply is safe iff the engine's current version is causally
+   * ≤ the new event's parent version — i.e. the engine only needs to advance
+   * (no retreat). When retreat would be needed, the new event is concurrent
+   * with state already applied and the engine cannot deterministically
+   * re-integrate concurrent inserts yet (#668), so we fall back to a full
+   * replay in topological order.
+   */
+  private canIncrementallyAdvance(event: GraphEvent): boolean {
+    const engineVersion = this.engine?.getCurrentVersion();
+    if (!engineVersion || engineVersion.size === 0) {
+      return true;
     }
-    for (const id of parents) {
-      if (!this.currentVersion.has(id)) {
+    const parentExpansion = this.eventGraph.expandVersion(event.parentVersion);
+    for (const id of engineVersion) {
+      if (!parentExpansion.has(id)) {
         return false;
       }
     }

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -24,6 +24,13 @@ import {
   MissingParentError,
 } from "../graph/event-graph";
 import { EgWalkerEngine } from "../engine/eg-walker-engine";
+import { CriticalVersionAnalyzer } from "../engine/critical-version";
+import { PartialReplayManager } from "../engine/partial-replay";
+
+interface CriticalCheckpoint {
+  readonly version: Version;
+  readonly text: string;
+}
 
 /**
  * Public replica for Eg-walker.
@@ -39,7 +46,11 @@ export class EgWalkerReplica {
   private readonly pendingByMissingParent = new Map<EventId, GraphEvent[]>();
   private readonly bufferedEventIds = new Set<EventId>();
   private fullReplayCount = 0;
+  private partialReplayCount = 0;
   private incrementalApplyCount = 0;
+  private readonly criticalAnalyzer = new CriticalVersionAnalyzer();
+  private readonly partialReplayer = new PartialReplayManager();
+  private readonly criticalCheckpoints: CriticalCheckpoint[] = [];
 
   constructor(
     private readonly replicaId: string,
@@ -54,6 +65,7 @@ export class EgWalkerReplica {
     if (this.eventGraph.getAllEvents().length > 0) {
       this.fullReplay();
     }
+    this.maybeAdvanceCheckpoint();
   }
 
   /**
@@ -197,16 +209,20 @@ export class EgWalkerReplica {
    */
   getReplayStats(): {
     readonly fullReplays: number;
+    readonly partialReplays: number;
     readonly incrementalApplies: number;
     readonly engineRetreats: number;
     readonly engineAdvances: number;
+    readonly checkpointCount: number;
   } {
     const engineStats = this.engine?.getStats();
     return {
       fullReplays: this.fullReplayCount,
+      partialReplays: this.partialReplayCount,
       incrementalApplies: this.incrementalApplyCount,
       engineRetreats: engineStats?.retreatCount ?? 0,
       engineAdvances: engineStats?.advanceCount ?? 0,
+      checkpointCount: this.criticalCheckpoints.length,
     };
   }
 
@@ -320,43 +336,50 @@ export class EgWalkerReplica {
   /**
    * Apply a single event on top of existing engine state.
    *
-   * For events that only advance the engine forward (no retreat needed) we
-   * take the cheap incremental path through {@link EgWalkerEngine.applyEvent}.
-   * That covers local edits and remote events that descend from the engine's
-   * current version — including the long-tail of sequential collaboration
-   * where every new event extends the latest frontier.
-   *
-   * Events that would require retreating already-applied events (concurrent
-   * merges) still go through a replay. The current implementation replays
-   * from initial state because the bucket-based integration in
-   * {@link EgWalkerEngine} is sensitive to apply order for concurrent items;
-   * see issues #665 and #668 for the path to bounded partial replay from a
-   * critical-version checkpoint without losing per-replica convergence.
+   * Three paths, cheapest first:
+   *   1. Incremental — when the engine's current version is causally ≤ the
+   *      new event's parent version, the engine only needs to advance, no
+   *      retreat. Covers local edits and remote events that extend the
+   *      current frontier (the common case for sequential collaboration).
+   *   2. Partial replay from a critical-version checkpoint — when retreat
+   *      is needed but the divergent suffix is dominated by a previously
+   *      observed critical version (Section 3.5 / 3.6 of the paper).
+   *      Replays only events in `expand(frontier) \ expand(checkpoint)`.
+   *   3. Full replay — only when no checkpoint dominates the divergent
+   *      region (e.g. concurrent root inserts with no critical ancestor).
    */
   private advanceWithEvent(event: GraphEvent): void {
     if (!this.engine) {
       this.fullReplay();
+      this.maybeAdvanceCheckpoint();
       return;
     }
 
-    if (!this.canIncrementallyAdvance(event)) {
+    if (this.canIncrementallyAdvance(event)) {
+      this.engine.applyEvent(event, this.eventGraph);
+      this.document = this.engine.getText();
+      this.currentVersion = this.eventGraph.getFrontier();
+      this.incrementalApplyCount++;
+      this.maybeAdvanceCheckpoint();
+      return;
+    }
+
+    const checkpoint = this.pickCheckpoint();
+    if (checkpoint) {
+      this.partialReplayFromCheckpoint(checkpoint);
+    } else {
       this.fullReplay();
-      return;
     }
-
-    this.engine.applyEvent(event, this.eventGraph);
-    this.document = this.engine.getText();
-    this.currentVersion = this.eventGraph.getFrontier();
-    this.incrementalApplyCount++;
+    this.maybeAdvanceCheckpoint();
   }
 
   /**
    * Incremental apply is safe iff the engine's current version is causally
    * ≤ the new event's parent version — i.e. the engine only needs to advance
    * (no retreat). When retreat would be needed, the new event is concurrent
-   * with state already applied and the engine cannot deterministically
-   * re-integrate concurrent inserts yet (#668), so we fall back to a full
-   * replay in topological order.
+   * with state already applied; the engine's bucket-based integration is
+   * order-sensitive for concurrent items (#668), so we re-process the
+   * divergent suffix in topological order via partial replay instead.
    */
   private canIncrementallyAdvance(event: GraphEvent): boolean {
     const engineVersion = this.engine?.getCurrentVersion();
@@ -366,6 +389,91 @@ export class EgWalkerReplica {
     const parentExpansion = this.eventGraph.expandVersion(event.parentVersion);
     for (const id of engineVersion) {
       if (!parentExpansion.has(id)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Snapshot the current (version, text) pair when the graph's frontier is a
+   * single-element critical version. These checkpoints let later concurrent
+   * branches partial-replay only the post-checkpoint suffix instead of the
+   * whole graph.
+   *
+   * Checkpoints are never pruned in this revision; a long linear history
+   * grows the list by O(N). Pruning is tracked under #670.
+   */
+  private maybeAdvanceCheckpoint(): void {
+    const frontier = this.eventGraph.getFrontier();
+    if (frontier.size !== 1) {
+      return;
+    }
+    if (!this.criticalAnalyzer.isCritical(this.eventGraph, frontier)) {
+      return;
+    }
+    const last = this.criticalCheckpoints[this.criticalCheckpoints.length - 1];
+    if (last && this.versionsEqual(last.version, frontier)) {
+      return;
+    }
+    this.criticalCheckpoints.push({
+      version: new Set(frontier),
+      text: this.document,
+    });
+  }
+
+  /**
+   * Latest checkpoint that is still a critical version of the current graph.
+   * Critical versions are causally ordered, so scanning newest-first returns
+   * the deepest dominating checkpoint.
+   */
+  private pickCheckpoint(): CriticalCheckpoint | null {
+    for (let i = this.criticalCheckpoints.length - 1; i >= 0; i--) {
+      const candidate = this.criticalCheckpoints[i];
+      if (!candidate) {
+        continue;
+      }
+      if (
+        this.criticalAnalyzer.isCritical(this.eventGraph, candidate.version)
+      ) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private partialReplayFromCheckpoint(checkpoint: CriticalCheckpoint): void {
+    const frontier = this.eventGraph.getFrontier();
+    const replayIds = new Set(
+      this.partialReplayer.getReplayEventIds(
+        this.eventGraph,
+        checkpoint.version,
+        frontier,
+      ),
+    );
+    const events = this.eventGraph
+      .getTopologicalOrder()
+      .filter((candidate) => replayIds.has(candidate.id));
+    const engine = new EgWalkerEngine();
+    engine.generate(events, checkpoint.text, {
+      initialVersion: checkpoint.version,
+      eventGraph: this.eventGraph,
+    });
+    this.engine = engine;
+    this.document = engine.getText();
+    this.currentVersion = frontier;
+    this.partialReplayCount++;
+  }
+
+  private versionsEqual(
+    left: ReadonlySet<EventId>,
+    right: ReadonlySet<EventId>,
+  ): boolean {
+    if (left.size !== right.size) {
+      return false;
+    }
+    for (const id of left) {
+      if (!right.has(id)) {
         return false;
       }
     }

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -134,6 +134,14 @@ export class EgWalkerEngine {
     return this.currentVersion;
   }
 
+  getStats(): EngineStats {
+    return {
+      retreatCount: this.retreatCount,
+      advanceCount: this.advanceCount,
+      eventsProcessed: this.eventsById.size,
+    };
+  }
+
   private processEvent(event: GraphEvent): ExternalOperation[] {
     const { retreat, advance } = this.diffVersions(
       this.currentVersion,

--- a/packages/eg-walker/src/test/replica.test.ts
+++ b/packages/eg-walker/src/test/replica.test.ts
@@ -377,8 +377,10 @@ describe("EgWalkerReplica - Edge cases and error handling", () => {
     expect(restored.exportEventGraph().some((e) => e.id === "r1:0")).toBe(true);
   });
 
-  it("falls back to full replay when concurrent remote parents differ from current", () => {
-    // Hits the parentsMatchCurrent !has branch (size matches, contents differ).
+  it("falls back to full replay when concurrent remote parents require retreat", () => {
+    // Concurrent remote events with parents not ⊆ engine's current version
+    // still trigger a replay so the bucket integration sees events in
+    // topological order (see issue #668 for the order-independence work).
     const api = new EgWalkerReplica("r1");
     api.applyRemoteEvent({
       id: "alice:0",
@@ -386,27 +388,59 @@ describe("EgWalkerReplica - Edge cases and error handling", () => {
       operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
       timestamp: 1,
     });
-    // Concurrent event: same number of parents (0) as currentVersion.size (1).
-    // parentsMatchCurrent first short-circuits on size; here we want the
-    // member mismatch path. Apply a follow-up event whose parents are a
-    // single-element set that does not match currentVersion's element.
     api.applyRemoteEvent({
       id: "alice:1",
       parentVersion: new Set(["alice:0"]),
       operation: { type: OPERATION_TYPE.INSERT, index: 1, text: "B" },
       timestamp: 2,
     });
-    // Now currentVersion = {alice:1}. Send a remote event whose parents are
-    // {alice:0} — same size, different content. Forces the !has branch.
+    const replaysBeforeConcurrent = api.getReplayStats().fullReplays;
+    // Concurrent branch: parent is {alice:0}, engine current is {alice:1}.
+    // alice:1 is not in expand({alice:0}), so a retreat is needed → replay.
     api.applyRemoteEvent({
       id: "bob:0",
       parentVersion: new Set(["alice:0"]),
       operation: { type: OPERATION_TYPE.INSERT, index: 1, text: "C" },
       timestamp: 3,
     });
+    expect(api.getReplayStats().fullReplays).toBe(replaysBeforeConcurrent + 1);
     expect(api.getText().includes("A")).toBe(true);
     expect(api.getText().includes("B")).toBe(true);
     expect(api.getText().includes("C")).toBe(true);
+  });
+
+  it("applies sequential remote events incrementally without replaying history", () => {
+    // Long linear history followed by remote events whose parents always
+    // extend the engine's current version → only the new event needs to be
+    // processed each time. Proves replay scope is bounded to the divergent
+    // suffix (here: just the new event).
+    const api = new EgWalkerReplica("r1");
+    const history: GraphEvent[] = [];
+    let parent: Set<string> = new Set();
+    for (let i = 0; i < 50; i++) {
+      const event: GraphEvent = {
+        id: `alice:${i}`,
+        parentVersion: parent,
+        operation: { type: OPERATION_TYPE.INSERT, index: i, text: "x" },
+        timestamp: i,
+      };
+      history.push(event);
+      parent = new Set([event.id]);
+    }
+
+    for (const event of history) {
+      api.applyRemoteEvent(event);
+    }
+
+    const stats = api.getReplayStats();
+    // Only the very first event cold-starts the engine via fullReplay; every
+    // subsequent event extends the current frontier and applies incrementally.
+    expect(stats.fullReplays).toBe(1);
+    expect(stats.incrementalApplies).toBe(history.length - 1);
+    // The engine should never have to retreat any event when applying a
+    // strictly-forward linear history.
+    expect(stats.engineRetreats).toBe(0);
+    expect(api.getText()).toBe("x".repeat(history.length));
   });
 
   describe("surrogate pair boundaries", () => {

--- a/packages/eg-walker/src/test/replica.test.ts
+++ b/packages/eg-walker/src/test/replica.test.ts
@@ -377,43 +377,10 @@ describe("EgWalkerReplica - Edge cases and error handling", () => {
     expect(restored.exportEventGraph().some((e) => e.id === "r1:0")).toBe(true);
   });
 
-  it("falls back to full replay when concurrent remote parents require retreat", () => {
-    // Concurrent remote events with parents not ⊆ engine's current version
-    // still trigger a replay so the bucket integration sees events in
-    // topological order (see issue #668 for the order-independence work).
-    const api = new EgWalkerReplica("r1");
-    api.applyRemoteEvent({
-      id: "alice:0",
-      parentVersion: new Set(),
-      operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
-      timestamp: 1,
-    });
-    api.applyRemoteEvent({
-      id: "alice:1",
-      parentVersion: new Set(["alice:0"]),
-      operation: { type: OPERATION_TYPE.INSERT, index: 1, text: "B" },
-      timestamp: 2,
-    });
-    const replaysBeforeConcurrent = api.getReplayStats().fullReplays;
-    // Concurrent branch: parent is {alice:0}, engine current is {alice:1}.
-    // alice:1 is not in expand({alice:0}), so a retreat is needed → replay.
-    api.applyRemoteEvent({
-      id: "bob:0",
-      parentVersion: new Set(["alice:0"]),
-      operation: { type: OPERATION_TYPE.INSERT, index: 1, text: "C" },
-      timestamp: 3,
-    });
-    expect(api.getReplayStats().fullReplays).toBe(replaysBeforeConcurrent + 1);
-    expect(api.getText().includes("A")).toBe(true);
-    expect(api.getText().includes("B")).toBe(true);
-    expect(api.getText().includes("C")).toBe(true);
-  });
-
   it("applies sequential remote events incrementally without replaying history", () => {
-    // Long linear history followed by remote events whose parents always
-    // extend the engine's current version → only the new event needs to be
-    // processed each time. Proves replay scope is bounded to the divergent
-    // suffix (here: just the new event).
+    // Sequential remote events whose parents always extend the engine's
+    // current version take the cheap incremental path — only the new event
+    // is processed each time.
     const api = new EgWalkerReplica("r1");
     const history: GraphEvent[] = [];
     let parent: Set<string> = new Set();
@@ -437,10 +404,89 @@ describe("EgWalkerReplica - Edge cases and error handling", () => {
     // subsequent event extends the current frontier and applies incrementally.
     expect(stats.fullReplays).toBe(1);
     expect(stats.incrementalApplies).toBe(history.length - 1);
-    // The engine should never have to retreat any event when applying a
-    // strictly-forward linear history.
+    // No retreats on a strictly-forward linear history.
     expect(stats.engineRetreats).toBe(0);
     expect(api.getText()).toBe("x".repeat(history.length));
+  });
+
+  it("replays only the post-checkpoint suffix when a concurrent branch arrives off a long linear history", () => {
+    // Acceptance criterion for issue #664: build a long linear history, then
+    // deliver a concurrent branch rooted at the latest critical version. The
+    // replica must replay just the divergent suffix from a critical-version
+    // checkpoint instead of re-walking the whole graph.
+    const api = new EgWalkerReplica("r1");
+    const linear: GraphEvent[] = [];
+    let parent: Set<string> = new Set();
+    for (let i = 0; i < 50; i++) {
+      const event: GraphEvent = {
+        id: `alice:${i}`,
+        parentVersion: parent,
+        operation: { type: OPERATION_TYPE.INSERT, index: i, text: "x" },
+        timestamp: i,
+      };
+      linear.push(event);
+      parent = new Set([event.id]);
+    }
+    for (const event of linear) {
+      api.applyRemoteEvent(event);
+    }
+    const tail: GraphEvent = linear[linear.length - 1]!;
+
+    // Local edit on top of the linear tail. Sibling concurrent edit below.
+    api.insert(api.getText().length, "L");
+    const statsBeforeMerge = api.getReplayStats();
+
+    // Concurrent remote event rooted at the same parent as the local edit —
+    // engine.currentVersion is the local event but the remote's parents
+    // point at the linear tail, so a retreat is required.
+    api.applyRemoteEvent({
+      id: "bob:0",
+      parentVersion: new Set([tail.id]),
+      operation: {
+        type: OPERATION_TYPE.INSERT,
+        index: linear.length,
+        text: "R",
+      },
+      timestamp: linear.length + 1,
+    });
+
+    const stats = api.getReplayStats();
+    // Bounded replay: no new full replay was triggered for the merge.
+    expect(stats.fullReplays).toBe(statsBeforeMerge.fullReplays);
+    // Exactly one partial replay covered the merge.
+    expect(stats.partialReplays).toBe(statsBeforeMerge.partialReplays + 1);
+    // Scope check: the engine seeded by the partial replay processes only
+    // the two post-checkpoint events (local "L" + remote "R"), not all 52.
+    expect(stats.engineRetreats + stats.engineAdvances).toBeLessThanOrEqual(2);
+    // Convergence sanity: both inserts present, linear prefix intact.
+    expect(api.getText().startsWith("x".repeat(linear.length))).toBe(true);
+    expect(api.getText().includes("L")).toBe(true);
+    expect(api.getText().includes("R")).toBe(true);
+  });
+
+  it("falls back to full replay only when no critical checkpoint dominates the merge", () => {
+    // Two concurrent root inserts share no critical-version ancestor (the
+    // empty version isn't critical once any event exists), so the replica
+    // legitimately falls back to a full replay in topological order.
+    const api = new EgWalkerReplica("r1");
+    api.applyRemoteEvent({
+      id: "alice:0",
+      parentVersion: new Set(),
+      operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
+      timestamp: 1,
+    });
+    const before = api.getReplayStats();
+    api.applyRemoteEvent({
+      id: "bob:0",
+      parentVersion: new Set(),
+      operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "B" },
+      timestamp: 2,
+    });
+    const after = api.getReplayStats();
+    expect(after.fullReplays).toBe(before.fullReplays + 1);
+    expect(after.partialReplays).toBe(before.partialReplays);
+    expect(api.getText().includes("A")).toBe(true);
+    expect(api.getText().includes("B")).toBe(true);
   });
 
   describe("surrogate pair boundaries", () => {


### PR DESCRIPTION
## Summary

Closes #664.

Replaces the full-replay fallback in `EgWalkerReplica` with the paper's Section 3.5 / 3.6 path:

- **Incremental** retreat/advance when the engine's current version is causally ≤ the new event's parents (no retreat needed). Covers local edits and remote events that extend the current frontier.
- **Partial replay** from the latest still-critical checkpoint when retreat is needed. Replays only events in `expand(frontier) \ expand(checkpoint.version)`.
- **Full replay** only when no checkpoint dominates the merge (e.g. concurrent root inserts that share no critical ancestor).

`CriticalVersionAnalyzer` and `PartialReplayManager` (already in the package) are now wired into the public replica path. A `(version, text)` snapshot is taken every time the graph's frontier becomes a single-element critical version, and `pickCheckpoint()` scans newest-first for one still critical in the current graph.

`getReplayStats()` exposes `fullReplays`, `partialReplays`, `incrementalApplies`, engine retreat/advance counts, and checkpoint count so tests (and downstream code) can prove replay scope is bounded.

## Test plan

- [x] `pnpm --filter @softmaple/eg-walker test` — 140 / 140 pass.
- [x] `pnpm --filter @softmaple/eg-walker typecheck`
- [x] `pnpm --filter @softmaple/eg-walker lint`
- [x] New test: long linear history (50 events) + concurrent branch off the latest critical version replays only the post-checkpoint suffix (`partialReplays += 1`, `fullReplays` unchanged, engine retreat+advance ≤ 2).
- [x] New test: sequential remote chain produces `fullReplays === 1` (cold-start only) and zero retreats.
- [x] New test: concurrent root inserts legitimately fall back to full replay (no usable checkpoint).

## Known limitations / follow-ups

- Checkpoints are not pruned; a long linear history grows the list O(N). Pruning is part of #670 (`Optimize critical-version detection and cache repeated graph order computations`).
- The bucket-based concurrent-insert integration in `EgWalkerEngine` is still apply-order-sensitive, which is why concurrent root inserts (no dominating checkpoint) still need a full replay in topological order. Order-independence is #668.
- Placeholder-based partial replay that retains pre-checkpoint CRDT items is #665 and would let deeper concurrent branches use a checkpoint too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)