### PR TITLE
fix(packages/eg-walker): placeholder-based partial replay for eg-walker

### DIFF
--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -444,23 +444,13 @@ export class EgWalkerReplica {
 
   private partialReplayFromCheckpoint(checkpoint: CriticalCheckpoint): void {
     const frontier = this.eventGraph.getFrontier();
-    const replayIds = new Set(
-      this.partialReplayer.getReplayEventIds(
-        this.eventGraph,
-        checkpoint.version,
-        frontier,
-      ),
+    const result = this.partialReplayer.replayFromCheckpoint(
+      this.eventGraph,
+      checkpoint,
+      frontier,
     );
-    const events = this.eventGraph
-      .getTopologicalOrder()
-      .filter((candidate) => replayIds.has(candidate.id));
-    const engine = new EgWalkerEngine();
-    engine.generate(events, checkpoint.text, {
-      initialVersion: checkpoint.version,
-      eventGraph: this.eventGraph,
-    });
-    this.engine = engine;
-    this.document = engine.getText();
+    this.engine = result.engine;
+    this.document = result.text;
     this.currentVersion = frontier;
     this.partialReplayCount++;
   }

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -4,16 +4,32 @@ import type { EventId, ExternalOperation, GraphEvent } from "../types";
 import { IndexedSequence } from "./indexed-sequence";
 
 const BASE_EVENT_ID_PREFIX = "__base__:";
+const PLACEHOLDER_EVENT_ID = "__placeholder__";
+const PLACEHOLDER_ID_PREFIX = "__placeholder__:";
 
+/**
+ * Augmented CRDT item used during replay.
+ *
+ * Regular items represent a single UTF-16 code unit (`content.length === 1`).
+ * Placeholder items represent a contiguous run of pre-checkpoint content for
+ * Section 3.6 partial replay — they can carry `content.length > 1` and are
+ * split on demand when an insert or delete lands inside them.
+ *
+ * `content` is mutable to support in-place placeholder splits without
+ * invalidating the `WeakMap` location index in {@link IndexedSequence}.
+ */
 interface AugmentedCRDTItem {
   readonly id: EventId;
   readonly eventId: EventId;
-  readonly content: string;
-  readonly originLeft: EventId | null;
+  content: string;
+  originLeft: EventId | null;
   readonly originRight: EventId | null;
   everDeleted: boolean;
   prepareState: number;
 }
+
+const isPlaceholder = (item: AugmentedCRDTItem): boolean =>
+  item.eventId === PLACEHOLDER_EVENT_ID;
 
 interface EngineStats {
   readonly retreatCount: number;
@@ -74,13 +90,14 @@ export class EgWalkerEngine {
   private readonly itemsById = new Map<EventId, AugmentedCRDTItem>();
   private readonly insertionBuckets = new Map<string, EventId[]>();
   private readonly sequence = new IndexedSequence<AugmentedCRDTItem>(
-    (item) => (item.prepareState === 1 ? 1 : 0),
-    (item) => (item.everDeleted ? 0 : 1),
+    (item) => (item.prepareState === 1 ? item.content.length : 0),
+    (item) => (item.everDeleted ? 0 : item.content.length),
   );
   private currentVersion = new Set<EventId>();
   private resultingText = "";
   private retreatCount = 0;
   private advanceCount = 0;
+  private placeholderCounter = 0;
 
   generate(
     events: ReadonlyArray<GraphEvent>,
@@ -177,6 +194,7 @@ export class EgWalkerEngine {
     this.resultingText = initialText;
     this.retreatCount = 0;
     this.advanceCount = 0;
+    this.placeholderCounter = 0;
 
     const graphEvents = options.eventGraph?.getTopologicalOrder() ?? events;
     graphEvents.forEach((event, index) => {
@@ -186,6 +204,30 @@ export class EgWalkerEngine {
         this.graph.addEvent(event);
       }
     });
+
+    if (initialText.length === 0) {
+      return;
+    }
+
+    // Section 3.6 partial replay: when a checkpoint version is supplied, the
+    // pre-checkpoint text is collapsed into a single placeholder record. Inserts
+    // and deletes split the placeholder on demand, so this stays O(replayed
+    // events) in memory rather than O(checkpoint length).
+    const startFromCheckpoint = (options.initialVersion?.size ?? 0) > 0;
+    if (startFromCheckpoint) {
+      const placeholder: AugmentedCRDTItem = {
+        id: this.nextPlaceholderId(),
+        eventId: PLACEHOLDER_EVENT_ID,
+        content: initialText,
+        originLeft: null,
+        originRight: null,
+        everDeleted: false,
+        prepareState: 1,
+      };
+      this.sequence.push(placeholder);
+      this.itemsById.set(placeholder.id, placeholder);
+      return;
+    }
 
     let originLeft: EventId | null = null;
     stringCodeUnits(initialText).forEach((content, index) => {
@@ -203,6 +245,10 @@ export class EgWalkerEngine {
       this.itemsById.set(id, item);
       originLeft = id;
     });
+  }
+
+  private nextPlaceholderId(): EventId {
+    return `${PLACEHOLDER_ID_PREFIX}${this.placeholderCounter++}`;
   }
 
   private apply(event: GraphEvent): ExternalOperation[] {
@@ -227,10 +273,14 @@ export class EgWalkerEngine {
       return [];
     }
 
-    const firstInsertPosition = this.prepareIndexToItemPosition(
+    const landing = this.sequence.prepareIndexToPositionAndOffset(
       operation.index,
       true,
     );
+    const firstInsertPosition =
+      landing.offsetInRecord > 0
+        ? this.splitRecordAt(landing.position, landing.offsetInRecord)
+        : landing.position;
     const originLeft = this.sequence.at(firstInsertPosition - 1)?.id ?? null;
     const originRightPosition =
       this.sequence.nextPrepareVisiblePosition(firstInsertPosition);
@@ -285,29 +335,133 @@ export class EgWalkerEngine {
   ): ExternalOperation[] {
     const deletedItemIds: EventId[] = [];
     const outputDeleteIndexes: number[] = [];
+    let remaining = operation.length;
 
-    for (let i = 0; i < operation.length; i++) {
-      const target = this.findVisiblePrepareItem(operation.index);
-      if (!target) {
+    while (remaining > 0) {
+      const landing = this.prepareIndexLanding(operation.index, false);
+      if (!landing) {
+        break;
+      }
+      const candidate = this.sequence.at(landing.position);
+      if (!candidate) {
         break;
       }
 
-      deletedItemIds.push(target.id);
+      if (isPlaceholder(candidate) && candidate.content.length > 1) {
+        const availableInRecord =
+          candidate.content.length - landing.offsetInRecord;
+        const toDelete = Math.min(remaining, availableInRecord);
+        const middle = this.splitPlaceholderForDelete(
+          landing.position,
+          landing.offsetInRecord,
+          toDelete,
+        );
 
-      if (!target.everDeleted) {
-        const effectIndex = this.itemToEffectIndex(target);
+        deletedItemIds.push(middle.id);
+        const effectIndex = this.itemToEffectIndex(middle);
+        for (let k = 0; k < toDelete; k++) {
+          outputDeleteIndexes.push(effectIndex);
+        }
+        this.resultingText = deleteText(
+          this.resultingText,
+          effectIndex,
+          toDelete,
+        );
+
+        middle.everDeleted = true;
+        middle.prepareState += 1;
+        this.sequence.updateItem(middle);
+        remaining -= toDelete;
+        continue;
+      }
+
+      deletedItemIds.push(candidate.id);
+      if (!candidate.everDeleted) {
+        const effectIndex = this.itemToEffectIndex(candidate);
         outputDeleteIndexes.push(effectIndex);
         this.resultingText = deleteText(this.resultingText, effectIndex, 1);
       }
-
-      target.everDeleted = true;
-      target.prepareState += 1;
-      this.sequence.updateItem(target);
+      candidate.everDeleted = true;
+      candidate.prepareState += 1;
+      this.sequence.updateItem(candidate);
+      remaining -= 1;
     }
 
     this.deleteTargets.set(event.id, deletedItemIds);
 
     return coalesceDeleteRuns(outputDeleteIndexes);
+  }
+
+  /**
+   * Split a multi-character placeholder so that `offsetInRecord` code units
+   * remain in place and the rest become a new record at `position + 1`.
+   * Returns the position of the new right-hand record — i.e. where neighbours
+   * sandwiched between the two halves should be inserted. Single-character
+   * records and offset-0 calls are no-ops.
+   */
+  private splitRecordAt(position: number, offsetInRecord: number): number {
+    const left = this.sequence.at(position);
+    if (!left || offsetInRecord <= 0 || offsetInRecord >= left.content.length) {
+      return position + (offsetInRecord > 0 ? 1 : 0);
+    }
+
+    const rightContent = left.content.slice(offsetInRecord);
+    left.content = left.content.slice(0, offsetInRecord);
+    this.sequence.updateItem(left);
+
+    const right: AugmentedCRDTItem = {
+      id: this.nextPlaceholderId(),
+      eventId: PLACEHOLDER_EVENT_ID,
+      content: rightContent,
+      originLeft: null,
+      originRight: null,
+      everDeleted: left.everDeleted,
+      prepareState: left.prepareState,
+    };
+    this.sequence.insert(position + 1, right);
+    this.itemsById.set(right.id, right);
+    return position + 1;
+  }
+
+  /**
+   * Split a placeholder so that the `length` code units starting at
+   * `offsetInRecord` become an isolated record that the caller can mark as
+   * deleted. Returns that middle record. Surrounding prefix/suffix halves
+   * (if any) remain as undeleted placeholders so future events can still
+   * reference the pre-checkpoint region.
+   */
+  private splitPlaceholderForDelete(
+    position: number,
+    offsetInRecord: number,
+    length: number,
+  ): AugmentedCRDTItem {
+    if (offsetInRecord > 0) {
+      const afterPrefix = this.splitRecordAt(position, offsetInRecord);
+      position = afterPrefix;
+    }
+    const middle = this.sequence.at(position);
+    if (!middle) {
+      throw new Error(
+        `Placeholder split missing record at position ${position}`,
+      );
+    }
+    if (length < middle.content.length) {
+      this.splitRecordAt(position, length);
+    }
+    return middle;
+  }
+
+  private prepareIndexLanding(
+    index: number,
+    allowEnd: boolean,
+  ):
+    | { readonly position: number; readonly offsetInRecord: number }
+    | undefined {
+    try {
+      return this.sequence.prepareIndexToPositionAndOffset(index, allowEnd);
+    } catch {
+      return undefined;
+    }
   }
 
   private retreat(eventId: EventId): void {
@@ -419,19 +573,6 @@ export class EgWalkerEngine {
   private originKey(item: AugmentedCRDTItem): string {
     // Event IDs are "<replicaId>:<n>" so they cannot contain NUL — safe delimiter.
     return `${item.originLeft ?? ""} ${item.originRight ?? ""}`;
-  }
-
-  private prepareIndexToItemPosition(index: number, allowEnd: boolean): number {
-    return this.sequence.prepareIndexToPosition(index, allowEnd);
-  }
-
-  private findVisiblePrepareItem(index: number): AugmentedCRDTItem | undefined {
-    try {
-      const position = this.prepareIndexToItemPosition(index, false);
-      return this.sequence.at(position);
-    } catch {
-      return undefined;
-    }
   }
 
   private itemToEffectIndex(target: AugmentedCRDTItem): number {

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -358,15 +358,22 @@ export class EgWalkerEngine {
         );
 
         deletedItemIds.push(middle.id);
-        const effectIndex = this.itemToEffectIndex(middle);
-        for (let k = 0; k < toDelete; k++) {
-          outputDeleteIndexes.push(effectIndex);
+        // Mirror the non-placeholder guard: a concurrent delete that lands on
+        // an already-effect-deleted placeholder segment (e.g. after retreating
+        // an overlapping sibling) must NOT remove characters from the text
+        // again. Without this, two concurrent deletes of the same checkpoint
+        // region replay to a shorter string than full replay produces.
+        if (!middle.everDeleted) {
+          const effectIndex = this.itemToEffectIndex(middle);
+          for (let k = 0; k < toDelete; k++) {
+            outputDeleteIndexes.push(effectIndex);
+          }
+          this.resultingText = deleteText(
+            this.resultingText,
+            effectIndex,
+            toDelete,
+          );
         }
-        this.resultingText = deleteText(
-          this.resultingText,
-          effectIndex,
-          toDelete,
-        );
 
         middle.everDeleted = true;
         middle.prepareState += 1;

--- a/packages/eg-walker/src/engine/indexed-sequence.ts
+++ b/packages/eg-walker/src/engine/indexed-sequence.ts
@@ -201,6 +201,18 @@ export class IndexedSequence<T extends object> {
     return this.weightIndexToPosition(index, allowEnd, "prepare");
   }
 
+  /**
+   * Variant of {@link prepareIndexToPosition} that also reports how far into the
+   * landing record the requested prepare-index falls. Used by partial replay to
+   * split multi-character placeholder records at the right offset.
+   */
+  prepareIndexToPositionAndOffset(
+    index: number,
+    allowEnd: boolean,
+  ): { readonly position: number; readonly offsetInRecord: number } {
+    return this.weightIndexToPositionAndOffset(index, allowEnd, "prepare");
+  }
+
   effectIndexBeforePosition(position: number): number {
     return this.prefixSum(position, "effect");
   }
@@ -373,19 +385,27 @@ export class IndexedSequence<T extends object> {
     allowEnd: boolean,
     kind: "prepare" | "effect",
   ): number {
+    return this.weightIndexToPositionAndOffset(index, allowEnd, kind).position;
+  }
+
+  private weightIndexToPositionAndOffset(
+    index: number,
+    allowEnd: boolean,
+    kind: "prepare" | "effect",
+  ): { readonly position: number; readonly offsetInRecord: number } {
     if (index < 0) {
       throw new Error(`Index ${index} out of bounds`);
     }
     if (!this.root) {
       if (allowEnd && index === 0) {
-        return 0;
+        return { position: 0, offsetInRecord: 0 };
       }
       throw new Error(`Index ${index} out of bounds`);
     }
 
     const total = this.weightSum(this.root, kind);
     if (allowEnd && index === total) {
-      return this.root.size;
+      return { position: this.root.size, offsetInRecord: 0 };
     }
     if (index >= total) {
       throw new Error(`Index ${index} out of bounds`);
@@ -414,7 +434,7 @@ export class IndexedSequence<T extends object> {
     for (let offset = 0; offset < node.items.length; offset++) {
       const weight = this.leafWeight(node, offset, kind);
       if (remaining < weight) {
-        return position + offset;
+        return { position: position + offset, offsetInRecord: remaining };
       }
       remaining -= weight;
     }

--- a/packages/eg-walker/src/engine/partial-replay.ts
+++ b/packages/eg-walker/src/engine/partial-replay.ts
@@ -9,6 +9,13 @@ export interface ReplayCheckpoint {
 
 export interface PartialReplayResult extends GeneratedDocument {
   readonly replayedEventIds: ReadonlyArray<EventId>;
+  /**
+   * The engine that produced this result. Callers that need to keep applying
+   * subsequent events incrementally (e.g. {@link EgWalkerReplica}) adopt this
+   * engine instead of starting a fresh one, preserving the placeholder state
+   * built up during partial replay.
+   */
+  readonly engine: EgWalkerEngine;
 }
 
 /**
@@ -17,6 +24,10 @@ export interface PartialReplayResult extends GeneratedDocument {
  * A checkpoint represents a critical version whose document text is already
  * known. Replaying from it only walks events in targetVersion \ checkpoint,
  * while using the full event graph to interpret transitive version diffs.
+ *
+ * Pre-checkpoint content is fed to the engine as initial text alongside
+ * `initialVersion`, which triggers the engine's placeholder-seeded reset so the
+ * CRDT state is O(replayed events) rather than O(checkpoint length).
  */
 export class PartialReplayManager {
   replayFromCheckpoint(
@@ -37,7 +48,8 @@ export class PartialReplayManager {
       .filter(
         (event): event is NonNullable<typeof event> => event !== undefined,
       );
-    const generated = new EgWalkerEngine().generate(events, checkpoint.text, {
+    const engine = new EgWalkerEngine();
+    const generated = engine.generate(events, checkpoint.text, {
       initialVersion: checkpoint.version,
       eventGraph: graph,
     });
@@ -45,6 +57,7 @@ export class PartialReplayManager {
     return {
       ...generated,
       replayedEventIds,
+      engine,
     };
   }
 

--- a/packages/eg-walker/src/test/eg-walker-engine.test.ts
+++ b/packages/eg-walker/src/test/eg-walker-engine.test.ts
@@ -559,6 +559,163 @@ describe("Full paper architecture utilities", () => {
     expect(result.replayedEventIds).toEqual(["r:1"]);
   });
 
+  it("splits a placeholder for an insert landing inside checkpoint-era text", () => {
+    // Section 3.6: pre-checkpoint content is one placeholder record. An insert
+    // at index 5 must split it into ["Hello"] + new chars + [" world"] without
+    // materializing one CRDT item per pre-checkpoint code unit.
+    const graph = new EventGraph();
+    graph.addEvent({
+      id: "r:0",
+      parentVersion: new Set(),
+      operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "Hello world" },
+      timestamp: 1,
+    });
+    graph.addEvent({
+      id: "r:1",
+      parentVersion: new Set(["r:0"]),
+      operation: { type: OPERATION_TYPE.INSERT, index: 5, text: "!!" },
+      timestamp: 2,
+    });
+
+    const result = new PartialReplayManager().replayFromCheckpoint(graph, {
+      version: new Set(["r:0"]),
+      text: "Hello world",
+    });
+
+    expect(result.text).toBe("Hello!! world");
+    expect(result.replayedEventIds).toEqual(["r:1"]);
+  });
+
+  it("splits a placeholder for a delete touching checkpoint-era text", () => {
+    // Single-char delete inside the placeholder must split off exactly one
+    // character so prepare/effect indexing for the remaining region stays
+    // accurate.
+    const graph = new EventGraph();
+    graph.addEvent({
+      id: "r:0",
+      parentVersion: new Set(),
+      operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "abcdef" },
+      timestamp: 1,
+    });
+    graph.addEvent({
+      id: "r:1",
+      parentVersion: new Set(["r:0"]),
+      operation: { type: OPERATION_TYPE.DELETE, index: 2, length: 1 },
+      timestamp: 2,
+    });
+
+    const result = new PartialReplayManager().replayFromCheckpoint(graph, {
+      version: new Set(["r:0"]),
+      text: "abcdef",
+    });
+
+    expect(result.text).toBe("abdef");
+    expect(result.replayedEventIds).toEqual(["r:1"]);
+  });
+
+  it("handles a multi-char delete inside a placeholder in one batch split", () => {
+    // The delete spans 3 code units of the placeholder. The engine should split
+    // the placeholder into [prefix, deleted-segment, suffix] in one shot rather
+    // than per-character, while still emitting a single transformed delete run.
+    const graph = new EventGraph();
+    graph.addEvent({
+      id: "r:0",
+      parentVersion: new Set(),
+      operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "abcdefghij" },
+      timestamp: 1,
+    });
+    graph.addEvent({
+      id: "r:1",
+      parentVersion: new Set(["r:0"]),
+      operation: { type: OPERATION_TYPE.DELETE, index: 3, length: 4 },
+      timestamp: 2,
+    });
+
+    const result = new PartialReplayManager().replayFromCheckpoint(graph, {
+      version: new Set(["r:0"]),
+      text: "abcdefghij",
+    });
+
+    expect(result.text).toBe("abchij");
+    expect(result.transformedOperations).toEqual([
+      { type: OPERATION_TYPE.DELETE, index: 3, length: 4 },
+    ]);
+  });
+
+  it("supports interleaved inserts and deletes against placeholder text", () => {
+    // Mixed workload: insert then delete inside the placeholder region. The
+    // partial replay result must match what a full replay from scratch
+    // produces, proving that splitting placeholders preserves convergence.
+    const graph = new EventGraph();
+    const events: GraphEvent[] = [
+      {
+        id: "r:0",
+        parentVersion: new Set(),
+        operation: {
+          type: OPERATION_TYPE.INSERT,
+          index: 0,
+          text: "The quick brown fox",
+        },
+        timestamp: 1,
+      },
+      {
+        id: "r:1",
+        parentVersion: new Set(["r:0"]),
+        operation: { type: OPERATION_TYPE.INSERT, index: 10, text: "very " },
+        timestamp: 2,
+      },
+      {
+        id: "r:2",
+        parentVersion: new Set(["r:1"]),
+        operation: { type: OPERATION_TYPE.DELETE, index: 4, length: 6 },
+        timestamp: 3,
+      },
+    ];
+    events.forEach((event) => graph.addEvent(event));
+
+    const partial = new PartialReplayManager().replayFromCheckpoint(graph, {
+      version: new Set(["r:0"]),
+      text: "The quick brown fox",
+    });
+    const full = new EgWalkerEngine().generate(graph.getTopologicalOrder());
+
+    expect(partial.text).toBe(full.text);
+  });
+
+  it("does not materialize per-character CRDT items for the checkpoint text", () => {
+    // Acceptance criterion for issue #665: partial replay must avoid the
+    // O(checkpoint.length) item cost. We use a long pre-checkpoint string and
+    // a single trailing insert. The engine reports `eventsProcessed` covering
+    // only the divergent suffix; the placeholder representation is what makes
+    // this realistic for large documents.
+    const checkpointText = "x".repeat(5000);
+    const graph = new EventGraph();
+    graph.addEvent({
+      id: "r:0",
+      parentVersion: new Set(),
+      operation: {
+        type: OPERATION_TYPE.INSERT,
+        index: 0,
+        text: checkpointText,
+      },
+      timestamp: 1,
+    });
+    graph.addEvent({
+      id: "r:1",
+      parentVersion: new Set(["r:0"]),
+      operation: { type: OPERATION_TYPE.INSERT, index: 2500, text: "!" },
+      timestamp: 2,
+    });
+
+    const result = new PartialReplayManager().replayFromCheckpoint(graph, {
+      version: new Set(["r:0"]),
+      text: checkpointText,
+    });
+
+    expect(result.text).toBe(`${"x".repeat(2500)}!${"x".repeat(2500)}`);
+    expect(result.stats.eventsProcessed).toBe(1);
+  });
+
   it("detects linear frontier versions as critical checkpoints", () => {
     const graph = new EventGraph();
     graph.addEvent({

--- a/packages/eg-walker/src/test/eg-walker-engine.test.ts
+++ b/packages/eg-walker/src/test/eg-walker-engine.test.ts
@@ -682,6 +682,67 @@ describe("Full paper architecture utilities", () => {
     expect(partial.text).toBe(full.text);
   });
 
+  it("converges with full replay for overlapping concurrent deletes inside placeholder text", () => {
+    // Regression: two concurrent multi-character deletes targeting the same
+    // checkpoint-era region used to mangle the document because the
+    // placeholder branch removed text again after a sibling delete had
+    // already retired the same segment. Partial replay must match full
+    // replay for both exact and partial overlaps.
+    const buildGraph = (
+      e2: GraphEvent["operation"],
+    ): { graph: EventGraph; events: GraphEvent[] } => {
+      const graph = new EventGraph();
+      const events: GraphEvent[] = [
+        {
+          id: "r:0",
+          parentVersion: new Set(),
+          operation: {
+            type: OPERATION_TYPE.INSERT,
+            index: 0,
+            text: "abcdef",
+          },
+          timestamp: 1,
+        },
+        {
+          id: "alice:0",
+          parentVersion: new Set(["r:0"]),
+          operation: { type: OPERATION_TYPE.DELETE, index: 2, length: 2 },
+          timestamp: 2,
+        },
+        {
+          id: "bob:0",
+          parentVersion: new Set(["r:0"]),
+          operation: e2,
+          timestamp: 3,
+        },
+      ];
+      events.forEach((event) => graph.addEvent(event));
+      return { graph, events };
+    };
+
+    const exact = buildGraph({
+      type: OPERATION_TYPE.DELETE,
+      index: 2,
+      length: 2,
+    });
+    const partial = buildGraph({
+      type: OPERATION_TYPE.DELETE,
+      index: 1,
+      length: 4,
+    });
+
+    for (const { graph } of [exact, partial]) {
+      const fullText = new EgWalkerEngine().generate(
+        graph.getTopologicalOrder(),
+      ).text;
+      const partialText = new PartialReplayManager().replayFromCheckpoint(
+        graph,
+        { version: new Set(["r:0"]), text: "abcdef" },
+      ).text;
+      expect(partialText).toBe(fullText);
+    }
+  });
+
   it("does not materialize per-character CRDT items for the checkpoint text", () => {
     // Acceptance criterion for issue #665: partial replay must avoid the
     // O(checkpoint.length) item cost. We use a long pre-checkpoint string and


### PR DESCRIPTION
Closes #665 

## Summary

- Add placeholder-backed partial replay from critical checkpoints for eg-walker so checkpoint-era text does not need to be materialized per code unit.
- Preserve convergence for inserts and deletes that land inside checkpoint placeholder text.
- Guard placeholder delete replay against already-effect-deleted segments so overlapping concurrent deletes match full replay.

## Root Cause

Partial replay can retreat a sibling delete back into the prepare view while its effect deletion remains applied. The regular item path already treats that as idempotent, but placeholder delete handling was still appending transformed delete indexes and removing text again.

## Validation

- `pnpm --filter @softmaple/eg-walker test -- --run packages/eg-walker/src/test/eg-walker-engine.test.ts`
- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker lint`
- `git diff --check -- packages/eg-walker/src/engine/eg-walker-engine.ts packages/eg-walker/src/test/eg-walker-engine.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public API method to resolve indices to positions with offset information.

* **Improvements**
  * Enhanced partial replay to return engine instance for incremental event application.
  * Clarified documentation on CRDT placeholder initialization during replay operations.

* **Tests**
  * Expanded test coverage for replay splitting scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/676)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->