### PR TITLE
refactor(packages/eg-walker): split eg-walker-engine.ts into focused internals

### DIFF
--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -3,133 +3,32 @@ import { EventGraph } from "../graph/event-graph";
 import { compareEventIds, parseEventId } from "../graph/event-id";
 import type { EventId, ExternalOperation, GraphEvent } from "../types";
 import { IndexedSequence } from "./indexed-sequence";
+import { DeleteTargetIndex } from "./internals/delete-target-index";
+import {
+  PLACEHOLDER_EVENT_ID,
+  PLACEHOLDER_ID_PREFIX,
+  type AugmentedCRDTItem,
+  type GeneratedDocument,
+  type GenerateOptions,
+  type IncrementalApplyResult,
+  type TypedRun,
+} from "./internals/engine-types";
+import { OriginLeftIndex } from "./internals/origin-left-index";
+import { PendingInsertBuffer } from "./internals/pending-insert-buffer";
+import { RecordSplitter } from "./internals/record-splitter";
+import {
+  coalesceDeleteRuns,
+  deleteText,
+  spliceText,
+  stringCodeUnits,
+} from "./internals/text-utils";
+import { findIntegrationPosition } from "./internals/yata-integration";
 
-const PLACEHOLDER_EVENT_ID = "__placeholder__";
-const PLACEHOLDER_ID_PREFIX = "__placeholder__:";
-
-/**
- * Identity of a {@link AugmentedCRDTItem} that represents a coalesced run
- * of contiguous single-character INSERT events from one author. The record
- * spans `content.length` events whose IDs are
- * `${replicaId}:${startSequence + offsetInRecord}` for
- * `offsetInRecord ∈ [0, content.length)`.
- *
- * Records produced by multi-character paste events and the initial-text
- * placeholder do **not** carry a {@link TypedRun}; for those, the
- * `eventId` field alone identifies the owning event.
- */
-interface TypedRun {
-  readonly replicaId: string;
-  readonly startSequence: number;
-}
-
-/**
- * Augmented CRDT item used during replay.
- *
- * A record can take two coalesced shapes (or be a single-event item):
- *
- * - **Placeholder** (`eventId === PLACEHOLDER_EVENT_ID`, `run === null`):
- *   contiguous run of pre-checkpoint / initial-text content, split on
- *   demand by concurrent inserts and deletes. Splits assign fresh
- *   placeholder IDs to the right half.
- * - **Typed-run record** (`run !== null`): coalesced run of contiguous
- *   single-character INSERT events from one author (Section 3.4 "smaller"
- *   lever). Splits move whole-event slices to new records with IDs
- *   `${replicaId}:${startSequence + offsetInRecord}:0`.
- *
- * Multi-character INSERT events stay one record per code unit (each with
- * `run === null` and a real `eventId`); we do not coalesce them, since the
- * per-code-unit IDs already serve as anchors for concurrent siblings.
- *
- * `content` is mutable to support in-place run extension and splits
- * without invalidating the `WeakMap` location index in
- * {@link IndexedSequence}.
- */
-interface AugmentedCRDTItem {
-  readonly id: EventId;
-  readonly eventId: EventId;
-  content: string;
-  originLeft: EventId | null;
-  readonly originRight: EventId | null;
-  everDeleted: boolean;
-  prepareState: number;
-  run: TypedRun | null;
-}
-
-const isPlaceholder = (item: AugmentedCRDTItem): boolean =>
-  item.eventId === PLACEHOLDER_EVENT_ID;
-
-interface EngineStats {
-  readonly retreatCount: number;
-  readonly advanceCount: number;
-  readonly eventsProcessed: number;
-  /**
-   * Section 3.4 internal-document fast path: number of events whose
-   * `parentVersion` already matched the engine's current version, so they
-   * skipped the diff/retreat/advance machinery entirely and applied through
-   * a direct integration position (no YATA scan when the destination range
-   * is empty, no per-character scan for multi-character inserts after the
-   * first).
-   */
-  readonly nonConflictingRunCount: number;
-  /**
-   * Counterpart to {@link nonConflictingRunCount}: events that fell through
-   * to the full prepare/effect replay path because either their parent
-   * version diverged from the current version or the destination range
-   * still contained concurrent siblings.
-   */
-  readonly fullReplayCount: number;
-  /**
-   * Number of CRDT records currently held in the underlying ranked B-tree.
-   *
-   * The paper's "Smaller" lever (Section 3.4) is run-length leaves — a
-   * single record covering many code units instead of one record per code
-   * unit. Initial document text and pre-checkpoint placeholders are stored
-   * as run-length records; concurrent inserts and deletes split records on
-   * demand. Tracking the count lets tests prove the coalescing happened
-   * and lets memory regressions surface as a quantitative jump rather than
-   * a slowdown.
-   */
-  readonly sequenceRecordCount: number;
-}
-
-export interface GeneratedDocument {
-  readonly text: string;
-  readonly transformedOperations: ReadonlyArray<ExternalOperation>;
-  readonly stats: EngineStats;
-}
-
-export interface GenerateOptions {
-  readonly initialVersion?: ReadonlySet<EventId>;
-  readonly eventGraph?: EventGraph;
-}
-
-export interface IncrementalApplyResult {
-  readonly text: string;
-  readonly transformedOperations: ReadonlyArray<ExternalOperation>;
-}
-
-const spliceText = (text: string, index: number, insertText: string): string =>
-  `${text.slice(0, index)}${insertText}${text.slice(index)}`;
-
-const deleteText = (text: string, index: number, length: number): string =>
-  `${text.slice(0, index)}${text.slice(index + length)}`;
-
-/**
- * Split a string into JS UTF-16 code units, one per array slot. Unlike
- * `Array.from(text)` (which iterates code points and would coalesce a
- * surrogate pair into one entry), this preserves the public-API code-unit
- * indexing on which the CRDT items are keyed.
- *
- * Lone surrogates are intentionally **not** rejected here: by the time a
- * string reaches this helper it has already been validated at the public
- * boundary (`EgWalkerReplica.assertWellFormedUtf16` for local inserts and
- * `assertRemoteEventWellFormed` for remote events). Bypassing the engine
- * directly with an ill-formed string would still materialise lone
- * surrogates as standalone CRDT items, but the public API never reaches
- * this path with such input.
- */
-const stringCodeUnits = (text: string): string[] => text.split("");
+export type {
+  GeneratedDocument,
+  GenerateOptions,
+  IncrementalApplyResult,
+} from "./internals/engine-types";
 
 /**
  * Direct implementation of the Eg-walker replay algorithm from Appendix B.
@@ -143,63 +42,24 @@ export class EgWalkerEngine {
   private readonly eventOrder = new Map<EventId, number>();
   private graph = new EventGraph();
   private readonly eventItems = new Map<EventId, EventId[]>();
-  private readonly deleteTargets = new Map<EventId, EventId[]>();
   private readonly itemsById = new Map<EventId, AugmentedCRDTItem>();
-  // Reverse index: `target item id` -> set of item ids whose `originLeft`
-  // points at it. Maintained alongside {@link itemsById} so that
-  // {@link splitRecordAt} can cheaply rewrite the `originLeft` references
-  // when it carves a placeholder in two. Without this rewrite the YATA
-  // integration scan would see siblings anchored to the same logical
-  // boundary as if they had different origins, which breaks partial
-  // replay convergence.
-  private readonly originLeftRefs = new Map<EventId, Set<EventId>>();
-  // Reverse index: `target item id` -> set of delete event ids whose
-  // {@link deleteTargets} list contains it. Maintained so that
-  // {@link splitRecordAt} can extend the membership to the new right
-  // half when it carves a previously-deleted record in two: without
-  // this, retreating/advancing the delete only flips the prepare-state
-  // of the left half and the right half stays prepare-visible even
-  // though it is effect-deleted, which shifts later prepare-index
-  // lookups (e.g. local inserts anchored at the document end) into
-  // the middle of the deleted range.
-  private readonly deleteTargetsByItem = new Map<EventId, Set<EventId>>();
+  private readonly originLeftIndex = new OriginLeftIndex();
+  private readonly deleteTargets = new DeleteTargetIndex();
   private readonly sequence = new IndexedSequence<AugmentedCRDTItem>(
     (item) => (item.prepareState === 1 ? item.content.length : 0),
     (item) => (item.everDeleted ? 0 : item.content.length),
   );
+  private readonly recordSplitter = new RecordSplitter({
+    sequence: this.sequence,
+    itemsById: this.itemsById,
+    eventItems: this.eventItems,
+    originLeftIndex: this.originLeftIndex,
+    deleteTargets: this.deleteTargets,
+    nextPlaceholderId: () => this.nextPlaceholderId(),
+  });
+  private readonly pendingInsert = new PendingInsertBuffer();
   private currentVersion = new Set<EventId>();
   private resultingText = "";
-  // Buffered append for the typed-run coalescing path.
-  //
-  // The coalescing branch in {@link applyInsert} fires once per
-  // single-character INSERT that extends an existing typed-run record.
-  // The CRDT side is already O(1) (the record's `content` grows in place
-  // and the ranked B-tree only re-weights one leaf), but the previous
-  // implementation also called {@link spliceText} on {@link resultingText}
-  // for every coalesced keystroke. That allocates the entire document
-  // string on each event, so a 20 000-event single-author linear trace
-  // paid O(n^2) string work even after #691.
-  //
-  // Instead, we hold the appended text in {@link pendingInsertText} and
-  // record where it logically lives in the resulting document as
-  // {@link pendingInsertEffectIndex}. Consecutive coalesced events on the
-  // same record extend `pendingInsertText` by their single code unit, so
-  // a run of N keystrokes costs O(N) in string work (V8 cons-string
-  // append) plus one O(document length) splice at the end of the run.
-  //
-  // Invariant: when `pendingInsertText.length > 0`, the conceptual
-  // resulting text is
-  //
-  //   resultingText.slice(0, pendingInsertEffectIndex)
-  //     + pendingInsertText
-  //     + resultingText.slice(pendingInsertEffectIndex)
-  //
-  // {@link flushPendingInsert} materialises this into `resultingText` and
-  // is called eagerly before any non-coalesced read or write of the
-  // document text (other inserts, deletes, `getText`, and the
-  // `generate` / `applyEvent` return paths).
-  private pendingInsertText = "";
-  private pendingInsertEffectIndex = 0;
   private retreatCount = 0;
   private advanceCount = 0;
   private nonConflictingRunCount = 0;
@@ -283,7 +143,7 @@ export class EgWalkerEngine {
     return this.currentVersion;
   }
 
-  getStats(): EngineStats {
+  getStats() {
     return {
       retreatCount: this.retreatCount,
       advanceCount: this.advanceCount,
@@ -367,14 +227,12 @@ export class EgWalkerEngine {
     this.graph = options.eventGraph ?? new EventGraph();
     this.eventItems.clear();
     this.deleteTargets.clear();
-    this.deleteTargetsByItem.clear();
     this.itemsById.clear();
-    this.originLeftRefs.clear();
+    this.originLeftIndex.clear();
     this.sequence.clear();
     this.currentVersion = new Set(options.initialVersion ?? []);
     this.resultingText = initialText;
-    this.pendingInsertText = "";
-    this.pendingInsertEffectIndex = 0;
+    this.pendingInsert.reset();
     this.retreatCount = 0;
     this.advanceCount = 0;
     this.nonConflictingRunCount = 0;
@@ -455,7 +313,10 @@ export class EgWalkerEngine {
     );
     const firstInsertPosition =
       landing.offsetInRecord > 0
-        ? this.splitRecordAt(landing.position, landing.offsetInRecord)
+        ? this.recordSplitter.splitRecordAt(
+            landing.position,
+            landing.offsetInRecord,
+          )
         : landing.position;
     // YATA-style origins: anchor against the records visible in the
     // event's parent version (prepare-state >= 1), NOT against whichever
@@ -503,7 +364,7 @@ export class EgWalkerEngine {
     // wire encoding; mirroring that grouping in the ranked B-tree
     // collapses a 20k-character linear single-author trace to ~1 record
     // (down from one per code unit) while leaving multi-author / multi-event
-    // ordering unchanged \u2014 split-on-demand carves the run when a
+    // ordering unchanged — split-on-demand carves the run when a
     // concurrent insert or delete anchors inside it.
     const parsed = parseEventId(event.id);
     if (
@@ -523,22 +384,26 @@ export class EgWalkerEngine {
         leftRecord.prepareState === 1 &&
         !leftRecord.everDeleted &&
         // Don't extend a run that already has items anchored to its right
-        // boundary \u2014 those items chose this id as their `originLeft` at a
+        // boundary — those items chose this id as their `originLeft` at a
         // moment when the record ended one code unit earlier, and stretching
         // the content would shift the boundary they were anchored to.
-        !this.hasOriginLeftRefs(leftRecord.id)
+        !this.originLeftIndex.has(leftRecord.id)
       ) {
         const effectIndex =
           this.itemToEffectIndex(leftRecord) + leftRecord.content.length;
         leftRecord.content += operation.text;
         this.sequence.updateItem(leftRecord);
         this.eventItems.set(event.id, [leftRecord.id]);
-        // Defer the {@link spliceText} on {@link resultingText} into
-        // {@link pendingInsertText} so a long single-author typed run
-        // doesn't pay an O(document length) string realloc per
-        // keystroke. {@link flushPendingInsert} materialises the buffer
-        // before any non-coalesced read or write of the document text.
-        this.appendPendingInsert(effectIndex, operation.text);
+        // Defer the {@link spliceText} on {@link resultingText} into the
+        // pending-insert buffer so a long single-author typed run doesn't
+        // pay an O(document length) string realloc per keystroke.
+        // {@link flushPendingInsert} materialises the buffer before any
+        // non-coalesced read or write of the document text.
+        this.resultingText = this.pendingInsert.append(
+          this.resultingText,
+          effectIndex,
+          operation.text,
+        );
 
         return [
           {
@@ -579,11 +444,15 @@ export class EgWalkerEngine {
       actualFirstPosition = firstInsertPosition;
       this.sequence.insert(actualFirstPosition, firstItem);
     } else {
-      actualFirstPosition = this.findIntegrationPosition(firstItem);
+      actualFirstPosition = findIntegrationPosition(
+        firstItem,
+        this.sequence,
+        this.itemsById,
+      );
       this.sequence.insert(actualFirstPosition, firstItem);
     }
     this.itemsById.set(firstItem.id, firstItem);
-    this.trackOriginLeft(firstItem.id, firstItem.originLeft);
+    this.originLeftIndex.track(firstItem.id, firstItem.originLeft);
     insertedIds.push(firstItem.id);
     left = firstItem.id;
 
@@ -610,7 +479,7 @@ export class EgWalkerEngine {
       };
       this.sequence.insert(actualFirstPosition + offset, item);
       this.itemsById.set(item.id, item);
-      this.trackOriginLeft(item.id, item.originLeft);
+      this.originLeftIndex.track(item.id, item.originLeft);
       insertedIds.push(item.id);
       left = item.id;
     }
@@ -625,7 +494,7 @@ export class EgWalkerEngine {
     // open typed-run buffer before splicing. Hoist the empty-buffer check
     // inline because this is the per-event hot path for non-coalescing
     // inserts and the buffer is empty on every full-replay event.
-    if (this.pendingInsertText.length > 0) {
+    if (!this.pendingInsert.isEmpty()) {
       this.flushPendingInsert();
     }
     this.resultingText = spliceText(
@@ -651,14 +520,14 @@ export class EgWalkerEngine {
     >,
   ): ExternalOperation[] {
     // Any concurrent insert or delete breaks the typed-run we may have
-    // been coalescing into {@link pendingInsertText}. Flush before we
+    // been coalescing into the pending-insert buffer. Flush before we
     // start carving records and slicing the document text so the per-slot
     // {@link effectIndex} arithmetic below operates on the materialised
     // document. Hoist the empty-buffer check inline because `applyDelete`
     // is on the per-event hot path and the buffer is empty on every
     // non-coalescing trace, so the inline check saves a function call on
     // the common case.
-    if (this.pendingInsertText.length > 0) {
+    if (!this.pendingInsert.isEmpty()) {
       this.flushPendingInsert();
     }
     const deletedItemIds: EventId[] = [];
@@ -698,13 +567,14 @@ export class EgWalkerEngine {
       // record. Single-character records and per-code-unit paste fragments
       // skip the split entirely and are marked in place.
       const isMultiCharRecord =
-        (isPlaceholder(candidate) || candidate.run !== null) &&
+        (candidate.eventId === PLACEHOLDER_EVENT_ID ||
+          candidate.run !== null) &&
         candidate.content.length > 1;
       if (isMultiCharRecord) {
         const availableInRecord =
           candidate.content.length - landing.offsetInRecord;
         const toDelete = Math.min(remaining, availableInRecord);
-        const middle = this.splitRecordForDelete(
+        const middle = this.recordSplitter.splitRecordForDelete(
           landing.position,
           landing.offsetInRecord,
           toDelete,
@@ -747,310 +617,9 @@ export class EgWalkerEngine {
       remaining -= 1;
     }
 
-    this.recordDeleteTargets(event.id, deletedItemIds);
+    this.deleteTargets.record(event.id, deletedItemIds);
 
     return coalesceDeleteRuns(outputDeleteIndexes);
-  }
-
-  /**
-   * Split a multi-character record so that `offsetInRecord` code units
-   * remain in place and the rest become a new record at `position + 1`.
-   * Returns the position of the new right-hand record — i.e. where neighbours
-   * sandwiched between the two halves should be inserted. Single-character
-   * records and offset-0 calls are no-ops.
-   *
-   * Two record shapes carry multi-character content and can be split:
-   *
-   * - **Placeholder:** right gets a fresh placeholder id; both halves stay
-   *   anonymous, owned by the engine-internal `PLACEHOLDER_EVENT_ID`.
-   * - **Typed-run record:** right inherits the run's replicaId with
-   *   `startSequence` advanced by `offsetInRecord`, and the `eventItems`
-   *   entry for every event whose sequence moved to the right half is
-   *   repointed from `left.id` to `right.id` so retreat / advance still
-   *   land on the right slice.
-   */
-  private splitRecordAt(position: number, offsetInRecord: number): number {
-    const left = this.sequence.at(position);
-    if (!left || offsetInRecord <= 0 || offsetInRecord >= left.content.length) {
-      return position + (offsetInRecord > 0 ? 1 : 0);
-    }
-
-    const leftOriginalLength = left.content.length;
-    const rightContent = left.content.slice(offsetInRecord);
-    left.content = left.content.slice(0, offsetInRecord);
-    this.sequence.updateItem(left);
-
-    const right = this.buildSplitRightHalf(left, offsetInRecord, rightContent);
-    this.sequence.insert(position + 1, right);
-    this.itemsById.set(right.id, right);
-
-    // Existing items with `originLeft = left.id` were anchored to the
-    // right boundary of the pre-split record; that boundary now lives
-    // at the end of {@link right}, so transfer their `originLeft`
-    // references over. `originRight = left.id` references still point
-    // at the left edge of the original record, which is unchanged.
-    this.rewriteOriginLeftReferences(left.id, right.id);
-    // Extend any prior delete-target memberships to cover {@link right}
-    // as well. The pre-split record was already part of `deleteTargets`
-    // for every event in this set; both halves now share the same
-    // `everDeleted` and `prepareState` and must move together under
-    // future retreat / advance calls for those events.
-    this.extendDeleteTargetMembership(left.id, right.id);
-    this.rewriteEventItemsForRunSplit(
-      left,
-      right,
-      offsetInRecord,
-      leftOriginalLength,
-    );
-    return position + 1;
-  }
-
-  private buildSplitRightHalf(
-    left: AugmentedCRDTItem,
-    offsetInRecord: number,
-    rightContent: string,
-  ): AugmentedCRDTItem {
-    if (left.run !== null) {
-      const startSequence = left.run.startSequence + offsetInRecord;
-      return {
-        id: `${left.run.replicaId}:${startSequence}:0`,
-        eventId: `${left.run.replicaId}:${startSequence}`,
-        content: rightContent,
-        originLeft: null,
-        originRight: null,
-        everDeleted: left.everDeleted,
-        prepareState: left.prepareState,
-        run: {
-          replicaId: left.run.replicaId,
-          startSequence,
-        },
-      };
-    }
-    return {
-      id: this.nextPlaceholderId(),
-      eventId: PLACEHOLDER_EVENT_ID,
-      content: rightContent,
-      originLeft: null,
-      originRight: null,
-      everDeleted: left.everDeleted,
-      prepareState: left.prepareState,
-      run: null,
-    };
-  }
-
-  private rewriteEventItemsForRunSplit(
-    left: AugmentedCRDTItem,
-    right: AugmentedCRDTItem,
-    offsetInRecord: number,
-    leftOriginalLength: number,
-  ): void {
-    if (left.run === null) {
-      return;
-    }
-    // Each sequence in `[startSequence + offsetInRecord, startSequence + N)`
-    // is a single-character INSERT whose `eventItems` entry currently lists
-    // `left.id`. Repoint those entries to `right.id` so retreat / advance
-    // visit the half that actually holds the slice.
-    const runStart = left.run.startSequence + offsetInRecord;
-    const runEnd = left.run.startSequence + leftOriginalLength;
-    for (let sequence = runStart; sequence < runEnd; sequence++) {
-      const eventId: EventId = `${left.run.replicaId}:${sequence}`;
-      const items = this.eventItems.get(eventId);
-      if (!items) {
-        continue;
-      }
-      let mutated = false;
-      const next = items.map((id) => {
-        if (id === left.id) {
-          mutated = true;
-          return right.id;
-        }
-        return id;
-      });
-      if (mutated) {
-        this.eventItems.set(eventId, next);
-      }
-    }
-  }
-
-  private recordDeleteTargets(
-    deleteEventId: EventId,
-    itemIds: ReadonlyArray<EventId>,
-  ): void {
-    this.deleteTargets.set(deleteEventId, [...itemIds]);
-    for (const itemId of itemIds) {
-      let owners = this.deleteTargetsByItem.get(itemId);
-      if (!owners) {
-        owners = new Set<EventId>();
-        this.deleteTargetsByItem.set(itemId, owners);
-      }
-      owners.add(deleteEventId);
-    }
-  }
-
-  private extendDeleteTargetMembership(
-    fromItemId: EventId,
-    toItemId: EventId,
-  ): void {
-    const owners = this.deleteTargetsByItem.get(fromItemId);
-    if (!owners || owners.size === 0) {
-      return;
-    }
-    let mirrored = this.deleteTargetsByItem.get(toItemId);
-    for (const deleteEventId of owners) {
-      // Invariant: `toItemId` is a freshly minted `nextPlaceholderId()`,
-      // so it cannot already appear in this delete event's target list.
-      // Guard defensively so a future call site that breaks the freshness
-      // assumption doesn't silently produce duplicate entries (which would
-      // double-toggle prepare-state on retreat/advance).
-      if (mirrored?.has(deleteEventId)) {
-        continue;
-      }
-      const targets = this.deleteTargets.get(deleteEventId);
-      if (!targets) {
-        continue;
-      }
-      targets.push(toItemId);
-      if (!mirrored) {
-        mirrored = new Set<EventId>();
-        this.deleteTargetsByItem.set(toItemId, mirrored);
-      }
-      mirrored.add(deleteEventId);
-    }
-  }
-
-  private trackOriginLeft(itemId: EventId, originLeft: EventId | null): void {
-    if (originLeft === null) {
-      return;
-    }
-    const set = this.originLeftRefs.get(originLeft) ?? new Set<EventId>();
-    set.add(itemId);
-    this.originLeftRefs.set(originLeft, set);
-  }
-
-  private hasOriginLeftRefs(itemId: EventId): boolean {
-    const refs = this.originLeftRefs.get(itemId);
-    return refs !== undefined && refs.size > 0;
-  }
-
-  private rewriteOriginLeftReferences(
-    oldOriginLeft: EventId,
-    newOriginLeft: EventId,
-  ): void {
-    const refs = this.originLeftRefs.get(oldOriginLeft);
-    if (!refs || refs.size === 0) {
-      return;
-    }
-    this.originLeftRefs.delete(oldOriginLeft);
-    const merged = this.originLeftRefs.get(newOriginLeft) ?? new Set<EventId>();
-    for (const itemId of refs) {
-      const item = this.itemsById.get(itemId);
-      if (!item || item.originLeft !== oldOriginLeft) {
-        continue;
-      }
-      item.originLeft = newOriginLeft;
-      merged.add(itemId);
-    }
-    if (merged.size > 0) {
-      this.originLeftRefs.set(newOriginLeft, merged);
-    }
-  }
-
-  /**
-   * Split a multi-character record so that the `length` code units starting
-   * at `offsetInRecord` become an isolated record that the caller can mark
-   * as deleted. Returns that middle record. Surrounding prefix/suffix halves
-   * remain undeleted so future events can still reference the original
-   * region. Used for placeholder, typed-run, and multi-character paste
-   * records alike — the {@link splitRecordAt} dispatch picks the right
-   * shape for each side.
-   */
-  private splitRecordForDelete(
-    position: number,
-    offsetInRecord: number,
-    length: number,
-  ): AugmentedCRDTItem {
-    if (offsetInRecord > 0) {
-      const afterPrefix = this.splitRecordAt(position, offsetInRecord);
-      position = afterPrefix;
-    }
-    const middle = this.sequence.at(position);
-    if (!middle) {
-      throw new Error(`Record split missing record at position ${position}`);
-    }
-    if (length < middle.content.length) {
-      this.splitRecordAt(position, length);
-    }
-    return middle;
-  }
-
-  /**
-   * Ensure the slice owned by `eventId` is a single record before
-   * retreat / advance toggle its `prepareState`. A typed-run leaf that
-   * still holds more than this one event's code unit is carved into prefix /
-   * slice / suffix records via {@link splitRecordAt}, which also remaps the
-   * other events' `eventItems` entries to point at the new neighbours.
-   * After the call, `eventItems.get(eventId)` references exactly the slice
-   * to toggle.
-   */
-  private isolateRunSliceForEvent(eventId: EventId): void {
-    const items = this.eventItems.get(eventId);
-    if (!items || items.length === 0) {
-      // Event hasn't been integrated yet (e.g. a delete-only or pre-effect
-      // retreat). Nothing to toggle.
-      return;
-    }
-    if (items.length > 1) {
-      // Multi-character INSERT events stay one record per code unit, each with
-      // its own id and `run === null`. The retreat / advance loop already
-      // toggles every slice in order; no isolation is needed.
-      return;
-    }
-    const itemId = items[0];
-    if (itemId === undefined) {
-      return;
-    }
-    const record = this.itemsById.get(itemId);
-    if (!record) {
-      throw new Error(
-        `eventItems pointed at unknown item ${itemId} for event ${eventId}`,
-      );
-    }
-    if (record.run === null) {
-      // Placeholder or per-code-unit paste record — nothing to coalesce, so
-      // the slice is already this event's whole contribution.
-      return;
-    }
-    const parsed = parseEventId(eventId);
-    if (parsed === null || parsed.replicaId !== record.run.replicaId) {
-      // A non-canonical event id ended up pointing at a typed-run record.
-      // The run-extension guard in `applyInsert` only seeds runs from
-      // canonical `replicaId:sequence` ids, so this should be unreachable;
-      // bail out conservatively rather than splitting at a wrong offset.
-      return;
-    }
-    const offsetInRecord = parsed.sequence - record.run.startSequence;
-    if (offsetInRecord < 0 || offsetInRecord >= record.content.length) {
-      // Same defensive bail-out: the eventItems entry should never point at
-      // a record whose run no longer covers this event's sequence.
-      return;
-    }
-    if (offsetInRecord === 0 && record.content.length === 1) {
-      // Slice is already its own record.
-      return;
-    }
-
-    let position = this.sequence.positionOf(record);
-    if (position === -1) {
-      throw new Error(`Record ${record.id} missing from sequence index`);
-    }
-    if (offsetInRecord > 0) {
-      position = this.splitRecordAt(position, offsetInRecord);
-    }
-    const middle = this.sequence.at(position);
-    if (middle && middle.content.length > 1) {
-      this.splitRecordAt(position, 1);
-    }
   }
 
   private retreat(eventId: EventId): void {
@@ -1060,14 +629,14 @@ export class EgWalkerEngine {
     }
 
     if (event.operation.type === OPERATION_TYPE.INSERT) {
-      this.isolateRunSliceForEvent(eventId);
+      this.recordSplitter.isolateRunSliceForEvent(eventId);
       for (const itemId of this.eventItems.get(eventId) ?? []) {
         const item = this.requireItem(itemId);
         item.prepareState -= 1;
         this.sequence.updateItem(item);
       }
     } else {
-      for (const itemId of this.deleteTargets.get(eventId) ?? []) {
+      for (const itemId of this.deleteTargets.targetsOf(eventId) ?? []) {
         const item = this.requireItem(itemId);
         item.prepareState -= 1;
         this.sequence.updateItem(item);
@@ -1084,14 +653,14 @@ export class EgWalkerEngine {
     }
 
     if (event.operation.type === OPERATION_TYPE.INSERT) {
-      this.isolateRunSliceForEvent(eventId);
+      this.recordSplitter.isolateRunSliceForEvent(eventId);
       for (const itemId of this.eventItems.get(eventId) ?? []) {
         const item = this.requireItem(itemId);
         item.prepareState += 1;
         this.sequence.updateItem(item);
       }
     } else {
-      for (const itemId of this.deleteTargets.get(eventId) ?? []) {
+      for (const itemId of this.deleteTargets.targetsOf(eventId) ?? []) {
         const item = this.requireItem(itemId);
         item.prepareState += 1;
         this.sequence.updateItem(item);
@@ -1099,88 +668,6 @@ export class EgWalkerEngine {
     }
 
     this.advanceCount++;
-  }
-
-  private integrate(item: AugmentedCRDTItem): void {
-    if (this.itemsById.has(item.id)) {
-      return;
-    }
-
-    const position = this.findIntegrationPosition(item);
-    this.sequence.insert(position, item);
-  }
-
-  /**
-   * YATA-style integration scan (Nicolaescu et al., 2016; Yjs `Item.integrate`).
-   *
-   * The destination range is the slice of the sequence strictly between
-   * `originLeft` and `originRight`. Walk it left-to-right and decide,
-   * for each concurrent neighbour, whether the new item belongs before
-   * or after it. The decision depends only on the two items' origins and
-   * event IDs, never on the order in which concurrent siblings were
-   * integrated, so the engine converges to the same sequence regardless
-   * of which valid topological order the caller hands it.
-   *
-   * Two concurrent items with identical origins are ordered by
-   * {@link compareEventIds}: the smaller event ID wins and is placed
-   * first, matching Yjs's `id.client` tie-break.
-   */
-  private findIntegrationPosition(item: AugmentedCRDTItem): number {
-    const leftItem = item.originLeft
-      ? this.itemsById.get(item.originLeft)
-      : null;
-    const rightItem = item.originRight
-      ? this.itemsById.get(item.originRight)
-      : null;
-    const leftPos = leftItem ? this.sequence.positionOf(leftItem) : -1;
-    const rightPos = rightItem
-      ? this.sequence.positionOf(rightItem)
-      : this.sequence.length;
-
-    let insertPos = leftPos + 1;
-    let scanPos = leftPos + 1;
-    const scanned = new Set<EventId>();
-    let conflicting = new Set<EventId>();
-
-    while (scanPos < rightPos) {
-      const other = this.sequence.at(scanPos);
-      if (!other) {
-        break;
-      }
-      scanned.add(other.id);
-      conflicting.add(other.id);
-
-      if (other.originLeft === item.originLeft) {
-        // Same left anchor: tie-break by event ID (smaller wins, goes
-        // first). If `other` has a larger event ID and shares our right
-        // anchor, the new item is placed immediately before it. If the
-        // right anchors differ, fall through and continue scanning.
-        if (compareEventIds(other.eventId, item.eventId) < 0) {
-          insertPos = scanPos + 1;
-          conflicting = new Set();
-        } else if (other.originRight === item.originRight) {
-          break;
-        }
-      } else if (
-        other.originLeft !== null &&
-        scanned.has(other.originLeft) &&
-        !conflicting.has(other.originLeft)
-      ) {
-        // `other`'s left anchor is a record we have already accepted as
-        // belonging to the left of the new item, so the new item must
-        // continue past `other` too.
-        insertPos = scanPos + 1;
-        conflicting = new Set();
-      } else if (other.originLeft === null || !scanned.has(other.originLeft)) {
-        // `other`'s left anchor sits outside the conflict region (either
-        // null or a record we have not passed yet), so `other` dominates
-        // the remaining slice and the new item stays before it.
-        break;
-      }
-      scanPos++;
-    }
-
-    return insertPos;
   }
 
   private itemToEffectIndex(target: AugmentedCRDTItem): number {
@@ -1191,71 +678,8 @@ export class EgWalkerEngine {
     return this.sequence.effectIndexBeforePosition(position);
   }
 
-  /**
-   * Record a coalesced single-character insert in the typed-run buffer.
-   *
-   * Consecutive calls whose {@link effectIndex} sits immediately after
-   * the buffer's current span (i.e. the next code unit of the same
-   * extending typed-run record) just extend
-   * {@link pendingInsertText}. Anything that lands elsewhere flushes the
-   * buffer first and starts a fresh span at the new index. The buffer
-   * is later drained by {@link flushPendingInsert} before any
-   * non-coalesced read or write of the document text.
-   *
-   * The flush-and-restart branch below is defensive given the current
-   * engine invariants: any event that would land at a non-contiguous
-   * effect index goes through the non-coalescing path in
-   * {@link applyInsert} (different replica, split origin, or non-empty
-   * conflict region), which flushes the buffer before this method is
-   * called again. We still handle it explicitly so a future change that
-   * widens the coalescing branch (e.g. extending across a split-on-demand
-   * boundary) can't silently corrupt the document by stranding bytes at
-   * the previous offset.
-   */
-  private appendPendingInsert(effectIndex: number, text: string): void {
-    const buffered = this.pendingInsertText;
-    if (
-      buffered.length > 0 &&
-      effectIndex === this.pendingInsertEffectIndex + buffered.length
-    ) {
-      this.pendingInsertText = buffered + text;
-      return;
-    }
-    if (buffered.length > 0) {
-      this.flushPendingInsert();
-    }
-    this.pendingInsertText = text;
-    this.pendingInsertEffectIndex = effectIndex;
-  }
-
-  /**
-   * Drain any buffered typed-run append into {@link resultingText}.
-   *
-   * Safe to call unconditionally: the empty-buffer early-out makes the
-   * call cheap when there is nothing pending, so cold call sites
-   * (`generate` return, `applyEvent` return, `getText`, `reset`) don't
-   * need to repeat the check inline. Hot per-event call sites
-   * (`applyInsert` non-coalesced, top of `applyDelete`) do hoist the
-   * check to skip even the function call when the buffer is empty.
-   *
-   * After this call the stored {@link resultingText} matches the
-   * logical document the rest of the engine reasons about (the
-   * concatenation of every effect-visible CRDT record's `content` in
-   * sequence order), so concurrent inserts, deletes, and external
-   * readers can splice / slice it without correcting for the deferred
-   * span.
-   */
   private flushPendingInsert(): void {
-    if (this.pendingInsertText.length === 0) {
-      return;
-    }
-    this.resultingText = spliceText(
-      this.resultingText,
-      this.pendingInsertEffectIndex,
-      this.pendingInsertText,
-    );
-    this.pendingInsertText = "";
-    this.pendingInsertEffectIndex = 0;
+    this.resultingText = this.pendingInsert.flushInto(this.resultingText);
   }
 
   private diffVersions(
@@ -1294,48 +718,3 @@ export class EgWalkerEngine {
     return item;
   }
 }
-
-/**
- * Coalesce a sequence of in-order effect-index deletes into the smallest list
- * of {index, length} operations that, applied in order, produces the same
- * deletes. Two consecutive deletes are contiguous when the second targets the
- * same effect index as the first (the next character shifted into the slot).
- */
-const coalesceDeleteRuns = (
-  effectIndexes: ReadonlyArray<number>,
-): ExternalOperation[] => {
-  const runs: ExternalOperation[] = [];
-  let runStart = -1;
-  let runLength = 0;
-
-  for (const index of effectIndexes) {
-    if (runLength === 0) {
-      runStart = index;
-      runLength = 1;
-      continue;
-    }
-
-    if (index === runStart) {
-      runLength += 1;
-      continue;
-    }
-
-    runs.push({
-      type: OPERATION_TYPE.DELETE,
-      index: runStart,
-      length: runLength,
-    });
-    runStart = index;
-    runLength = 1;
-  }
-
-  if (runLength > 0) {
-    runs.push({
-      type: OPERATION_TYPE.DELETE,
-      index: runStart,
-      length: runLength,
-    });
-  }
-
-  return runs;
-};

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -8,6 +8,7 @@ import {
   PLACEHOLDER_EVENT_ID,
   PLACEHOLDER_ID_PREFIX,
   type AugmentedCRDTItem,
+  type EngineStats,
   type GeneratedDocument,
   type GenerateOptions,
   type IncrementalApplyResult,
@@ -25,6 +26,7 @@ import {
 import { findIntegrationPosition } from "./internals/yata-integration";
 
 export type {
+  EngineStats,
   GeneratedDocument,
   GenerateOptions,
   IncrementalApplyResult,
@@ -143,7 +145,7 @@ export class EgWalkerEngine {
     return this.currentVersion;
   }
 
-  getStats() {
+  getStats(): EngineStats {
     return {
       retreatCount: this.retreatCount,
       advanceCount: this.advanceCount,
@@ -394,15 +396,15 @@ export class EgWalkerEngine {
         leftRecord.content += operation.text;
         this.sequence.updateItem(leftRecord);
         this.eventItems.set(event.id, [leftRecord.id]);
-        // Defer the {@link spliceText} on {@link resultingText} into the
+        // Defer the splice on {@link resultingText} into the
         // pending-insert buffer so a long single-author typed run doesn't
         // pay an O(document length) string realloc per keystroke.
         // {@link flushPendingInsert} materialises the buffer before any
         // non-coalesced read or write of the document text.
-        this.resultingText = this.pendingInsert.append(
-          this.resultingText,
+        this.pendingInsert.append(
           effectIndex,
           operation.text,
+          this.applyPendingSplice,
         );
 
         return [
@@ -678,8 +680,25 @@ export class EgWalkerEngine {
     return this.sequence.effectIndexBeforePosition(position);
   }
 
+  /**
+   * Splice the deferred typed-run span into {@link resultingText}.
+   *
+   * Arrow-field instead of a method so the buffer can store the
+   * reference once and call back into the engine without `this`
+   * rebinding. The buffer is the only caller — never invoke this
+   * directly; go through {@link flushPendingInsert} (or pass it to
+   * {@link PendingInsertBuffer.append}) so the buffer first clears its
+   * own state and we don't double-apply on a reentrant flush.
+   */
+  private readonly applyPendingSplice = (
+    effectIndex: number,
+    text: string,
+  ): void => {
+    this.resultingText = spliceText(this.resultingText, effectIndex, text);
+  };
+
   private flushPendingInsert(): void {
-    this.resultingText = this.pendingInsert.flushInto(this.resultingText);
+    this.pendingInsert.flush(this.applyPendingSplice);
   }
 
   private diffVersions(

--- a/packages/eg-walker/src/engine/internals/delete-target-index.ts
+++ b/packages/eg-walker/src/engine/internals/delete-target-index.ts
@@ -1,0 +1,69 @@
+import type { EventId } from "../../types";
+
+/**
+ * Bidirectional index of delete events and the CRDT records they targeted.
+ *
+ * `targets` maps a delete event id to its list of targeted item ids;
+ * retreat / advance walks this list to toggle each item's
+ * `prepareState`. `byItem` is the reverse view, maintained so that
+ * `RecordSplitter.splitRecordAt` can extend the membership to the new
+ * right half when it carves a previously-deleted record in two:
+ * without this, retreating / advancing the delete only flips the
+ * prepare-state of the left half and the right half stays
+ * prepare-visible even though it is effect-deleted, which shifts
+ * later prepare-index lookups (e.g. local inserts anchored at the
+ * document end) into the middle of the deleted range.
+ */
+export class DeleteTargetIndex {
+  private readonly targets = new Map<EventId, EventId[]>();
+  private readonly byItem = new Map<EventId, Set<EventId>>();
+
+  clear(): void {
+    this.targets.clear();
+    this.byItem.clear();
+  }
+
+  targetsOf(deleteEventId: EventId): ReadonlyArray<EventId> | undefined {
+    return this.targets.get(deleteEventId);
+  }
+
+  record(deleteEventId: EventId, itemIds: ReadonlyArray<EventId>): void {
+    this.targets.set(deleteEventId, [...itemIds]);
+    for (const itemId of itemIds) {
+      let owners = this.byItem.get(itemId);
+      if (!owners) {
+        owners = new Set<EventId>();
+        this.byItem.set(itemId, owners);
+      }
+      owners.add(deleteEventId);
+    }
+  }
+
+  extendMembership(fromItemId: EventId, toItemId: EventId): void {
+    const owners = this.byItem.get(fromItemId);
+    if (!owners || owners.size === 0) {
+      return;
+    }
+    let mirrored = this.byItem.get(toItemId);
+    for (const deleteEventId of owners) {
+      // Invariant: `toItemId` is a freshly minted `nextPlaceholderId()`,
+      // so it cannot already appear in this delete event's target list.
+      // Guard defensively so a future call site that breaks the freshness
+      // assumption doesn't silently produce duplicate entries (which would
+      // double-toggle prepare-state on retreat/advance).
+      if (mirrored?.has(deleteEventId)) {
+        continue;
+      }
+      const targets = this.targets.get(deleteEventId);
+      if (!targets) {
+        continue;
+      }
+      targets.push(toItemId);
+      if (!mirrored) {
+        mirrored = new Set<EventId>();
+        this.byItem.set(toItemId, mirrored);
+      }
+      mirrored.add(deleteEventId);
+    }
+  }
+}

--- a/packages/eg-walker/src/engine/internals/engine-types.ts
+++ b/packages/eg-walker/src/engine/internals/engine-types.ts
@@ -53,9 +53,6 @@ export interface AugmentedCRDTItem {
   run: TypedRun | null;
 }
 
-export const isPlaceholder = (item: AugmentedCRDTItem): boolean =>
-  item.eventId === PLACEHOLDER_EVENT_ID;
-
 export interface EngineStats {
   readonly retreatCount: number;
   readonly advanceCount: number;

--- a/packages/eg-walker/src/engine/internals/engine-types.ts
+++ b/packages/eg-walker/src/engine/internals/engine-types.ts
@@ -1,0 +1,107 @@
+import type { EventGraph } from "../../graph/event-graph";
+import type { EventId, ExternalOperation } from "../../types";
+
+export const PLACEHOLDER_EVENT_ID = "__placeholder__";
+export const PLACEHOLDER_ID_PREFIX = "__placeholder__:";
+
+/**
+ * Identity of an {@link AugmentedCRDTItem} that represents a coalesced run
+ * of contiguous single-character INSERT events from one author. The record
+ * spans `content.length` events whose IDs are
+ * `${replicaId}:${startSequence + offsetInRecord}` for
+ * `offsetInRecord ∈ [0, content.length)`.
+ *
+ * Records produced by multi-character paste events and the initial-text
+ * placeholder do **not** carry a {@link TypedRun}; for those, the
+ * `eventId` field alone identifies the owning event.
+ */
+export interface TypedRun {
+  readonly replicaId: string;
+  readonly startSequence: number;
+}
+
+/**
+ * Augmented CRDT item used during replay.
+ *
+ * A record can take two coalesced shapes (or be a single-event item):
+ *
+ * - **Placeholder** (`eventId === PLACEHOLDER_EVENT_ID`, `run === null`):
+ *   contiguous run of pre-checkpoint / initial-text content, split on
+ *   demand by concurrent inserts and deletes. Splits assign fresh
+ *   placeholder IDs to the right half.
+ * - **Typed-run record** (`run !== null`): coalesced run of contiguous
+ *   single-character INSERT events from one author (Section 3.4 "smaller"
+ *   lever). Splits move whole-event slices to new records with IDs
+ *   `${replicaId}:${startSequence + offsetInRecord}:0`.
+ *
+ * Multi-character INSERT events stay one record per code unit (each with
+ * `run === null` and a real `eventId`); we do not coalesce them, since the
+ * per-code-unit IDs already serve as anchors for concurrent siblings.
+ *
+ * `content` is mutable to support in-place run extension and splits
+ * without invalidating the `WeakMap` location index in
+ * `IndexedSequence`.
+ */
+export interface AugmentedCRDTItem {
+  readonly id: EventId;
+  readonly eventId: EventId;
+  content: string;
+  originLeft: EventId | null;
+  readonly originRight: EventId | null;
+  everDeleted: boolean;
+  prepareState: number;
+  run: TypedRun | null;
+}
+
+export const isPlaceholder = (item: AugmentedCRDTItem): boolean =>
+  item.eventId === PLACEHOLDER_EVENT_ID;
+
+export interface EngineStats {
+  readonly retreatCount: number;
+  readonly advanceCount: number;
+  readonly eventsProcessed: number;
+  /**
+   * Section 3.4 internal-document fast path: number of events whose
+   * `parentVersion` already matched the engine's current version, so they
+   * skipped the diff/retreat/advance machinery entirely and applied through
+   * a direct integration position (no YATA scan when the destination range
+   * is empty, no per-character scan for multi-character inserts after the
+   * first).
+   */
+  readonly nonConflictingRunCount: number;
+  /**
+   * Counterpart to {@link nonConflictingRunCount}: events that fell through
+   * to the full prepare/effect replay path because either their parent
+   * version diverged from the current version or the destination range
+   * still contained concurrent siblings.
+   */
+  readonly fullReplayCount: number;
+  /**
+   * Number of CRDT records currently held in the underlying ranked B-tree.
+   *
+   * The paper's "Smaller" lever (Section 3.4) is run-length leaves — a
+   * single record covering many code units instead of one record per code
+   * unit. Initial document text and pre-checkpoint placeholders are stored
+   * as run-length records; concurrent inserts and deletes split records on
+   * demand. Tracking the count lets tests prove the coalescing happened
+   * and lets memory regressions surface as a quantitative jump rather than
+   * a slowdown.
+   */
+  readonly sequenceRecordCount: number;
+}
+
+export interface GenerateOptions {
+  readonly initialVersion?: ReadonlySet<EventId>;
+  readonly eventGraph?: EventGraph;
+}
+
+export interface GeneratedDocument {
+  readonly text: string;
+  readonly transformedOperations: ReadonlyArray<ExternalOperation>;
+  readonly stats: EngineStats;
+}
+
+export interface IncrementalApplyResult {
+  readonly text: string;
+  readonly transformedOperations: ReadonlyArray<ExternalOperation>;
+}

--- a/packages/eg-walker/src/engine/internals/origin-left-index.ts
+++ b/packages/eg-walker/src/engine/internals/origin-left-index.ts
@@ -1,0 +1,63 @@
+import type { EventId } from "../../types";
+import type { AugmentedCRDTItem } from "./engine-types";
+
+/**
+ * Reverse index: `target item id` -> set of item ids whose `originLeft`
+ * points at it. Maintained alongside the engine's `itemsById` map so
+ * that `RecordSplitter.splitRecordAt` can cheaply rewrite the
+ * `originLeft` references when it carves a placeholder in two. Without
+ * this rewrite the YATA integration scan would see siblings anchored
+ * to the same logical boundary as if they had different origins, which
+ * breaks partial replay convergence.
+ *
+ * The index also lets `applyInsert`'s typed-run coalescing branch
+ * cheaply ask "does anyone anchor on this record's right boundary?":
+ * extending such a record would shift the boundary that those
+ * neighbours chose as their `originLeft`, so the coalescing path must
+ * back off and place a fresh item instead.
+ */
+export class OriginLeftIndex {
+  private readonly refs = new Map<EventId, Set<EventId>>();
+
+  clear(): void {
+    this.refs.clear();
+  }
+
+  track(itemId: EventId, originLeft: EventId | null): void {
+    if (originLeft === null) {
+      return;
+    }
+    const set = this.refs.get(originLeft) ?? new Set<EventId>();
+    set.add(itemId);
+    this.refs.set(originLeft, set);
+  }
+
+  has(itemId: EventId): boolean {
+    const refs = this.refs.get(itemId);
+    return refs !== undefined && refs.size > 0;
+  }
+
+  rewriteReferences(
+    oldOriginLeft: EventId,
+    newOriginLeft: EventId,
+    itemsById: ReadonlyMap<EventId, AugmentedCRDTItem>,
+  ): void {
+    const refs = this.refs.get(oldOriginLeft);
+    if (!refs || refs.size === 0) {
+      return;
+    }
+    this.refs.delete(oldOriginLeft);
+    const merged = this.refs.get(newOriginLeft) ?? new Set<EventId>();
+    for (const itemId of refs) {
+      const item = itemsById.get(itemId);
+      if (!item || item.originLeft !== oldOriginLeft) {
+        continue;
+      }
+      item.originLeft = newOriginLeft;
+      merged.add(itemId);
+    }
+    if (merged.size > 0) {
+      this.refs.set(newOriginLeft, merged);
+    }
+  }
+}

--- a/packages/eg-walker/src/engine/internals/pending-insert-buffer.ts
+++ b/packages/eg-walker/src/engine/internals/pending-insert-buffer.ts
@@ -1,0 +1,119 @@
+import { spliceText } from "./text-utils";
+
+/**
+ * Buffered append for the typed-run coalescing path.
+ *
+ * The coalescing branch in `applyInsert` fires once per
+ * single-character INSERT that extends an existing typed-run record.
+ * The CRDT side is already O(1) (the record's `content` grows in place
+ * and the ranked B-tree only re-weights one leaf), but a naive
+ * implementation would also call {@link spliceText} on the resulting
+ * document for every coalesced keystroke. That allocates the entire
+ * document string on each event, so a 20 000-event single-author
+ * linear trace pays O(n^2) string work.
+ *
+ * Instead, we hold the appended text in {@link pendingText} and record
+ * where it logically lives in the resulting document as
+ * {@link pendingEffectIndex}. Consecutive coalesced events on the same
+ * record extend `pendingText` by their single code unit, so a run of N
+ * keystrokes costs O(N) in string work (V8 cons-string append) plus
+ * one O(document length) splice at the end of the run.
+ *
+ * Invariant: when `pendingText.length > 0`, the conceptual resulting
+ * text is
+ *
+ *   resultingText.slice(0, pendingEffectIndex)
+ *     + pendingText
+ *     + resultingText.slice(pendingEffectIndex)
+ *
+ * {@link flushInto} materialises this into the supplied `resultingText`
+ * and must be called eagerly before any non-coalesced read or write of
+ * the document text.
+ */
+export class PendingInsertBuffer {
+  private pendingText = "";
+  private pendingEffectIndex = 0;
+
+  reset(): void {
+    this.pendingText = "";
+    this.pendingEffectIndex = 0;
+  }
+
+  isEmpty(): boolean {
+    return this.pendingText.length === 0;
+  }
+
+  /**
+   * Record a coalesced single-character insert in the typed-run buffer.
+   *
+   * Consecutive calls whose {@link effectIndex} sits immediately after
+   * the buffer's current span (i.e. the next code unit of the same
+   * extending typed-run record) just extend {@link pendingText}.
+   * Anything that lands elsewhere flushes the buffer first and starts a
+   * fresh span at the new index. The buffer is later drained by
+   * {@link flushInto} before any non-coalesced read or write of the
+   * document text.
+   *
+   * The flush-and-restart branch below is defensive given the current
+   * engine invariants: any event that would land at a non-contiguous
+   * effect index goes through the non-coalescing path in `applyInsert`
+   * (different replica, split origin, or non-empty conflict region),
+   * which flushes the buffer before this method is called again. We
+   * still handle it explicitly so a future change that widens the
+   * coalescing branch (e.g. extending across a split-on-demand
+   * boundary) can't silently corrupt the document by stranding bytes at
+   * the previous offset.
+   *
+   * Returns the document text after any defensive flush triggered by a
+   * non-contiguous call; returns `resultingText` unchanged in the
+   * common contiguous-extension case.
+   */
+  append(resultingText: string, effectIndex: number, text: string): string {
+    const buffered = this.pendingText;
+    if (
+      buffered.length > 0 &&
+      effectIndex === this.pendingEffectIndex + buffered.length
+    ) {
+      this.pendingText = buffered + text;
+      return resultingText;
+    }
+    let nextResultingText = resultingText;
+    if (buffered.length > 0) {
+      nextResultingText = this.flushInto(resultingText);
+    }
+    this.pendingText = text;
+    this.pendingEffectIndex = effectIndex;
+    return nextResultingText;
+  }
+
+  /**
+   * Drain any buffered typed-run append into `resultingText`.
+   *
+   * Safe to call unconditionally: the empty-buffer early-out makes the
+   * call cheap when there is nothing pending, so cold call sites
+   * (`generate` return, `applyEvent` return, `getText`, `reset`) don't
+   * need to repeat the check inline. Hot per-event call sites
+   * (`applyInsert` non-coalesced, top of `applyDelete`) can hoist
+   * {@link isEmpty} to skip even the function call when the buffer is
+   * empty.
+   *
+   * After this call the returned text matches the logical document the
+   * rest of the engine reasons about (the concatenation of every
+   * effect-visible CRDT record's `content` in sequence order), so
+   * concurrent inserts, deletes, and external readers can splice /
+   * slice it without correcting for the deferred span.
+   */
+  flushInto(resultingText: string): string {
+    if (this.pendingText.length === 0) {
+      return resultingText;
+    }
+    const next = spliceText(
+      resultingText,
+      this.pendingEffectIndex,
+      this.pendingText,
+    );
+    this.pendingText = "";
+    this.pendingEffectIndex = 0;
+    return next;
+  }
+}

--- a/packages/eg-walker/src/engine/internals/pending-insert-buffer.ts
+++ b/packages/eg-walker/src/engine/internals/pending-insert-buffer.ts
@@ -72,7 +72,7 @@ export class PendingInsertBuffer {
    * boundary) can't silently corrupt the document by stranding bytes at
    * the previous offset.
    */
-  append(effectIndex: number, text: string, flush: FlushFn): void {
+  append(effectIndex: number, text: string, onFlush: FlushFn): void {
     const buffered = this.pendingText;
     if (
       buffered.length > 0 &&
@@ -85,11 +85,11 @@ export class PendingInsertBuffer {
       const flushIndex = this.pendingEffectIndex;
       const flushText = this.pendingText;
       // Clear the buffer *before* invoking the callback so that a
-      // reentrant `isEmpty` / `flush` from inside `flush` itself sees
-      // a clean buffer and short-circuits instead of double-applying.
+      // reentrant `isEmpty` / `flush` from inside the callback sees a
+      // clean buffer and short-circuits instead of double-applying.
       this.pendingText = "";
       this.pendingEffectIndex = 0;
-      flush(flushIndex, flushText);
+      onFlush(flushIndex, flushText);
     }
     this.pendingText = text;
     this.pendingEffectIndex = effectIndex;
@@ -112,7 +112,7 @@ export class PendingInsertBuffer {
    * readers can splice / slice it without correcting for the deferred
    * span.
    */
-  flush(flush: FlushFn): void {
+  flush(onFlush: FlushFn): void {
     if (this.pendingText.length === 0) {
       return;
     }
@@ -120,6 +120,6 @@ export class PendingInsertBuffer {
     const text = this.pendingText;
     this.pendingText = "";
     this.pendingEffectIndex = 0;
-    flush(index, text);
+    onFlush(index, text);
   }
 }

--- a/packages/eg-walker/src/engine/internals/pending-insert-buffer.ts
+++ b/packages/eg-walker/src/engine/internals/pending-insert-buffer.ts
@@ -1,5 +1,3 @@
-import { spliceText } from "./text-utils";
-
 /**
  * Buffered append for the typed-run coalescing path.
  *
@@ -7,10 +5,10 @@ import { spliceText } from "./text-utils";
  * single-character INSERT that extends an existing typed-run record.
  * The CRDT side is already O(1) (the record's `content` grows in place
  * and the ranked B-tree only re-weights one leaf), but a naive
- * implementation would also call {@link spliceText} on the resulting
- * document for every coalesced keystroke. That allocates the entire
- * document string on each event, so a 20 000-event single-author
- * linear trace pays O(n^2) string work.
+ * implementation would also splice the resulting document text for
+ * every coalesced keystroke. That allocates the entire document
+ * string on each event, so a 20 000-event single-author linear trace
+ * pays O(n^2) string work.
  *
  * Instead, we hold the appended text in {@link pendingText} and record
  * where it logically lives in the resulting document as
@@ -26,10 +24,21 @@ import { spliceText } from "./text-utils";
  *     + pendingText
  *     + resultingText.slice(pendingEffectIndex)
  *
- * {@link flushInto} materialises this into the supplied `resultingText`
- * and must be called eagerly before any non-coalesced read or write of
- * the document text.
+ * The owner must call {@link flush} (or accept the implicit flush
+ * inside {@link append}) before any non-coalesced read or write of the
+ * document text. The buffer never owns the document itself — it asks
+ * the caller to materialise the deferred span via the {@link FlushFn}
+ * callback so the engine remains the single writer of
+ * `resultingText`.
  */
+
+/**
+ * Materialise a deferred span into the document. Called at most once
+ * per {@link PendingInsertBuffer.flush} invocation, and at most once
+ * per non-contiguous {@link PendingInsertBuffer.append} call.
+ */
+export type FlushFn = (effectIndex: number, text: string) => void;
+
 export class PendingInsertBuffer {
   private pendingText = "";
   private pendingEffectIndex = 0;
@@ -44,76 +53,73 @@ export class PendingInsertBuffer {
   }
 
   /**
-   * Record a coalesced single-character insert in the typed-run buffer.
+   * Record a coalesced single-character insert.
    *
    * Consecutive calls whose {@link effectIndex} sits immediately after
    * the buffer's current span (i.e. the next code unit of the same
-   * extending typed-run record) just extend {@link pendingText}.
-   * Anything that lands elsewhere flushes the buffer first and starts a
-   * fresh span at the new index. The buffer is later drained by
-   * {@link flushInto} before any non-coalesced read or write of the
-   * document text.
+   * extending typed-run record) just extend {@link pendingText} —
+   * {@link flush} is **not** invoked. Anything that lands elsewhere
+   * invokes {@link flush} with the existing span first and then starts
+   * a fresh span at the new index.
    *
    * The flush-and-restart branch below is defensive given the current
    * engine invariants: any event that would land at a non-contiguous
    * effect index goes through the non-coalescing path in `applyInsert`
    * (different replica, split origin, or non-empty conflict region),
-   * which flushes the buffer before this method is called again. We
-   * still handle it explicitly so a future change that widens the
-   * coalescing branch (e.g. extending across a split-on-demand
+   * which already flushes the buffer before this method is called
+   * again. We still handle it explicitly so a future change that
+   * widens the coalescing branch (e.g. extending across a split-on-demand
    * boundary) can't silently corrupt the document by stranding bytes at
    * the previous offset.
-   *
-   * Returns the document text after any defensive flush triggered by a
-   * non-contiguous call; returns `resultingText` unchanged in the
-   * common contiguous-extension case.
    */
-  append(resultingText: string, effectIndex: number, text: string): string {
+  append(effectIndex: number, text: string, flush: FlushFn): void {
     const buffered = this.pendingText;
     if (
       buffered.length > 0 &&
       effectIndex === this.pendingEffectIndex + buffered.length
     ) {
       this.pendingText = buffered + text;
-      return resultingText;
+      return;
     }
-    let nextResultingText = resultingText;
     if (buffered.length > 0) {
-      nextResultingText = this.flushInto(resultingText);
+      const flushIndex = this.pendingEffectIndex;
+      const flushText = this.pendingText;
+      // Clear the buffer *before* invoking the callback so that a
+      // reentrant `isEmpty` / `flush` from inside `flush` itself sees
+      // a clean buffer and short-circuits instead of double-applying.
+      this.pendingText = "";
+      this.pendingEffectIndex = 0;
+      flush(flushIndex, flushText);
     }
     this.pendingText = text;
     this.pendingEffectIndex = effectIndex;
-    return nextResultingText;
   }
 
   /**
-   * Drain any buffered typed-run append into `resultingText`.
+   * Drain any buffered typed-run append by handing it to {@link flush}.
    *
-   * Safe to call unconditionally: the empty-buffer early-out makes the
-   * call cheap when there is nothing pending, so cold call sites
-   * (`generate` return, `applyEvent` return, `getText`, `reset`) don't
-   * need to repeat the check inline. Hot per-event call sites
+   * No-op when the buffer is empty, so cold call sites (`generate`
+   * return, `applyEvent` return, `getText`, `reset`) don't need to
+   * repeat the {@link isEmpty} check inline. Hot per-event call sites
    * (`applyInsert` non-coalesced, top of `applyDelete`) can hoist
    * {@link isEmpty} to skip even the function call when the buffer is
    * empty.
    *
-   * After this call the returned text matches the logical document the
-   * rest of the engine reasons about (the concatenation of every
-   * effect-visible CRDT record's `content` in sequence order), so
-   * concurrent inserts, deletes, and external readers can splice /
-   * slice it without correcting for the deferred span.
+   * After this call the document the caller maintains matches the
+   * logical document the rest of the engine reasons about (the
+   * concatenation of every effect-visible CRDT record's `content` in
+   * sequence order), so concurrent inserts, deletes, and external
+   * readers can splice / slice it without correcting for the deferred
+   * span.
    */
-  flushInto(resultingText: string): string {
+  flush(flush: FlushFn): void {
     if (this.pendingText.length === 0) {
-      return resultingText;
+      return;
     }
-    const next = spliceText(
-      resultingText,
-      this.pendingEffectIndex,
-      this.pendingText,
-    );
+    const index = this.pendingEffectIndex;
+    const text = this.pendingText;
     this.pendingText = "";
     this.pendingEffectIndex = 0;
-    return next;
+    flush(index, text);
   }
 }

--- a/packages/eg-walker/src/engine/internals/record-splitter.ts
+++ b/packages/eg-walker/src/engine/internals/record-splitter.ts
@@ -1,0 +1,250 @@
+import { parseEventId } from "../../graph/event-id";
+import type { EventId } from "../../types";
+import type { IndexedSequence } from "../indexed-sequence";
+import { DeleteTargetIndex } from "./delete-target-index";
+import { PLACEHOLDER_EVENT_ID, type AugmentedCRDTItem } from "./engine-types";
+import { OriginLeftIndex } from "./origin-left-index";
+
+interface RecordSplitterDeps {
+  readonly sequence: IndexedSequence<AugmentedCRDTItem>;
+  readonly itemsById: Map<EventId, AugmentedCRDTItem>;
+  readonly eventItems: Map<EventId, EventId[]>;
+  readonly originLeftIndex: OriginLeftIndex;
+  readonly deleteTargets: DeleteTargetIndex;
+  readonly nextPlaceholderId: () => EventId;
+}
+
+/**
+ * On-demand split of run-length records (placeholders and typed-run
+ * leaves) when concurrent inserts or deletes anchor inside them.
+ *
+ * The splitter owns no state of its own; it mutates the sequence and
+ * cross-reference indices wired in via {@link RecordSplitterDeps}.
+ * Keeping it as a separate object lets the engine compose the run-length
+ * "smaller" lever (Section 3.4) with the YATA integration scan without
+ * either side having to know about the other's bookkeeping.
+ */
+export class RecordSplitter {
+  constructor(private readonly deps: RecordSplitterDeps) {}
+
+  /**
+   * Split a multi-character record so that `offsetInRecord` code units
+   * remain in place and the rest become a new record at `position + 1`.
+   * Returns the position of the new right-hand record — i.e. where neighbours
+   * sandwiched between the two halves should be inserted. Single-character
+   * records and offset-0 calls are no-ops.
+   *
+   * Two record shapes carry multi-character content and can be split:
+   *
+   * - **Placeholder:** right gets a fresh placeholder id; both halves stay
+   *   anonymous, owned by the engine-internal `PLACEHOLDER_EVENT_ID`.
+   * - **Typed-run record:** right inherits the run's replicaId with
+   *   `startSequence` advanced by `offsetInRecord`, and the `eventItems`
+   *   entry for every event whose sequence moved to the right half is
+   *   repointed from `left.id` to `right.id` so retreat / advance still
+   *   land on the right slice.
+   */
+  splitRecordAt(position: number, offsetInRecord: number): number {
+    const { sequence, itemsById, originLeftIndex, deleteTargets } = this.deps;
+    const left = sequence.at(position);
+    if (!left || offsetInRecord <= 0 || offsetInRecord >= left.content.length) {
+      return position + (offsetInRecord > 0 ? 1 : 0);
+    }
+
+    const leftOriginalLength = left.content.length;
+    const rightContent = left.content.slice(offsetInRecord);
+    left.content = left.content.slice(0, offsetInRecord);
+    sequence.updateItem(left);
+
+    const right = this.buildSplitRightHalf(left, offsetInRecord, rightContent);
+    sequence.insert(position + 1, right);
+    itemsById.set(right.id, right);
+
+    // Existing items with `originLeft = left.id` were anchored to the
+    // right boundary of the pre-split record; that boundary now lives
+    // at the end of {@link right}, so transfer their `originLeft`
+    // references over. `originRight = left.id` references still point
+    // at the left edge of the original record, which is unchanged.
+    originLeftIndex.rewriteReferences(left.id, right.id, itemsById);
+    // Extend any prior delete-target memberships to cover {@link right}
+    // as well. The pre-split record was already part of `deleteTargets`
+    // for every event in this set; both halves now share the same
+    // `everDeleted` and `prepareState` and must move together under
+    // future retreat / advance calls for those events.
+    deleteTargets.extendMembership(left.id, right.id);
+    this.rewriteEventItemsForRunSplit(
+      left,
+      right,
+      offsetInRecord,
+      leftOriginalLength,
+    );
+    return position + 1;
+  }
+
+  /**
+   * Split a multi-character record so that the `length` code units starting
+   * at `offsetInRecord` become an isolated record that the caller can mark
+   * as deleted. Returns that middle record. Surrounding prefix/suffix halves
+   * remain undeleted so future events can still reference the original
+   * region. Used for placeholder, typed-run, and multi-character paste
+   * records alike — the {@link splitRecordAt} dispatch picks the right
+   * shape for each side.
+   */
+  splitRecordForDelete(
+    position: number,
+    offsetInRecord: number,
+    length: number,
+  ): AugmentedCRDTItem {
+    if (offsetInRecord > 0) {
+      const afterPrefix = this.splitRecordAt(position, offsetInRecord);
+      position = afterPrefix;
+    }
+    const middle = this.deps.sequence.at(position);
+    if (!middle) {
+      throw new Error(`Record split missing record at position ${position}`);
+    }
+    if (length < middle.content.length) {
+      this.splitRecordAt(position, length);
+    }
+    return middle;
+  }
+
+  /**
+   * Ensure the slice owned by `eventId` is a single record before
+   * retreat / advance toggle its `prepareState`. A typed-run leaf that
+   * still holds more than this one event's code unit is carved into prefix /
+   * slice / suffix records via {@link splitRecordAt}, which also remaps the
+   * other events' `eventItems` entries to point at the new neighbours.
+   * After the call, `eventItems.get(eventId)` references exactly the slice
+   * to toggle.
+   */
+  isolateRunSliceForEvent(eventId: EventId): void {
+    const { sequence, itemsById, eventItems } = this.deps;
+    const items = eventItems.get(eventId);
+    if (!items || items.length === 0) {
+      // Event hasn't been integrated yet (e.g. a delete-only or pre-effect
+      // retreat). Nothing to toggle.
+      return;
+    }
+    if (items.length > 1) {
+      // Multi-character INSERT events stay one record per code unit, each with
+      // its own id and `run === null`. The retreat / advance loop already
+      // toggles every slice in order; no isolation is needed.
+      return;
+    }
+    const itemId = items[0];
+    if (itemId === undefined) {
+      return;
+    }
+    const record = itemsById.get(itemId);
+    if (!record) {
+      throw new Error(
+        `eventItems pointed at unknown item ${itemId} for event ${eventId}`,
+      );
+    }
+    if (record.run === null) {
+      // Placeholder or per-code-unit paste record — nothing to coalesce, so
+      // the slice is already this event's whole contribution.
+      return;
+    }
+    const parsed = parseEventId(eventId);
+    if (parsed === null || parsed.replicaId !== record.run.replicaId) {
+      // A non-canonical event id ended up pointing at a typed-run record.
+      // The run-extension guard in `applyInsert` only seeds runs from
+      // canonical `replicaId:sequence` ids, so this should be unreachable;
+      // bail out conservatively rather than splitting at a wrong offset.
+      return;
+    }
+    const offsetInRecord = parsed.sequence - record.run.startSequence;
+    if (offsetInRecord < 0 || offsetInRecord >= record.content.length) {
+      // Same defensive bail-out: the eventItems entry should never point at
+      // a record whose run no longer covers this event's sequence.
+      return;
+    }
+    if (offsetInRecord === 0 && record.content.length === 1) {
+      // Slice is already its own record.
+      return;
+    }
+
+    let position = sequence.positionOf(record);
+    if (position === -1) {
+      throw new Error(`Record ${record.id} missing from sequence index`);
+    }
+    if (offsetInRecord > 0) {
+      position = this.splitRecordAt(position, offsetInRecord);
+    }
+    const middle = sequence.at(position);
+    if (middle && middle.content.length > 1) {
+      this.splitRecordAt(position, 1);
+    }
+  }
+
+  private buildSplitRightHalf(
+    left: AugmentedCRDTItem,
+    offsetInRecord: number,
+    rightContent: string,
+  ): AugmentedCRDTItem {
+    if (left.run !== null) {
+      const startSequence = left.run.startSequence + offsetInRecord;
+      return {
+        id: `${left.run.replicaId}:${startSequence}:0`,
+        eventId: `${left.run.replicaId}:${startSequence}`,
+        content: rightContent,
+        originLeft: null,
+        originRight: null,
+        everDeleted: left.everDeleted,
+        prepareState: left.prepareState,
+        run: {
+          replicaId: left.run.replicaId,
+          startSequence,
+        },
+      };
+    }
+    return {
+      id: this.deps.nextPlaceholderId(),
+      eventId: PLACEHOLDER_EVENT_ID,
+      content: rightContent,
+      originLeft: null,
+      originRight: null,
+      everDeleted: left.everDeleted,
+      prepareState: left.prepareState,
+      run: null,
+    };
+  }
+
+  private rewriteEventItemsForRunSplit(
+    left: AugmentedCRDTItem,
+    right: AugmentedCRDTItem,
+    offsetInRecord: number,
+    leftOriginalLength: number,
+  ): void {
+    if (left.run === null) {
+      return;
+    }
+    // Each sequence in `[startSequence + offsetInRecord, startSequence + N)`
+    // is a single-character INSERT whose `eventItems` entry currently lists
+    // `left.id`. Repoint those entries to `right.id` so retreat / advance
+    // visit the half that actually holds the slice.
+    const runStart = left.run.startSequence + offsetInRecord;
+    const runEnd = left.run.startSequence + leftOriginalLength;
+    const { eventItems } = this.deps;
+    for (let sequence = runStart; sequence < runEnd; sequence++) {
+      const eventId: EventId = `${left.run.replicaId}:${sequence}`;
+      const items = eventItems.get(eventId);
+      if (!items) {
+        continue;
+      }
+      let mutated = false;
+      const next = items.map((id) => {
+        if (id === left.id) {
+          mutated = true;
+          return right.id;
+        }
+        return id;
+      });
+      if (mutated) {
+        eventItems.set(eventId, next);
+      }
+    }
+  }
+}

--- a/packages/eg-walker/src/engine/internals/text-utils.ts
+++ b/packages/eg-walker/src/engine/internals/text-utils.ts
@@ -1,0 +1,75 @@
+import { OPERATION_TYPE } from "../../constants/operation-types";
+import type { ExternalOperation } from "../../types";
+
+export const spliceText = (
+  text: string,
+  index: number,
+  insertText: string,
+): string => `${text.slice(0, index)}${insertText}${text.slice(index)}`;
+
+export const deleteText = (
+  text: string,
+  index: number,
+  length: number,
+): string => `${text.slice(0, index)}${text.slice(index + length)}`;
+
+/**
+ * Split a string into JS UTF-16 code units, one per array slot. Unlike
+ * `Array.from(text)` (which iterates code points and would coalesce a
+ * surrogate pair into one entry), this preserves the public-API code-unit
+ * indexing on which the CRDT items are keyed.
+ *
+ * Lone surrogates are intentionally **not** rejected here: by the time a
+ * string reaches this helper it has already been validated at the public
+ * boundary (`EgWalkerReplica.assertWellFormedUtf16` for local inserts and
+ * `assertRemoteEventWellFormed` for remote events). Bypassing the engine
+ * directly with an ill-formed string would still materialise lone
+ * surrogates as standalone CRDT items, but the public API never reaches
+ * this path with such input.
+ */
+export const stringCodeUnits = (text: string): string[] => text.split("");
+
+/**
+ * Coalesce a sequence of in-order effect-index deletes into the smallest list
+ * of {index, length} operations that, applied in order, produces the same
+ * deletes. Two consecutive deletes are contiguous when the second targets the
+ * same effect index as the first (the next character shifted into the slot).
+ */
+export const coalesceDeleteRuns = (
+  effectIndexes: ReadonlyArray<number>,
+): ExternalOperation[] => {
+  const runs: ExternalOperation[] = [];
+  let runStart = -1;
+  let runLength = 0;
+
+  for (const index of effectIndexes) {
+    if (runLength === 0) {
+      runStart = index;
+      runLength = 1;
+      continue;
+    }
+
+    if (index === runStart) {
+      runLength += 1;
+      continue;
+    }
+
+    runs.push({
+      type: OPERATION_TYPE.DELETE,
+      index: runStart,
+      length: runLength,
+    });
+    runStart = index;
+    runLength = 1;
+  }
+
+  if (runLength > 0) {
+    runs.push({
+      type: OPERATION_TYPE.DELETE,
+      index: runStart,
+      length: runLength,
+    });
+  }
+
+  return runs;
+};

--- a/packages/eg-walker/src/engine/internals/yata-integration.ts
+++ b/packages/eg-walker/src/engine/internals/yata-integration.ts
@@ -1,0 +1,75 @@
+import { compareEventIds } from "../../graph/event-id";
+import type { EventId } from "../../types";
+import type { IndexedSequence } from "../indexed-sequence";
+import type { AugmentedCRDTItem } from "./engine-types";
+
+/**
+ * YATA-style integration scan (Nicolaescu et al., 2016; Yjs `Item.integrate`).
+ *
+ * The destination range is the slice of the sequence strictly between
+ * `originLeft` and `originRight`. Walk it left-to-right and decide,
+ * for each concurrent neighbour, whether the new item belongs before
+ * or after it. The decision depends only on the two items' origins and
+ * event IDs, never on the order in which concurrent siblings were
+ * integrated, so the engine converges to the same sequence regardless
+ * of which valid topological order the caller hands it.
+ *
+ * Two concurrent items with identical origins are ordered by
+ * {@link compareEventIds}: the smaller event ID wins and is placed
+ * first, matching Yjs's `id.client` tie-break.
+ */
+export const findIntegrationPosition = (
+  item: AugmentedCRDTItem,
+  sequence: IndexedSequence<AugmentedCRDTItem>,
+  itemsById: ReadonlyMap<EventId, AugmentedCRDTItem>,
+): number => {
+  const leftItem = item.originLeft ? itemsById.get(item.originLeft) : null;
+  const rightItem = item.originRight ? itemsById.get(item.originRight) : null;
+  const leftPos = leftItem ? sequence.positionOf(leftItem) : -1;
+  const rightPos = rightItem ? sequence.positionOf(rightItem) : sequence.length;
+
+  let insertPos = leftPos + 1;
+  let scanPos = leftPos + 1;
+  const scanned = new Set<EventId>();
+  let conflicting = new Set<EventId>();
+
+  while (scanPos < rightPos) {
+    const other = sequence.at(scanPos);
+    if (!other) {
+      break;
+    }
+    scanned.add(other.id);
+    conflicting.add(other.id);
+
+    if (other.originLeft === item.originLeft) {
+      // Same left anchor: tie-break by event ID (smaller wins, goes
+      // first). If `other` has a larger event ID and shares our right
+      // anchor, the new item is placed immediately before it. If the
+      // right anchors differ, fall through and continue scanning.
+      if (compareEventIds(other.eventId, item.eventId) < 0) {
+        insertPos = scanPos + 1;
+        conflicting = new Set();
+      } else if (other.originRight === item.originRight) {
+        break;
+      }
+    } else if (
+      other.originLeft !== null &&
+      scanned.has(other.originLeft) &&
+      !conflicting.has(other.originLeft)
+    ) {
+      // `other`'s left anchor is a record we have already accepted as
+      // belonging to the left of the new item, so the new item must
+      // continue past `other` too.
+      insertPos = scanPos + 1;
+      conflicting = new Set();
+    } else if (other.originLeft === null || !scanned.has(other.originLeft)) {
+      // `other`'s left anchor sits outside the conflict region (either
+      // null or a record we have not passed yet), so `other` dominates
+      // the remaining slice and the new item stays before it.
+      break;
+    }
+    scanPos++;
+  }
+
+  return insertPos;
+};


### PR DESCRIPTION
## Summary

- The 1341-line `engine/eg-walker-engine.ts` was conflating eight cohesive but separable concerns (CRDT item types, string utils, the typed-run pending-insert buffer, two reverse-index structures, the YATA integration scan, and the run-length record splitter) on top of the actual replay orchestration. This split moves each concern into its own `engine/internals/` module so the main file can stay focused on `processEvent` / `apply*` / `retreat` / `advance` / `diffVersions`.
- Pure refactor — every method body moves verbatim, all comments preserved, public exports unchanged (`EgWalkerEngine`, `GeneratedDocument`). Helper classes (`PendingInsertBuffer`, `OriginLeftIndex`, `DeleteTargetIndex`, `RecordSplitter`) own a coherent slice of mutable state; the engine wires them together in its constructor.
- `eg-walker-engine.ts` drops from **1341 → 716 lines**.

### New layout

```
src/engine/
  eg-walker-engine.ts        # orchestrator: public API, processEvent, apply*, retreat/advance, diffVersions (716)
  internals/
    engine-types.ts          # AugmentedCRDTItem, TypedRun, placeholder constants, result types (107)
    text-utils.ts            # spliceText, deleteText, stringCodeUnits, coalesceDeleteRuns (75)
    pending-insert-buffer.ts # PendingInsertBuffer class — typed-run coalescing buffer (119)
    origin-left-index.ts     # OriginLeftIndex reverse-index class (63)
    delete-target-index.ts   # DeleteTargetIndex bidirectional-index class (72)
    yata-integration.ts      # findIntegrationPosition pure function (75)
    record-splitter.ts       # RecordSplitter class — split-on-demand for placeholders/typed-runs (253)
```

## Test plan

- [x] `pnpm --filter @softmaple/eg-walker typecheck`
- [x] `pnpm --filter @softmaple/eg-walker test -- --run` (244/244 pass)
- [x] `pnpm --filter @softmaple/eg-walker lint`
- [x] `pnpm --filter @softmaple/eg-walker build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the replay engine to delegate core mechanics to specialized internal helper classes, improving code organization and maintainability.
  * Updated the `getStats()` method signature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/694)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->