### PR TITLE
docs(packages/eg-walker): sync layout with engine/internals split and rename

### DIFF
--- a/packages/eg-walker/AGENTS.md
+++ b/packages/eg-walker/AGENTS.md
@@ -14,8 +14,8 @@ This package implements the eg-walker CRDT algorithm for text collaboration, foc
 
 ### Code Organization
 
-- **Public API**: `src/core/external-api.ts`
-- **Replay engine**: `src/engine/eg-walker-engine.ts`
+- **Public API**: `src/core/replica.ts`
+- **Replay engine**: `src/engine/eg-walker-engine.ts` (orchestrator) with engine-private helpers under `src/engine/internals/`
 - **Graph and storage**: `src/graph/event-graph.ts`, `src/graph/columnar-codec.ts`
 - **Tests**: `src/test/` with corresponding `.test.ts` files
 

--- a/packages/eg-walker/CLAUDE.md
+++ b/packages/eg-walker/CLAUDE.md
@@ -9,14 +9,22 @@ There is no legacy `crdt/` runtime layer.
 src/
   constants/operation-types.ts
   core/
-    external-api.ts
+    replica.ts
     invariants.ts
-    walker.ts
+    replay-walker.ts
   engine/
     eg-walker-engine.ts
     indexed-sequence.ts
     critical-version.ts
     partial-replay.ts
+    internals/
+      engine-types.ts
+      text-utils.ts
+      pending-insert-buffer.ts
+      origin-left-index.ts
+      delete-target-index.ts
+      yata-integration.ts
+      record-splitter.ts
   graph/
     event-graph.ts
     columnar-codec.ts
@@ -29,6 +37,7 @@ src/
 - Do not persist or export temporary replay metadata.
 - Put causal graph logic in `graph/`.
 - Put prepare/effect replay logic in `engine/`.
+- Put engine-private helpers (no semver) under `engine/internals/`.
 - Keep `core/` thin and user-facing.
 - Avoid adding compatibility modules for removed legacy files.
 

--- a/packages/eg-walker/IMPLEMENTATION_GUIDE.md
+++ b/packages/eg-walker/IMPLEMENTATION_GUIDE.md
@@ -9,32 +9,40 @@ legacy scaffolded `crdt/` implementation has been removed.
 ```text
 src/
   core/
-    external-api.ts   Public index-based API
-    walker.ts         Thin graph replay coordinator
-    invariants.ts     Strong-list helpers used by tests and callers
+    replica.ts            Public index-based API (EgWalkerReplica)
+    replay-walker.ts      Thin graph replay coordinator
+    invariants.ts         Strong-list helpers used by tests and callers
   engine/
-    eg-walker-engine.ts  Prepare/effect replay algorithm
-    indexed-sequence.ts  Ranked B-tree index mapping
-    critical-version.ts  Critical checkpoint detection
-    partial-replay.ts    Replay from checkpoint text/version
+    eg-walker-engine.ts   Prepare/effect replay orchestrator
+    indexed-sequence.ts   Ranked B-tree index mapping
+    critical-version.ts   Critical checkpoint detection
+    partial-replay.ts     Replay from checkpoint text/version
+    internals/            Engine-private helpers (no semver)
+      engine-types.ts        AugmentedCRDTItem, TypedRun, placeholder constants, result types
+      text-utils.ts          spliceText, deleteText, stringCodeUnits, coalesceDeleteRuns
+      pending-insert-buffer.ts  Typed-run coalescing buffer for the Section 3.4 fast path
+      origin-left-index.ts   Reverse index: target id -> items anchored as originLeft
+      delete-target-index.ts Bidirectional index of delete events and the items they targeted
+      yata-integration.ts    findIntegrationPosition (YATA scan)
+      record-splitter.ts     Split-on-demand for placeholder and typed-run records
   graph/
-    event-graph.ts       Persistent DAG, frontiers, causal diff
-    columnar-codec.ts    Columnar event graph encode/decode
+    event-graph.ts        Persistent DAG, frontiers, causal diff
+    columnar-codec.ts     Columnar event graph encode/decode
   types/
-    index.ts          Public package types
+    index.ts              Public package types
 ```
 
 ## Paper Mapping
 
-| Paper section               | Implementation                                                             |
-| --------------------------- | -------------------------------------------------------------------------- |
-| 3.1 Characteristics         | `core/external-api.ts`, `core/invariants.ts`, `engine/eg-walker-engine.ts` |
-| 3.2 Walking the event graph | `core/walker.ts`, `graph/event-graph.ts`, `engine/eg-walker-engine.ts`     |
-| 3.3 Prepare/effect versions | `engine/eg-walker-engine.ts`                                               |
-| 3.4 Index mapping           | `engine/indexed-sequence.ts`                                               |
-| 3.5 Critical versions       | `engine/critical-version.ts`                                               |
-| 3.6 Partial replay          | `engine/partial-replay.ts`                                                 |
-| 3.8 Event graph storage     | `graph/columnar-codec.ts`                                                  |
+| Paper section               | Implementation                                                                                                                            |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.1 Characteristics         | `core/replica.ts`, `core/invariants.ts`, `engine/eg-walker-engine.ts`                                                                     |
+| 3.2 Walking the event graph | `core/replay-walker.ts`, `graph/event-graph.ts`, `engine/eg-walker-engine.ts`                                                             |
+| 3.3 Prepare/effect versions | `engine/eg-walker-engine.ts`, `engine/internals/yata-integration.ts`                                                                      |
+| 3.4 Index mapping           | `engine/indexed-sequence.ts`, `engine/internals/record-splitter.ts`, `engine/internals/pending-insert-buffer.ts`                          |
+| 3.5 Critical versions       | `engine/critical-version.ts`                                                                                                              |
+| 3.6 Partial replay          | `engine/partial-replay.ts`                                                                                                                |
+| 3.8 Event graph storage     | `graph/columnar-codec.ts`                                                                                                                 |
 
 ## Runtime Model
 
@@ -114,7 +122,8 @@ The test suite is architecture-focused:
 
 - `eg-walker-engine.test.ts`: replay, deletes, critical checkpoints, partial replay, columnar codec.
 - `event-graph.test.ts`: DAG, frontier, causal expansion/diff, serialization.
-- `external-api.test.ts`: public API and persistence round-trip.
+- `replica.test.ts`: public API and persistence round-trip.
 - `algorithm-characteristics.test.ts`: convergence, non-interleaving, no persistent CRDT metadata.
 - `invariants.test.ts`: strong-list helper behavior.
 - `non-conflicting-run-perf.test.ts`: Section 3.4 fast-path activation, fallback correctness, and a 20k-event linear-trace benchmark.
+- `pending-insert-buffer.test.ts`, `origin-left-index.test.ts`, `delete-target-index.test.ts`: focused unit tests for the `engine/internals/` helpers.


### PR DESCRIPTION
## Summary

- The three eg-walker package-level docs (`IMPLEMENTATION_GUIDE.md`, `CLAUDE.md`, `AGENTS.md`) still listed the pre-#694 file layout (single `engine/eg-walker-engine.ts`, no `engine/internals/`) and the pre-#642 file names (`core/external-api.ts`, `core/walker.ts`, `external-api.test.ts`).
- Refresh the layout trees and references so a reader following the docs to find a file lands on something that actually exists. Expand the paper-mapping table so Section 3.3 / 3.4 point at their new `internals/` counterparts (`yata-integration`, `record-splitter`, `pending-insert-buffer`). Add a working-rule entry to `CLAUDE.md` directing engine-private helpers into `engine/internals/`.
- List the three new internals unit tests (added in #695) in `IMPLEMENTATION_GUIDE.md`'s test inventory.
- Cross-implementation oracle work is tracked separately in #696.

## Test plan

- [x] Spot-check every path mentioned in the updated docs exists in `packages/eg-walker/src/`.
- [x] Docs only — no code changes; `pnpm --filter @softmaple/eg-walker test` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)