### PR TITLE
feat(packages/awareness, apps/playground): cursor + selection polish (PresenceLayer, multi-line, theme adaptivity)

### DIFF
--- a/apps/playground/src/components/awareness-collab/AwarenessOverlay.tsx
+++ b/apps/playground/src/components/awareness-collab/AwarenessOverlay.tsx
@@ -29,7 +29,7 @@ export function AwarenessOverlay({
   return (
     <PresenceProvider adapter={adapter}>
       <div className="space-y-4">
-        <div className="flex items-center justify-between gap-3 flex-wrap rounded-xl bg-slate-800/60 border border-slate-700 px-4 py-3">
+        <div className="flex items-center justify-between gap-3 flex-wrap rounded-xl bg-slate-800/60 border border-slate-700 px-4 py-3 text-slate-100">
           <div className="flex items-center gap-3 min-w-0">
             <div className="flex items-center gap-2 shrink-0">
               <img

--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -187,6 +187,7 @@ export function EditorSurface({
                   key={`cursor-${peer.userId}`}
                   user={peer}
                   point={point}
+                  showLabel="hover"
                 />
               );
             }

--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -45,19 +45,21 @@ export function EditorSurface({
   const updateTyping = useUpdateTyping();
 
   const editorBoxRef = useRef<HTMLDivElement>(null);
+  // Track the *textarea*'s bounding rect — `caret-coordinates` returns
+  // offsets measured from the textarea's top-left, so any other origin
+  // (like the outer card, which also includes the header bar) would push
+  // overlays up by the header height.
   const [editorRect, setEditorRect] = useState<DOMRect | null>(null);
   const typingTimerRef = useRef<number | null>(null);
 
-  // Track the editor box for overlay positioning. Recompute on resize.
   useLayoutEffect(() => {
     const update = () => {
-      if (editorBoxRef.current) {
-        setEditorRect(editorBoxRef.current.getBoundingClientRect());
-      }
+      const el = textareaRef.current;
+      if (el) setEditorRect(el.getBoundingClientRect());
     };
     update();
     const ro = new ResizeObserver(update);
-    if (editorBoxRef.current) ro.observe(editorBoxRef.current);
+    if (textareaRef.current) ro.observe(textareaRef.current);
     window.addEventListener("scroll", update, true);
     window.addEventListener("resize", update);
     return () => {
@@ -65,7 +67,7 @@ export function EditorSurface({
       window.removeEventListener("scroll", update, true);
       window.removeEventListener("resize", update);
     };
-  }, []);
+  }, [textareaRef]);
 
   // Clear typing indicator after a short idle period.
   useEffect(() => {

--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -6,6 +6,7 @@
 
 import {
   LiveCursor,
+  PresenceLayer,
   SelectionHighlight,
   type SelectionRange,
   useOthers,
@@ -13,7 +14,7 @@ import {
   useUpdateSelection,
   useUpdateTyping,
 } from "@softmaple/awareness";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { caretCoordinates } from "@/modules/awareness-collab/caret-coordinates";
 import { BlockActivityBadge } from "./BlockActivityBadge";
 
@@ -45,29 +46,7 @@ export function EditorSurface({
   const updateTyping = useUpdateTyping();
 
   const editorBoxRef = useRef<HTMLDivElement>(null);
-  // Track the *textarea*'s bounding rect — `caret-coordinates` returns
-  // offsets measured from the textarea's top-left, so any other origin
-  // (like the outer card, which also includes the header bar) would push
-  // overlays up by the header height.
-  const [editorRect, setEditorRect] = useState<DOMRect | null>(null);
   const typingTimerRef = useRef<number | null>(null);
-
-  useLayoutEffect(() => {
-    const update = () => {
-      const el = textareaRef.current;
-      if (el) setEditorRect(el.getBoundingClientRect());
-    };
-    update();
-    const ro = new ResizeObserver(update);
-    if (textareaRef.current) ro.observe(textareaRef.current);
-    window.addEventListener("scroll", update, true);
-    window.addEventListener("resize", update);
-    return () => {
-      ro.disconnect();
-      window.removeEventListener("scroll", update, true);
-      window.removeEventListener("resize", update);
-    };
-  }, [textareaRef]);
 
   // Clear typing indicator after a short idle period.
   useEffect(() => {
@@ -108,40 +87,41 @@ export function EditorSurface({
     }, 800);
   };
 
-  // Compute a screen-relative point for an offset in the textarea.
+  // Coordinates returned here are *host-local* (relative to the textarea
+  // top-left, post-scroll). PresenceLayer translates them to screen space
+  // on render, so we never have to reach for `getBoundingClientRect`.
   const pointFor = (offset: number) => {
     const el = textareaRef.current;
-    if (!el || !editorRect) return null;
+    if (!el) return null;
     const local = caretCoordinates(el, Math.min(offset, text.length));
     return {
-      x: editorRect.left + local.left - el.scrollLeft,
-      y: editorRect.top + local.top - el.scrollTop,
+      x: local.left - el.scrollLeft,
+      y: local.top - el.scrollTop,
     };
   };
 
-  // Compute a screen-relative rect for a selection range. Naive
-  // single-line bounding box — sufficient for the demo and matches
+  // Naive single-line bounding rect — sufficient for the demo and matches
   // SelectionHighlight's contract (HighlightRect with x,y,width,height).
   const rectFor = (range: SelectionRange) => {
     const el = textareaRef.current;
-    if (!el || !editorRect) return null;
+    if (!el) return null;
     const from = caretCoordinates(el, Math.min(range.from, text.length));
     const to = caretCoordinates(el, Math.min(range.to, text.length));
     const lineHeight = to.height || from.height || 20;
     if (from.top === to.top) {
       return {
-        x: editorRect.left + from.left - el.scrollLeft,
-        y: editorRect.top + from.top - el.scrollTop,
+        x: from.left - el.scrollLeft,
+        y: from.top - el.scrollTop,
         width: Math.max(2, to.left - from.left),
         height: lineHeight,
       };
     }
-    // Multi-line: span from `from` to right edge of editor as a coarse
-    // approximation. The demo seldom selects across many lines.
+    // Multi-line: span from `from` to the textarea's right edge as a
+    // coarse approximation. The demo seldom selects across many lines.
     return {
-      x: editorRect.left + from.left - el.scrollLeft,
-      y: editorRect.top + from.top - el.scrollTop,
-      width: editorRect.width - (from.left - el.scrollLeft) - 24,
+      x: from.left - el.scrollLeft,
+      y: from.top - el.scrollTop,
+      width: el.clientWidth - (from.left - el.scrollLeft) - 24,
       height: to.top - from.top + lineHeight,
     };
   };
@@ -173,50 +153,47 @@ export function EditorSurface({
         />
       </div>
 
-      {/* Awareness overlays. Rendered as a position:fixed layer so cursor
-       *  coordinates are screen-relative and survive scroll. */}
-      {editorRect ? (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none fixed inset-0 z-30"
-        >
-          {others.map((peer) => {
-            if (peer.cursor && peer.cursor.blockId === blockId) {
-              const point = pointFor(peer.cursor.offset);
-              if (!point) return null;
-              return (
-                <LiveCursor
-                  key={`cursor-${peer.userId}`}
-                  user={peer}
-                  point={point}
-                  showLabel="hover"
-                />
-              );
-            }
-            return null;
-          })}
-          {others.map((peer) => {
-            if (peer.selection && peer.selection.blockId === blockId) {
-              const rect = rectFor(peer.selection);
-              if (!rect) return null;
-              const selectedText = text.slice(
-                peer.selection.from,
-                peer.selection.to,
-              );
-              return (
-                <SelectionHighlight
-                  key={`sel-${peer.userId}`}
-                  user={peer}
-                  rect={rect}
-                  selectedText={selectedText}
-                  showLabel="hover"
-                />
-              );
-            }
-            return null;
-          })}
-        </div>
-      ) : null}
+      {/* Awareness overlays. PresenceLayer owns the fixed positioning
+       *  layer and translates host-local coordinates from `pointFor` /
+       *  `rectFor` into screen space, so we never compute screen offsets
+       *  here. */}
+      <PresenceLayer host={textareaRef}>
+        {others.map((peer) => {
+          if (peer.cursor && peer.cursor.blockId === blockId) {
+            const point = pointFor(peer.cursor.offset);
+            if (!point) return null;
+            return (
+              <LiveCursor
+                key={`cursor-${peer.userId}`}
+                user={peer}
+                point={point}
+                showLabel="hover"
+              />
+            );
+          }
+          return null;
+        })}
+        {others.map((peer) => {
+          if (peer.selection && peer.selection.blockId === blockId) {
+            const rect = rectFor(peer.selection);
+            if (!rect) return null;
+            const selectedText = text.slice(
+              peer.selection.from,
+              peer.selection.to,
+            );
+            return (
+              <SelectionHighlight
+                key={`sel-${peer.userId}`}
+                user={peer}
+                rect={rect}
+                selectedText={selectedText}
+                showLabel="hover"
+              />
+            );
+          }
+          return null;
+        })}
+      </PresenceLayer>
     </div>
   );
 }

--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -5,6 +5,7 @@
  */
 
 import {
+  type HighlightRect,
   LiveCursor,
   PresenceLayer,
   SelectionHighlight,
@@ -100,30 +101,66 @@ export function EditorSurface({
     };
   };
 
-  // Naive single-line bounding rect — sufficient for the demo and matches
-  // SelectionHighlight's contract (HighlightRect with x,y,width,height).
-  const rectFor = (range: SelectionRange) => {
+  // Build one rect per visible line so wrapped selections render the way
+  // browsers natively highlight text — line 1 from `from.left` to the
+  // content right edge, full-width middle lines, last line from the
+  // content left edge to `to.left`. A single bounding rect would paint a
+  // giant block over unselected content between the wrap boundaries.
+  const rectsFor = (range: SelectionRange): HighlightRect[] => {
     const el = textareaRef.current;
-    if (!el) return null;
-    const from = caretCoordinates(el, Math.min(range.from, text.length));
-    const to = caretCoordinates(el, Math.min(range.to, text.length));
-    const lineHeight = to.height || from.height || 20;
-    if (from.top === to.top) {
-      return {
-        x: from.left - el.scrollLeft,
-        y: from.top - el.scrollTop,
-        width: Math.max(2, to.left - from.left),
-        height: lineHeight,
-      };
+    if (!el) return [];
+    const fromOff = Math.min(range.from, text.length);
+    const toOff = Math.min(range.to, text.length);
+    if (fromOff >= toOff) return [];
+
+    const start = caretCoordinates(el, fromOff);
+    const end = caretCoordinates(el, toOff);
+    const lineHeight = start.height || end.height || 20;
+
+    if (start.top === end.top) {
+      return [
+        {
+          x: start.left - el.scrollLeft,
+          y: start.top - el.scrollTop,
+          width: Math.max(2, end.left - start.left),
+          height: lineHeight,
+        },
+      ];
     }
-    // Multi-line: span from `from` to the textarea's right edge as a
-    // coarse approximation. The demo seldom selects across many lines.
-    return {
-      x: from.left - el.scrollLeft,
-      y: from.top - el.scrollTop,
-      width: el.clientWidth - (from.left - el.scrollLeft) - 24,
-      height: to.top - from.top + lineHeight,
-    };
+
+    const cs = window.getComputedStyle(el);
+    const padLeft = Number.parseFloat(cs.paddingLeft) || 0;
+    const padRight = Number.parseFloat(cs.paddingRight) || 0;
+    const contentLeft = padLeft;
+    const contentRight = el.clientWidth - padRight;
+    const contentWidth = Math.max(2, contentRight - contentLeft);
+
+    const rects: HighlightRect[] = [];
+    rects.push({
+      x: start.left - el.scrollLeft,
+      y: start.top - el.scrollTop,
+      width: Math.max(2, contentRight - start.left),
+      height: lineHeight,
+    });
+    const middleLines = Math.max(
+      0,
+      Math.round((end.top - start.top) / lineHeight) - 1,
+    );
+    for (let i = 0; i < middleLines; i++) {
+      rects.push({
+        x: contentLeft - el.scrollLeft,
+        y: start.top + (i + 1) * lineHeight - el.scrollTop,
+        width: contentWidth,
+        height: lineHeight,
+      });
+    }
+    rects.push({
+      x: contentLeft - el.scrollLeft,
+      y: end.top - el.scrollTop,
+      width: Math.max(2, end.left - contentLeft),
+      height: lineHeight,
+    });
+    return rects;
   };
 
   return (
@@ -173,25 +210,26 @@ export function EditorSurface({
           }
           return null;
         })}
-        {others.map((peer) => {
-          if (peer.selection && peer.selection.blockId === blockId) {
-            const rect = rectFor(peer.selection);
-            if (!rect) return null;
-            const selectedText = text.slice(
-              peer.selection.from,
-              peer.selection.to,
-            );
-            return (
-              <SelectionHighlight
-                key={`sel-${peer.userId}`}
-                user={peer}
-                rect={rect}
-                selectedText={selectedText}
-                showLabel="hover"
-              />
-            );
-          }
-          return null;
+        {others.flatMap((peer) => {
+          if (!peer.selection || peer.selection.blockId !== blockId) return [];
+          const rects = rectsFor(peer.selection);
+          if (rects.length === 0) return [];
+          const selectedText = text.slice(
+            peer.selection.from,
+            peer.selection.to,
+          );
+          // Only the first rect carries the user-visible label and the
+          // full selectedText aria-label; sibling rects render as
+          // unlabeled continuations of the same selection.
+          return rects.map((rect, i) => (
+            <SelectionHighlight
+              key={`sel-${peer.userId}-${i}`}
+              user={peer}
+              rect={rect}
+              selectedText={i === 0 ? selectedText : undefined}
+              showLabel={i === 0 ? "hover" : false}
+            />
+          ));
         })}
       </PresenceLayer>
     </div>

--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -106,6 +106,17 @@ export function EditorSurface({
   // content right edge, full-width middle lines, last line from the
   // content left edge to `to.left`. A single bounding rect would paint a
   // giant block over unselected content between the wrap boundaries.
+  //
+  // The `Math.max(2, …)` floors below keep degenerate rects (collapsed
+  // ranges, caret at line edge) visible — 0-width rects would disappear
+  // and a 1px rect blends with the background.
+  //
+  // Assumes uniform line height (textarea has a single font/leading);
+  // the middle-line count uses `Math.round((end.top - start.top) /
+  // lineHeight) - 1`, which is robust for integer line heights but can
+  // drift off-by-one if the host has fractional `line-height` and the
+  // wrap span lands near a half-line boundary. Adequate for demo-grade
+  // textarea selections.
   const rectsFor = (range: SelectionRange): HighlightRect[] => {
     const el = textareaRef.current;
     if (!el) return [];

--- a/packages/awareness/package.json
+++ b/packages/awareness/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/components/presence-bar.d.ts",
       "import": "./dist/components/presence-bar.js"
     },
+    "./components/presence-layer": {
+      "types": "./dist/components/presence-layer.d.ts",
+      "import": "./dist/components/presence-layer.js"
+    },
     "./components/selection-highlight": {
       "types": "./dist/components/selection-highlight.d.ts",
       "import": "./dist/components/selection-highlight.js"

--- a/packages/awareness/src/components/index.ts
+++ b/packages/awareness/src/components/index.ts
@@ -25,6 +25,7 @@ export {
 export { PresenceBar, type PresenceBarProps } from "./presence-bar";
 export {
   PresenceLayer,
+  PresenceLayerContext,
   type PresenceLayerOffset,
   type PresenceLayerProps,
   usePresenceLayerOffset,

--- a/packages/awareness/src/components/index.ts
+++ b/packages/awareness/src/components/index.ts
@@ -24,6 +24,12 @@ export {
 } from "./presence-avatar";
 export { PresenceBar, type PresenceBarProps } from "./presence-bar";
 export {
+  PresenceLayer,
+  type PresenceLayerOffset,
+  type PresenceLayerProps,
+  usePresenceLayerOffset,
+} from "./presence-layer";
+export {
   type HighlightRect,
   SelectionHighlight,
   type SelectionHighlightProps,

--- a/packages/awareness/src/components/live-cursor.tsx
+++ b/packages/awareness/src/components/live-cursor.tsx
@@ -125,6 +125,9 @@ export const LiveCursor = ({
     };
   }, [viewport]);
 
+  // `point.x` / `point.y` are intentional dependencies: every move re-arms
+  // the auto-fade so the label re-appears at the new location, matching
+  // design §6 ("label visible while cursor is active, then fades").
   useEffect(() => {
     if (showLabel !== true) {
       setIsLabelVisible(false);
@@ -175,6 +178,11 @@ export const LiveCursor = ({
         ...toUserColorStyle(user.color),
         transform: `translate3d(${screenPoint.x}px, ${screenPoint.y}px, 0)`,
       }}
+      // Hover variant is keyboard-discoverable: focusing the caret reveals
+      // the user badge via CSS `:focus-visible`. Each visible peer adds one
+      // tab stop — intentional, so screen-reader / keyboard users can
+      // inspect attribution without a pointer. Mirrors the same pattern in
+      // `SelectionHighlight`.
       tabIndex={isHoverLabel ? 0 : undefined}
     >
       <span aria-hidden="true" className="awareness-live-cursor__caret" />

--- a/packages/awareness/src/components/live-cursor.tsx
+++ b/packages/awareness/src/components/live-cursor.tsx
@@ -30,7 +30,16 @@ export interface LiveCursorProps {
   readonly user: PresenceUser;
   readonly point: LiveCursorPoint;
   readonly labelVisibleMs?: number;
-  readonly showLabel?: boolean;
+  /**
+   * Controls how the user label is presented.
+   * - `true` (default): label shows on mount and after every move, then
+   *   auto-hides after `labelVisibleMs`.
+   * - `false`: label is never rendered.
+   * - `"hover"`: label is hidden until the caret is hovered or keyboard-
+   *   focused — matches the same opt-in pattern used by
+   *   `SelectionHighlight` (design doc §5.3 "Hover reveals user badge").
+   */
+  readonly showLabel?: boolean | "hover";
   readonly className?: string;
   /**
    * Bounds used for off-screen culling. Defaults to the current window.
@@ -83,7 +92,12 @@ export const LiveCursor = ({
   viewport = "window",
   cullMargin = 32,
 }: LiveCursorProps): ReactNode => {
-  const [isLabelVisible, setIsLabelVisible] = useState(showLabel);
+  const isHoverLabel = showLabel === "hover";
+  const renderLabel = showLabel === true || isHoverLabel;
+  // Auto-fade only applies to the always-on label. The hover variant lets
+  // CSS :hover / :focus-visible drive opacity, so we don't toggle the
+  // `--label-visible` class for it.
+  const [isLabelVisible, setIsLabelVisible] = useState(showLabel === true);
   const previousPointRef = useRef(point);
 
   // Re-evaluate window-based culling on resize so cursors near the edge
@@ -101,7 +115,7 @@ export const LiveCursor = ({
   }, [viewport]);
 
   useEffect(() => {
-    if (!showLabel) {
+    if (showLabel !== true) {
       setIsLabelVisible(false);
       return;
     }
@@ -133,6 +147,7 @@ export const LiveCursor = ({
       className={cx(
         "awareness-live-cursor",
         isLabelVisible && "awareness-live-cursor--label-visible",
+        isHoverLabel && "awareness-live-cursor--hoverable",
         className,
       )}
       role="img"
@@ -140,9 +155,10 @@ export const LiveCursor = ({
         ...toUserColorStyle(user.color),
         transform: `translate3d(${point.x}px, ${point.y}px, 0)`,
       }}
+      tabIndex={isHoverLabel ? 0 : undefined}
     >
       <span aria-hidden="true" className="awareness-live-cursor__caret" />
-      {showLabel ? (
+      {renderLabel ? (
         <span className="awareness-live-cursor__label">{user.name}</span>
       ) : null}
     </div>

--- a/packages/awareness/src/components/live-cursor.tsx
+++ b/packages/awareness/src/components/live-cursor.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useReducer, useRef, useState } from "react";
 import type { PresenceUser } from "../types/presence";
 import { cx, toUserColorStyle } from "./internal-utils";
+import { usePresenceLayerOffset } from "./presence-layer";
 
 export interface LiveCursorPoint {
   readonly x: number;
@@ -100,6 +101,14 @@ export const LiveCursor = ({
   const [isLabelVisible, setIsLabelVisible] = useState(showLabel === true);
   const previousPointRef = useRef(point);
 
+  // When wrapped in a `<PresenceLayer>`, `point` is host-local; outside one
+  // it stays screen-relative (back-compat for direct consumers and stories).
+  const layerOffset = usePresenceLayerOffset();
+  const screenPoint =
+    layerOffset === null
+      ? point
+      : { x: point.x + layerOffset.left, y: point.y + layerOffset.top };
+
   // Re-evaluate window-based culling on resize so cursors near the edge
   // cull/uncull correctly without waiting for the next pointer move.
   const [, bumpResize] = useReducer((x: number) => x + 1, 0);
@@ -137,7 +146,7 @@ export const LiveCursor = ({
     };
   }, [labelVisibleMs, point.x, point.y, showLabel]);
 
-  if (!isPointInViewport(point, viewport, cullMargin)) {
+  if (!isPointInViewport(screenPoint, viewport, cullMargin)) {
     return null;
   }
 
@@ -153,7 +162,7 @@ export const LiveCursor = ({
       role="img"
       style={{
         ...toUserColorStyle(user.color),
-        transform: `translate3d(${point.x}px, ${point.y}px, 0)`,
+        transform: `translate3d(${screenPoint.x}px, ${screenPoint.y}px, 0)`,
       }}
       tabIndex={isHoverLabel ? 0 : undefined}
     >

--- a/packages/awareness/src/components/live-cursor.tsx
+++ b/packages/awareness/src/components/live-cursor.tsx
@@ -1,7 +1,10 @@
 import { type ReactNode, useEffect, useReducer, useRef, useState } from "react";
 import type { PresenceUser } from "../types/presence";
 import { cx, toUserColorStyle } from "./internal-utils";
-import { usePresenceLayerOffset } from "./presence-layer";
+import {
+  usePresenceLayerOffset,
+  warnMissingPresenceLayerOnce,
+} from "./presence-layer";
 
 export interface LiveCursorPoint {
   readonly x: number;
@@ -101,13 +104,12 @@ export const LiveCursor = ({
   const [isLabelVisible, setIsLabelVisible] = useState(showLabel === true);
   const previousPointRef = useRef(point);
 
-  // When wrapped in a `<PresenceLayer>`, `point` is host-local; outside one
-  // it stays screen-relative (back-compat for direct consumers and stories).
+  // `LiveCursor` requires a `<PresenceLayer>` ancestor — the layer owns the
+  // host's bounding rect, which is the only sane reference frame for
+  // overlay coordinates. Without one, the cursor would render at the
+  // wrong position (the original bug class this API was introduced to
+  // remove), so we render nothing instead.
   const layerOffset = usePresenceLayerOffset();
-  const screenPoint =
-    layerOffset === null
-      ? point
-      : { x: point.x + layerOffset.left, y: point.y + layerOffset.top };
 
   // Re-evaluate window-based culling on resize so cursors near the edge
   // cull/uncull correctly without waiting for the next pointer move.
@@ -145,6 +147,15 @@ export const LiveCursor = ({
       clearTimeout(timeoutId);
     };
   }, [labelVisibleMs, point.x, point.y, showLabel]);
+
+  if (layerOffset === null) {
+    warnMissingPresenceLayerOnce("LiveCursor");
+    return null;
+  }
+  const screenPoint = {
+    x: point.x + layerOffset.left,
+    y: point.y + layerOffset.top,
+  };
 
   if (!isPointInViewport(screenPoint, viewport, cullMargin)) {
     return null;

--- a/packages/awareness/src/components/presence-interactions.test.tsx
+++ b/packages/awareness/src/components/presence-interactions.test.tsx
@@ -25,7 +25,23 @@ import { PresenceProvider } from "../providers/presence-provider";
 import type { PresenceUser } from "../types/presence";
 import { BlockActivityIndicator } from "./block-activity-indicator";
 import { LiveCursor } from "./live-cursor";
+import {
+  PresenceLayerContext,
+  type PresenceLayerOffset,
+} from "./presence-layer";
 import { SelectionHighlight } from "./selection-highlight";
+
+// `LiveCursor` and `SelectionHighlight` require a `<PresenceLayer>`
+// ancestor in production. The layer's measurement effect doesn't fire
+// under SSR / `renderToStaticMarkup`, so SSR tests inject the context
+// directly with an identity offset — enough to satisfy the guard while
+// leaving the rendered HTML structurally identical.
+const IDENTITY_OFFSET: PresenceLayerOffset = { left: 0, top: 0 };
+const InTestLayer = ({ children }: { children: React.ReactNode }) => (
+  <PresenceLayerContext.Provider value={IDENTITY_OFFSET}>
+    {children}
+  </PresenceLayerContext.Provider>
+);
 
 const reactActGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -52,33 +68,41 @@ afterEach(() => {
 describe("LiveCursor off-screen culling (design §7)", () => {
   it("renders when point is inside the window viewport", () => {
     const html = renderToStaticMarkup(
-      <LiveCursor point={{ x: 100, y: 100 }} user={user("a")} />,
+      <InTestLayer>
+        <LiveCursor point={{ x: 100, y: 100 }} user={user("a")} />
+      </InTestLayer>,
     );
     expect(html).toContain("awareness-live-cursor");
   });
 
   it("returns null when point is far outside the window viewport", () => {
     const html = renderToStaticMarkup(
-      <LiveCursor point={{ x: 999_999, y: 999_999 }} user={user("a")} />,
+      <InTestLayer>
+        <LiveCursor point={{ x: 999_999, y: 999_999 }} user={user("a")} />
+      </InTestLayer>,
     );
     expect(html).toBe("");
   });
 
   it("honors an explicit viewport rect", () => {
     const inside = renderToStaticMarkup(
-      <LiveCursor
-        point={{ x: 50, y: 50 }}
-        user={user("a")}
-        viewport={{ x: 0, y: 0, width: 200, height: 200 }}
-      />,
+      <InTestLayer>
+        <LiveCursor
+          point={{ x: 50, y: 50 }}
+          user={user("a")}
+          viewport={{ x: 0, y: 0, width: 200, height: 200 }}
+        />
+      </InTestLayer>,
     );
     const outside = renderToStaticMarkup(
-      <LiveCursor
-        point={{ x: 500, y: 500 }}
-        user={user("a")}
-        cullMargin={0}
-        viewport={{ x: 0, y: 0, width: 200, height: 200 }}
-      />,
+      <InTestLayer>
+        <LiveCursor
+          point={{ x: 500, y: 500 }}
+          user={user("a")}
+          cullMargin={0}
+          viewport={{ x: 0, y: 0, width: 200, height: 200 }}
+        />
+      </InTestLayer>,
     );
     expect(inside).toContain("awareness-live-cursor");
     expect(outside).toBe("");
@@ -86,11 +110,13 @@ describe("LiveCursor off-screen culling (design §7)", () => {
 
   it('never culls when viewport="none"', () => {
     const html = renderToStaticMarkup(
-      <LiveCursor
-        point={{ x: 999_999, y: 999_999 }}
-        user={user("a")}
-        viewport="none"
-      />,
+      <InTestLayer>
+        <LiveCursor
+          point={{ x: 999_999, y: 999_999 }}
+          user={user("a")}
+          viewport="none"
+        />
+      </InTestLayer>,
     );
     expect(html).toContain("awareness-live-cursor");
   });
@@ -105,11 +131,13 @@ describe("LiveCursor off-screen culling (design §7)", () => {
 
     await act(async () => {
       root.render(
-        <LiveCursor
-          cullMargin={0}
-          point={{ x: 400, y: 400 }}
-          user={user("a")}
-        />,
+        <InTestLayer>
+          <LiveCursor
+            cullMargin={0}
+            point={{ x: 400, y: 400 }}
+            user={user("a")}
+          />
+        </InTestLayer>,
       );
     });
     expect(container.querySelector(".awareness-live-cursor")).not.toBeNull();
@@ -148,11 +176,13 @@ describe("LiveCursor off-screen culling (design §7)", () => {
 describe("SelectionHighlight hover-to-reveal label (design §5.3)", () => {
   it('adds hoverable class when showLabel="hover"', () => {
     const html = renderToStaticMarkup(
-      <SelectionHighlight
-        rect={{ x: 0, y: 0, width: 10, height: 10 }}
-        showLabel="hover"
-        user={user("a", { name: "Hover" })}
-      />,
+      <InTestLayer>
+        <SelectionHighlight
+          rect={{ x: 0, y: 0, width: 10, height: 10 }}
+          showLabel="hover"
+          user={user("a", { name: "Hover" })}
+        />
+      </InTestLayer>,
     );
     expect(html).toContain("awareness-selection-highlight--hoverable");
     expect(html).toContain("Hover");
@@ -161,11 +191,13 @@ describe("SelectionHighlight hover-to-reveal label (design §5.3)", () => {
 
   it("does not add hoverable class for boolean showLabel", () => {
     const truthy = renderToStaticMarkup(
-      <SelectionHighlight
-        rect={{ x: 0, y: 0, width: 10, height: 10 }}
-        showLabel
-        user={user("a", { name: "Vis" })}
-      />,
+      <InTestLayer>
+        <SelectionHighlight
+          rect={{ x: 0, y: 0, width: 10, height: 10 }}
+          showLabel
+          user={user("a", { name: "Vis" })}
+        />
+      </InTestLayer>,
     );
     expect(truthy).not.toContain("awareness-selection-highlight--hoverable");
     expect(truthy).toContain("Vis");
@@ -175,11 +207,13 @@ describe("SelectionHighlight hover-to-reveal label (design §5.3)", () => {
 describe("LiveCursor hover-to-reveal label (design §5.3)", () => {
   it('adds hoverable class, tabindex, and renders label when showLabel="hover"', () => {
     const html = renderToStaticMarkup(
-      <LiveCursor
-        point={{ x: 0, y: 0 }}
-        showLabel="hover"
-        user={user("a", { name: "HoverCaret" })}
-      />,
+      <InTestLayer>
+        <LiveCursor
+          point={{ x: 0, y: 0 }}
+          showLabel="hover"
+          user={user("a", { name: "HoverCaret" })}
+        />
+      </InTestLayer>,
     );
     expect(html).toContain("awareness-live-cursor--hoverable");
     expect(html).toContain('tabindex="0"');
@@ -191,21 +225,25 @@ describe("LiveCursor hover-to-reveal label (design §5.3)", () => {
 
   it("does not add hoverable class for boolean showLabel", () => {
     const truthy = renderToStaticMarkup(
-      <LiveCursor
-        point={{ x: 0, y: 0 }}
-        showLabel
-        user={user("a", { name: "VisCaret" })}
-      />,
+      <InTestLayer>
+        <LiveCursor
+          point={{ x: 0, y: 0 }}
+          showLabel
+          user={user("a", { name: "VisCaret" })}
+        />
+      </InTestLayer>,
     );
     expect(truthy).not.toContain("awareness-live-cursor--hoverable");
     expect(truthy).toContain("VisCaret");
 
     const hidden = renderToStaticMarkup(
-      <LiveCursor
-        point={{ x: 0, y: 0 }}
-        showLabel={false}
-        user={user("a", { name: "HiddenCaret" })}
-      />,
+      <InTestLayer>
+        <LiveCursor
+          point={{ x: 0, y: 0 }}
+          showLabel={false}
+          user={user("a", { name: "HiddenCaret" })}
+        />
+      </InTestLayer>,
     );
     expect(hidden).not.toContain("awareness-live-cursor--hoverable");
     // The label span itself isn't rendered when showLabel={false}; the

--- a/packages/awareness/src/components/presence-interactions.test.tsx
+++ b/packages/awareness/src/components/presence-interactions.test.tsx
@@ -172,6 +172,48 @@ describe("SelectionHighlight hover-to-reveal label (design §5.3)", () => {
   });
 });
 
+describe("LiveCursor hover-to-reveal label (design §5.3)", () => {
+  it('adds hoverable class, tabindex, and renders label when showLabel="hover"', () => {
+    const html = renderToStaticMarkup(
+      <LiveCursor
+        point={{ x: 0, y: 0 }}
+        showLabel="hover"
+        user={user("a", { name: "HoverCaret" })}
+      />,
+    );
+    expect(html).toContain("awareness-live-cursor--hoverable");
+    expect(html).toContain('tabindex="0"');
+    expect(html).toContain("HoverCaret");
+    // Hoverable cursors don't get the always-on label-visible class —
+    // CSS :hover/:focus-visible drives opacity instead.
+    expect(html).not.toContain("awareness-live-cursor--label-visible");
+  });
+
+  it("does not add hoverable class for boolean showLabel", () => {
+    const truthy = renderToStaticMarkup(
+      <LiveCursor
+        point={{ x: 0, y: 0 }}
+        showLabel
+        user={user("a", { name: "VisCaret" })}
+      />,
+    );
+    expect(truthy).not.toContain("awareness-live-cursor--hoverable");
+    expect(truthy).toContain("VisCaret");
+
+    const hidden = renderToStaticMarkup(
+      <LiveCursor
+        point={{ x: 0, y: 0 }}
+        showLabel={false}
+        user={user("a", { name: "HiddenCaret" })}
+      />,
+    );
+    expect(hidden).not.toContain("awareness-live-cursor--hoverable");
+    // The label span itself isn't rendered when showLabel={false}; the
+    // name still appears inside the aria-label, which is expected.
+    expect(hidden).not.toContain("awareness-live-cursor__label");
+  });
+});
+
 describe("BlockActivityIndicator (design §5.4)", () => {
   const a = user("a", {
     name: "Ada",

--- a/packages/awareness/src/components/presence-interactions.test.tsx
+++ b/packages/awareness/src/components/presence-interactions.test.tsx
@@ -114,47 +114,50 @@ describe("LiveCursor off-screen culling (design §7)", () => {
     document.body.append(container);
     const root = createRoot(container);
 
-    await act(async () => {
-      root.render(
-        <InTestLayer>
-          <LiveCursor
-            cullMargin={0}
-            point={{ x: 400, y: 400 }}
-            user={user("a")}
-          />
-        </InTestLayer>,
-      );
-    });
-    expect(container.querySelector(".awareness-live-cursor")).not.toBeNull();
+    try {
+      await act(async () => {
+        root.render(
+          <InTestLayer>
+            <LiveCursor
+              cullMargin={0}
+              point={{ x: 400, y: 400 }}
+              user={user("a")}
+            />
+          </InTestLayer>,
+        );
+      });
+      expect(container.querySelector(".awareness-live-cursor")).not.toBeNull();
 
-    // Shrink the window and dispatch resize — cursor should re-evaluate
-    // and cull itself without any pointer movement.
-    Object.defineProperty(window, "innerWidth", {
-      configurable: true,
-      value: 100,
-    });
-    Object.defineProperty(window, "innerHeight", {
-      configurable: true,
-      value: 100,
-    });
-    await act(async () => {
-      window.dispatchEvent(new Event("resize"));
-    });
+      // Shrink the window and dispatch resize — cursor should re-evaluate
+      // and cull itself without any pointer movement.
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: 100,
+      });
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        value: 100,
+      });
+      await act(async () => {
+        window.dispatchEvent(new Event("resize"));
+      });
 
-    expect(container.querySelector(".awareness-live-cursor")).toBeNull();
+      expect(container.querySelector(".awareness-live-cursor")).toBeNull();
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        value: originalInnerHeight,
+      });
 
-    Object.defineProperty(window, "innerWidth", {
-      configurable: true,
-      value: originalInnerWidth,
-    });
-    Object.defineProperty(window, "innerHeight", {
-      configurable: true,
-      value: originalInnerHeight,
-    });
-
-    await act(async () => {
-      root.unmount();
-    });
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
   });
 });
 

--- a/packages/awareness/src/components/presence-interactions.test.tsx
+++ b/packages/awareness/src/components/presence-interactions.test.tsx
@@ -25,23 +25,8 @@ import { PresenceProvider } from "../providers/presence-provider";
 import type { PresenceUser } from "../types/presence";
 import { BlockActivityIndicator } from "./block-activity-indicator";
 import { LiveCursor } from "./live-cursor";
-import {
-  PresenceLayerContext,
-  type PresenceLayerOffset,
-} from "./presence-layer";
 import { SelectionHighlight } from "./selection-highlight";
-
-// `LiveCursor` and `SelectionHighlight` require a `<PresenceLayer>`
-// ancestor in production. The layer's measurement effect doesn't fire
-// under SSR / `renderToStaticMarkup`, so SSR tests inject the context
-// directly with an identity offset — enough to satisfy the guard while
-// leaving the rendered HTML structurally identical.
-const IDENTITY_OFFSET: PresenceLayerOffset = { left: 0, top: 0 };
-const InTestLayer = ({ children }: { children: React.ReactNode }) => (
-  <PresenceLayerContext.Provider value={IDENTITY_OFFSET}>
-    {children}
-  </PresenceLayerContext.Provider>
-);
+import { InTestLayer } from "./test-utils";
 
 const reactActGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;

--- a/packages/awareness/src/components/presence-layer.tsx
+++ b/packages/awareness/src/components/presence-layer.tsx
@@ -13,16 +13,45 @@ export interface PresenceLayerOffset {
   readonly top: number;
 }
 
-const PresenceLayerContext = createContext<PresenceLayerOffset | null>(null);
+/**
+ * The context that `<PresenceLayer>` populates with the host's bounding
+ * offset. Exposed so unit tests can inject a fixed offset without going
+ * through `useLayoutEffect`-based measurement (which doesn't run under
+ * SSR / `renderToStaticMarkup`). Prefer `<PresenceLayer>` in real apps.
+ */
+export const PresenceLayerContext = createContext<PresenceLayerOffset | null>(
+  null,
+);
 
 /**
  * Read the current host offset injected by the nearest `<PresenceLayer>`
- * ancestor. Returns `null` outside a layer — components that consume this
- * should treat that as "use coordinates as-is" so they keep working when
- * rendered standalone (e.g. in stories or one-off overlays).
+ * ancestor. Returns `null` when no layer is in scope; the consumer
+ * should treat that as a misuse and either render nothing or fall back
+ * loudly (see `warnMissingPresenceLayerOnce`).
  */
 export const usePresenceLayerOffset = (): PresenceLayerOffset | null =>
   useContext(PresenceLayerContext);
+
+const warnedComponents = new Set<string>();
+
+/**
+ * Logs a single dev-mode warning the first time a given component is
+ * rendered without a `<PresenceLayer>` ancestor. Stripped from
+ * production bundles by the standard `process.env.NODE_ENV` check.
+ */
+export const warnMissingPresenceLayerOnce = (componentName: string): void => {
+  if (
+    typeof process === "undefined" ||
+    process.env.NODE_ENV === "production" ||
+    warnedComponents.has(componentName)
+  ) {
+    return;
+  }
+  warnedComponents.add(componentName);
+  console.warn(
+    `[@softmaple/awareness] <${componentName}> was rendered without a <PresenceLayer> ancestor and will not render. Wrap it in <PresenceLayer host={ref}> so coordinates can be translated against a host element.`,
+  );
+};
 
 export interface PresenceLayerProps {
   /**
@@ -37,6 +66,14 @@ export interface PresenceLayerProps {
   readonly className?: string;
 }
 
+// Identity offset used until the host is measured. Rendering with this
+// value (rather than waiting for the first useLayoutEffect tick) means
+// children mount on the first commit, which keeps refs and effects
+// inside the layer (e.g. `useEffect` in `LiveCursor`) wired up
+// predictably. The layer corrects the offset on the same paint via
+// `useLayoutEffect`, so there's no visible flicker.
+const IDENTITY_OFFSET: PresenceLayerOffset = { left: 0, top: 0 };
+
 /**
  * Fixed-position overlay aligned to a host element. Owns the
  * `getBoundingClientRect` tracking (ResizeObserver + scroll/resize) so
@@ -44,16 +81,13 @@ export interface PresenceLayerProps {
  * presence overlay anchored to the wrong element pushes cursors and
  * selections off the line goes away once everything inside the layer
  * uses host-local coordinates.
- *
- * The layer renders nothing visible until the host has been measured;
- * this avoids a one-frame flash at (0,0) before the first layout pass.
  */
 export const PresenceLayer = ({
   host,
   children,
   className,
 }: PresenceLayerProps): ReactNode => {
-  const [offset, setOffset] = useState<PresenceLayerOffset | null>(null);
+  const [offset, setOffset] = useState<PresenceLayerOffset>(IDENTITY_OFFSET);
 
   useLayoutEffect(() => {
     const el = host.current;
@@ -62,7 +96,7 @@ export const PresenceLayer = ({
     const update = (): void => {
       const rect = el.getBoundingClientRect();
       setOffset((prev) =>
-        prev !== null && prev.left === rect.left && prev.top === rect.top
+        prev.left === rect.left && prev.top === rect.top
           ? prev
           : { left: rect.left, top: rect.top },
       );
@@ -85,8 +119,6 @@ export const PresenceLayer = ({
       window.removeEventListener("resize", update);
     };
   }, [host]);
-
-  if (!offset) return null;
 
   return (
     <PresenceLayerContext.Provider value={offset}>

--- a/packages/awareness/src/components/presence-layer.tsx
+++ b/packages/awareness/src/components/presence-layer.tsx
@@ -81,6 +81,15 @@ const IDENTITY_OFFSET: PresenceLayerOffset = { left: 0, top: 0 };
  * presence overlay anchored to the wrong element pushes cursors and
  * selections off the line goes away once everything inside the layer
  * uses host-local coordinates.
+ *
+ * Contract: the layer tracks the host's **position** (its bounding
+ * rect in viewport space). It does *not* observe host-internal
+ * scrolling — `getBoundingClientRect` doesn't change when a textarea
+ * or scroll container scrolls its own content. Consumers that produce
+ * host-local `point`/`rect` values must subtract `host.scrollLeft` /
+ * `host.scrollTop` themselves (see `EditorSurface.pointFor` for the
+ * pattern), and must re-emit those values when the host scrolls if
+ * the underlying caret/selection didn't move.
  */
 export const PresenceLayer = ({
   host,

--- a/packages/awareness/src/components/presence-layer.tsx
+++ b/packages/awareness/src/components/presence-layer.tsx
@@ -1,0 +1,105 @@
+import {
+  createContext,
+  type ReactNode,
+  type RefObject,
+  useContext,
+  useLayoutEffect,
+  useState,
+} from "react";
+import { cx } from "./internal-utils";
+
+export interface PresenceLayerOffset {
+  readonly left: number;
+  readonly top: number;
+}
+
+const PresenceLayerContext = createContext<PresenceLayerOffset | null>(null);
+
+/**
+ * Read the current host offset injected by the nearest `<PresenceLayer>`
+ * ancestor. Returns `null` outside a layer — components that consume this
+ * should treat that as "use coordinates as-is" so they keep working when
+ * rendered standalone (e.g. in stories or one-off overlays).
+ */
+export const usePresenceLayerOffset = (): PresenceLayerOffset | null =>
+  useContext(PresenceLayerContext);
+
+export interface PresenceLayerProps {
+  /**
+   * The element overlay coordinates are measured against. Children pass
+   * `point`/`rect` values whose `x`/`y` are relative to this element's
+   * top-left in viewport coordinates (i.e., already adjusted for any
+   * internal scroll the host has). The layer adds the host's bounding
+   * rect so children render in the right place.
+   */
+  readonly host: RefObject<HTMLElement | null>;
+  readonly children?: ReactNode;
+  readonly className?: string;
+}
+
+/**
+ * Fixed-position overlay aligned to a host element. Owns the
+ * `getBoundingClientRect` tracking (ResizeObserver + scroll/resize) so
+ * consumers don't have to wire it themselves — the bug class where a
+ * presence overlay anchored to the wrong element pushes cursors and
+ * selections off the line goes away once everything inside the layer
+ * uses host-local coordinates.
+ *
+ * The layer renders nothing visible until the host has been measured;
+ * this avoids a one-frame flash at (0,0) before the first layout pass.
+ */
+export const PresenceLayer = ({
+  host,
+  children,
+  className,
+}: PresenceLayerProps): ReactNode => {
+  const [offset, setOffset] = useState<PresenceLayerOffset | null>(null);
+
+  useLayoutEffect(() => {
+    const el = host.current;
+    if (!el) return;
+
+    const update = (): void => {
+      const rect = el.getBoundingClientRect();
+      setOffset((prev) =>
+        prev !== null && prev.left === rect.left && prev.top === rect.top
+          ? prev
+          : { left: rect.left, top: rect.top },
+      );
+    };
+    update();
+
+    // ResizeObserver is missing in jsdom and older SSR environments —
+    // the scroll/resize listeners below cover the most common cases
+    // even when it's unavailable.
+    const ro =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+    ro?.observe(el);
+    // Capture-phase scroll catches scrolls in any ancestor (the host can
+    // sit inside an arbitrary scroll container the consumer owns).
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      ro?.disconnect();
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [host]);
+
+  if (!offset) return null;
+
+  return (
+    <PresenceLayerContext.Provider value={offset}>
+      {/*
+       * Intentionally not `aria-hidden` — the cursors and selections inside
+       * carry their own aria-labels ("Pikachu cursor", "Charmander
+       * selection: ...") that assistive tech should be able to announce on
+       * hover or focus. Hiding the whole subtree at the layer level would
+       * silence those.
+       */}
+      <div className={cx("awareness-presence-layer", className)}>
+        {children}
+      </div>
+    </PresenceLayerContext.Provider>
+  );
+};

--- a/packages/awareness/src/components/presence-rendering.test.tsx
+++ b/packages/awareness/src/components/presence-rendering.test.tsx
@@ -1,4 +1,4 @@
-import { act } from "react";
+import { act, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +8,7 @@ import { ActivityIndicator } from "./activity-indicator";
 import { LiveCursor } from "./live-cursor";
 import { PresenceAvatar } from "./presence-avatar";
 import { PresenceBar } from "./presence-bar";
+import { PresenceLayer } from "./presence-layer";
 import { SelectionHighlight } from "./selection-highlight";
 
 const reactActGlobal = globalThis as typeof globalThis & {
@@ -166,6 +167,73 @@ describe("presence components", () => {
 
     expect(html).toContain(`Grace selection: ${"a".repeat(120)}…`);
     expect(html).not.toContain("a".repeat(121));
+  });
+
+  it("translates host-local cursor and selection coordinates by the layer offset", async () => {
+    const user = createUser("1", { name: "Hostie" });
+
+    const HOST_LEFT = 40;
+    const HOST_TOP = 80;
+    // jsdom's `getBoundingClientRect` is hard-coded to 0/0, so override
+    // the host element's per-instance to simulate it sitting at (40, 80).
+    const Harness = (): React.ReactNode => {
+      const hostRef = useRef<HTMLDivElement | null>(null);
+      return (
+        <>
+          <div
+            ref={(el) => {
+              if (!el) return;
+              hostRef.current = el;
+              el.getBoundingClientRect = () =>
+                ({
+                  left: HOST_LEFT,
+                  top: HOST_TOP,
+                  right: HOST_LEFT + 200,
+                  bottom: HOST_TOP + 100,
+                  width: 200,
+                  height: 100,
+                  x: HOST_LEFT,
+                  y: HOST_TOP,
+                  toJSON() {
+                    return {};
+                  },
+                }) as DOMRect;
+            }}
+          />
+          <PresenceLayer host={hostRef}>
+            <LiveCursor point={{ x: 5, y: 7 }} showLabel={false} user={user} />
+            <SelectionHighlight
+              rect={{ x: 10, y: 12, width: 30, height: 18 }}
+              user={user}
+            />
+          </PresenceLayer>
+        </>
+      );
+    };
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    const cursor = container.querySelector(".awareness-live-cursor");
+    const selection = container.querySelector(".awareness-selection-highlight");
+
+    // 5 + 40 = 45, 7 + 80 = 87
+    expect((cursor as HTMLElement).style.transform).toBe(
+      "translate3d(45px, 87px, 0)",
+    );
+    // 10 + 40 = 50, 12 + 80 = 92
+    expect((selection as HTMLElement).style.transform).toBe(
+      "translate3d(50px, 92px, 0)",
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 
   it("hides the initial LiveCursor label after the configured timeout", async () => {

--- a/packages/awareness/src/components/presence-rendering.test.tsx
+++ b/packages/awareness/src/components/presence-rendering.test.tsx
@@ -8,24 +8,9 @@ import { ActivityIndicator } from "./activity-indicator";
 import { LiveCursor } from "./live-cursor";
 import { PresenceAvatar } from "./presence-avatar";
 import { PresenceBar } from "./presence-bar";
-import {
-  PresenceLayer,
-  PresenceLayerContext,
-  type PresenceLayerOffset,
-} from "./presence-layer";
+import { PresenceLayer } from "./presence-layer";
 import { SelectionHighlight } from "./selection-highlight";
-
-// Tests that render `LiveCursor`/`SelectionHighlight` via SSR-style
-// `renderToStaticMarkup` can't go through `<PresenceLayer>` (its layout
-// effect doesn't fire under SSR), so they inject the context offset
-// directly. An identity offset {0, 0} satisfies the layer-required
-// guard without affecting the structural HTML the tests inspect.
-const IDENTITY_OFFSET: PresenceLayerOffset = { left: 0, top: 0 };
-const InTestLayer = ({ children }: { children: React.ReactNode }) => (
-  <PresenceLayerContext.Provider value={IDENTITY_OFFSET}>
-    {children}
-  </PresenceLayerContext.Provider>
-);
+import { InTestLayer } from "./test-utils";
 
 const reactActGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -260,6 +245,48 @@ describe("presence components", () => {
     await act(async () => {
       root.unmount();
     });
+  });
+
+  it("warns once when LiveCursor or SelectionHighlight is rendered without a PresenceLayer", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const user = createUser("1", { name: "Lone" });
+
+    // Rendered without an <InTestLayer> wrapper — both components should
+    // bail out and emit a single dev warning naming themselves. The
+    // dedupe set inside `presence-layer.tsx` is module-scoped so the
+    // second render of the same component must NOT re-warn.
+    const cursorHtml = renderToStaticMarkup(
+      <LiveCursor point={{ x: 0, y: 0 }} user={user} />,
+    );
+    const cursorHtmlAgain = renderToStaticMarkup(
+      <LiveCursor point={{ x: 1, y: 1 }} user={user} />,
+    );
+    const selectionHtml = renderToStaticMarkup(
+      <SelectionHighlight
+        rect={{ x: 0, y: 0, width: 10, height: 10 }}
+        user={user}
+      />,
+    );
+    const selectionHtmlAgain = renderToStaticMarkup(
+      <SelectionHighlight
+        rect={{ x: 0, y: 0, width: 10, height: 10 }}
+        user={user}
+      />,
+    );
+
+    expect(cursorHtml).toBe("");
+    expect(cursorHtmlAgain).toBe("");
+    expect(selectionHtml).toBe("");
+    expect(selectionHtmlAgain).toBe("");
+
+    const messages = warn.mock.calls.map((args) => String(args[0] ?? ""));
+    expect(messages.filter((m) => m.includes("<LiveCursor>"))).toHaveLength(1);
+    expect(
+      messages.filter((m) => m.includes("<SelectionHighlight>")),
+    ).toHaveLength(1);
+    expect(messages[0]).toContain("PresenceLayer");
+
+    warn.mockRestore();
   });
 
   it("hides the initial LiveCursor label after the configured timeout", async () => {

--- a/packages/awareness/src/components/presence-rendering.test.tsx
+++ b/packages/awareness/src/components/presence-rendering.test.tsx
@@ -8,8 +8,24 @@ import { ActivityIndicator } from "./activity-indicator";
 import { LiveCursor } from "./live-cursor";
 import { PresenceAvatar } from "./presence-avatar";
 import { PresenceBar } from "./presence-bar";
-import { PresenceLayer } from "./presence-layer";
+import {
+  PresenceLayer,
+  PresenceLayerContext,
+  type PresenceLayerOffset,
+} from "./presence-layer";
 import { SelectionHighlight } from "./selection-highlight";
+
+// Tests that render `LiveCursor`/`SelectionHighlight` via SSR-style
+// `renderToStaticMarkup` can't go through `<PresenceLayer>` (its layout
+// effect doesn't fire under SSR), so they inject the context offset
+// directly. An identity offset {0, 0} satisfies the layer-required
+// guard without affecting the structural HTML the tests inspect.
+const IDENTITY_OFFSET: PresenceLayerOffset = { left: 0, top: 0 };
+const InTestLayer = ({ children }: { children: React.ReactNode }) => (
+  <PresenceLayerContext.Provider value={IDENTITY_OFFSET}>
+    {children}
+  </PresenceLayerContext.Provider>
+);
 
 const reactActGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -99,15 +115,19 @@ describe("presence components", () => {
     const user = createUser("1", { name: "Grace" });
 
     const cursorHtml = renderToStaticMarkup(
-      <LiveCursor point={{ x: 12, y: 24 }} user={user} />,
+      <InTestLayer>
+        <LiveCursor point={{ x: 12, y: 24 }} user={user} />
+      </InTestLayer>,
     );
     const selectionHtml = renderToStaticMarkup(
-      <SelectionHighlight
-        rect={{ x: 4, y: 8, width: 120, height: 20 }}
-        selectedText="shared note"
-        showLabel
-        user={user}
-      />,
+      <InTestLayer>
+        <SelectionHighlight
+          rect={{ x: 4, y: 8, width: 120, height: 20 }}
+          selectedText="shared note"
+          showLabel
+          user={user}
+        />
+      </InTestLayer>,
     );
 
     expect(cursorHtml).toContain("translate3d(12px, 24px, 0)");
@@ -134,17 +154,21 @@ describe("presence components", () => {
     const user = createUser("1", { name: "Grace" });
 
     const undefinedHtml = renderToStaticMarkup(
-      <SelectionHighlight
-        rect={{ x: 0, y: 0, width: 10, height: 10 }}
-        user={user}
-      />,
+      <InTestLayer>
+        <SelectionHighlight
+          rect={{ x: 0, y: 0, width: 10, height: 10 }}
+          user={user}
+        />
+      </InTestLayer>,
     );
     const emptyHtml = renderToStaticMarkup(
-      <SelectionHighlight
-        rect={{ x: 0, y: 0, width: 10, height: 10 }}
-        selectedText=""
-        user={user}
-      />,
+      <InTestLayer>
+        <SelectionHighlight
+          rect={{ x: 0, y: 0, width: 10, height: 10 }}
+          selectedText=""
+          user={user}
+        />
+      </InTestLayer>,
     );
 
     expect(undefinedHtml).toContain('aria-label="Grace selection"');
@@ -158,11 +182,13 @@ describe("presence components", () => {
     const longText = "a".repeat(200);
 
     const html = renderToStaticMarkup(
-      <SelectionHighlight
-        rect={{ x: 0, y: 0, width: 10, height: 10 }}
-        selectedText={longText}
-        user={user}
-      />,
+      <InTestLayer>
+        <SelectionHighlight
+          rect={{ x: 0, y: 0, width: 10, height: 10 }}
+          selectedText={longText}
+          user={user}
+        />
+      </InTestLayer>,
     );
 
     expect(html).toContain(`Grace selection: ${"a".repeat(120)}…`);
@@ -245,11 +271,13 @@ describe("presence components", () => {
 
     await act(async () => {
       root.render(
-        <LiveCursor
-          labelVisibleMs={100}
-          point={{ x: 12, y: 24 }}
-          user={user}
-        />,
+        <InTestLayer>
+          <LiveCursor
+            labelVisibleMs={100}
+            point={{ x: 12, y: 24 }}
+            user={user}
+          />
+        </InTestLayer>,
       );
     });
 

--- a/packages/awareness/src/components/presence-rendering.test.tsx
+++ b/packages/awareness/src/components/presence-rendering.test.tsx
@@ -232,6 +232,8 @@ describe("presence components", () => {
 
     const cursor = container.querySelector(".awareness-live-cursor");
     const selection = container.querySelector(".awareness-selection-highlight");
+    expect(cursor).toBeInstanceOf(HTMLElement);
+    expect(selection).toBeInstanceOf(HTMLElement);
 
     // 5 + 40 = 45, 7 + 80 = 87
     expect((cursor as HTMLElement).style.transform).toBe(

--- a/packages/awareness/src/components/selection-highlight.tsx
+++ b/packages/awareness/src/components/selection-highlight.tsx
@@ -84,6 +84,10 @@ export const SelectionHighlight = ({
         width: rect.width,
         ...style,
       }}
+      // Hover variant is keyboard-discoverable: focusing the highlight
+      // reveals the user badge via CSS `:focus-visible`. Each visible
+      // selection adds one tab stop — intentional, so screen-reader /
+      // keyboard users can inspect attribution without a pointer.
       tabIndex={isHoverLabel ? 0 : undefined}
     >
       {renderLabel ? (

--- a/packages/awareness/src/components/selection-highlight.tsx
+++ b/packages/awareness/src/components/selection-highlight.tsx
@@ -1,7 +1,10 @@
 import type { CSSProperties, ReactNode } from "react";
 import type { PresenceUser } from "../types/presence";
 import { cx, toUserColorStyle } from "./internal-utils";
-import { usePresenceLayerOffset } from "./presence-layer";
+import {
+  usePresenceLayerOffset,
+  warnMissingPresenceLayerOnce,
+} from "./presence-layer";
 
 export interface HighlightRect {
   readonly x: number;
@@ -52,12 +55,18 @@ export const SelectionHighlight = ({
   const isHoverLabel = showLabel === "hover";
   const renderLabel = showLabel === true || isHoverLabel;
 
-  // When wrapped in a `<PresenceLayer>`, `rect.x/y` are host-local; outside
-  // a layer they stay screen-relative (back-compat for stories and one-off
-  // direct consumers).
+  // `SelectionHighlight` requires a `<PresenceLayer>` ancestor — the
+  // layer owns the host's bounding rect, which is the only sane reference
+  // frame for overlay coordinates. Without one, the highlight would
+  // render at the wrong position (the bug class this API was introduced
+  // to remove), so we render nothing instead.
   const layerOffset = usePresenceLayerOffset();
-  const screenX = layerOffset === null ? rect.x : rect.x + layerOffset.left;
-  const screenY = layerOffset === null ? rect.y : rect.y + layerOffset.top;
+  if (layerOffset === null) {
+    warnMissingPresenceLayerOnce("SelectionHighlight");
+    return null;
+  }
+  const screenX = rect.x + layerOffset.left;
+  const screenY = rect.y + layerOffset.top;
 
   return (
     <div

--- a/packages/awareness/src/components/selection-highlight.tsx
+++ b/packages/awareness/src/components/selection-highlight.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
 import type { PresenceUser } from "../types/presence";
 import { cx, toUserColorStyle } from "./internal-utils";
+import { usePresenceLayerOffset } from "./presence-layer";
 
 export interface HighlightRect {
   readonly x: number;
@@ -51,6 +52,13 @@ export const SelectionHighlight = ({
   const isHoverLabel = showLabel === "hover";
   const renderLabel = showLabel === true || isHoverLabel;
 
+  // When wrapped in a `<PresenceLayer>`, `rect.x/y` are host-local; outside
+  // a layer they stay screen-relative (back-compat for stories and one-off
+  // direct consumers).
+  const layerOffset = usePresenceLayerOffset();
+  const screenX = layerOffset === null ? rect.x : rect.x + layerOffset.left;
+  const screenY = layerOffset === null ? rect.y : rect.y + layerOffset.top;
+
   return (
     <div
       aria-label={getSelectionLabel(user, selectedText)}
@@ -63,7 +71,7 @@ export const SelectionHighlight = ({
       style={{
         ...toUserColorStyle(user.color),
         height: rect.height,
-        transform: `translate3d(${rect.x}px, ${rect.y}px, 0)`,
+        transform: `translate3d(${screenX}px, ${screenY}px, 0)`,
         width: rect.width,
         ...style,
       }}

--- a/packages/awareness/src/components/test-utils.tsx
+++ b/packages/awareness/src/components/test-utils.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import {
+  PresenceLayerContext,
+  type PresenceLayerOffset,
+} from "./presence-layer";
+
+/**
+ * Tests that render `LiveCursor` / `SelectionHighlight` via SSR-style
+ * `renderToStaticMarkup` can't go through `<PresenceLayer>` (its layout
+ * effect doesn't fire under SSR), so they inject the context offset
+ * directly. An identity offset `{0, 0}` satisfies the layer-required
+ * guard without affecting the structural HTML the tests inspect.
+ */
+export const IDENTITY_OFFSET: PresenceLayerOffset = { left: 0, top: 0 };
+
+export const InTestLayer = ({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode => (
+  <PresenceLayerContext.Provider value={IDENTITY_OFFSET}>
+    {children}
+  </PresenceLayerContext.Provider>
+);

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -301,6 +301,7 @@
 .awareness-live-cursor {
   --awareness-live-cursor-label-x: 0px;
   --awareness-live-cursor-label-y: 3px;
+  --awareness-live-cursor-caret-height: 1.25rem;
   font-size: 12px;
   line-height: 1;
   /*
@@ -311,12 +312,42 @@
   @apply absolute top-0 left-0 z-20 inline-flex items-start pointer-events-none will-change-transform;
 }
 
+/*
+ * The caret is centered on the consumer-provided `point.x` rather than
+ * sitting flush-right of it: a real text caret straddles the character
+ * boundary, so we shift the 2px bar left by half its width. Without this,
+ * the caret visually drifts one pixel to the right of where the local
+ * text cursor would sit.
+ */
 .awareness-live-cursor__caret {
   background: var(--awareness-user-color);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--awareness-user-color) 34%, transparent),
-    0 5px 14px color-mix(in srgb, var(--awareness-user-color) 30%, transparent);
-  @apply relative block w-[2px] h-5 rounded-full;
+  /*
+   * Soft directional shadow only (no all-around halo). The previous
+   * 1px ring on every side rendered as a stubby "flag" at the top edge
+   * of the bar; the drop shadow below gives depth without the halo.
+   */
+  box-shadow: 0 2px 6px
+    color-mix(in srgb, var(--awareness-user-color) 28%, transparent);
+  height: var(--awareness-live-cursor-caret-height);
+  margin-left: -1px;
+  @apply relative block w-[2px] rounded-[1px];
+}
+
+/*
+ * Small "flag" chip at the top of the caret — a 5×5 rounded square that
+ * matches the user color. It marks the caret with a consistent visual
+ * anchor (the same shape consumers see on hover labels), without
+ * relying on the always-on name label to communicate presence.
+ */
+.awareness-live-cursor__caret::before {
+  content: "";
+  background: var(--awareness-user-color);
+  border-radius: 2px 2px 2px 0;
+  height: 5px;
+  width: 5px;
+  inset-block-start: -3px;
+  inset-inline-start: -1.5px;
+  @apply absolute pointer-events-none;
 }
 
 .awareness-live-cursor__label {
@@ -331,18 +362,63 @@
   transition:
     opacity 160ms ease,
     transform 160ms ease;
-  box-shadow: var(--shadow-awareness);
+  box-shadow: var(--shadow-awareness-close);
   /*
    * Soft dark shadow gives white text a readable edge over pale user
    * colors (yellow/pastel) without relying on theme-dependent contrast.
    */
   text-shadow: 0 1px 1px color-mix(in srgb, black 38%, transparent);
-  @apply absolute bottom-full left-0 mb-[2px] max-w-64 overflow-hidden px-2 py-[3px] rounded-md text-white font-awareness text-xs tracking-normal leading-[1.2] opacity-0 text-ellipsis whitespace-nowrap shadow-awareness;
+  @apply absolute bottom-full left-0 mb-[3px] max-w-64 overflow-hidden px-[7px] py-[3px] rounded-md rounded-bl-none text-white font-awareness text-[11px] tracking-normal leading-[1.2] opacity-0 text-ellipsis whitespace-nowrap;
 }
 
 .awareness-live-cursor--label-visible .awareness-live-cursor__label {
   --awareness-live-cursor-label-y: 0px;
   @apply opacity-100;
+}
+
+/*
+ * Hoverable cursor: the label is rendered but invisible until the caret
+ * is hovered or keyboard-focused. Keeps the editor surface low-noise
+ * while still letting collaborators inspect attribution on demand — the
+ * same opt-in pattern used by `.awareness-selection-highlight--hoverable`.
+ */
+.awareness-live-cursor--hoverable {
+  pointer-events: auto;
+}
+
+/*
+ * The caret bar is only 2px wide — too small to comfortably hit with a
+ * pointer or focus ring. Pad the hit/focus area to ~16×24 via the
+ * caret's ::after so the underlying click target stays accessible.
+ */
+.awareness-live-cursor--hoverable .awareness-live-cursor__caret::after {
+  content: "";
+  inset-block: -4px;
+  inset-inline: -8px;
+  @apply absolute pointer-events-auto;
+}
+
+.awareness-live-cursor--hoverable .awareness-live-cursor__label {
+  --awareness-live-cursor-label-y: 0px;
+  opacity: 0;
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.awareness-live-cursor--hoverable:hover .awareness-live-cursor__label,
+.awareness-live-cursor--hoverable:focus-visible .awareness-live-cursor__label {
+  opacity: 1;
+}
+
+.awareness-live-cursor--hoverable:focus-visible {
+  outline: none;
+}
+
+.awareness-live-cursor--hoverable:focus-visible .awareness-live-cursor__caret {
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, CanvasText 60%, transparent),
+    0 2px 6px color-mix(in srgb, var(--awareness-user-color) 28%, transparent);
 }
 
 .awareness-selection-highlight {
@@ -357,32 +433,33 @@
    * the editor surface beneath, never the rest of the viewport stack.
    */
   isolation: isolate;
-  @apply absolute top-0 left-0 z-10 box-border rounded-[3px] pointer-events-none;
+  @apply absolute top-0 left-0 z-10 box-border rounded-[4px] pointer-events-none;
 }
 
+/*
+ * Soft, evenly-tinted fill — no hard left border or hard 1px outline.
+ * The previous `border-left: 2px solid` + `inset 0 0 0 1px` ring produced
+ * a blocky/highlighter-marker look that fought the prose underneath; a
+ * flat low-opacity tint matches what users expect from native browser
+ * selection while still keeping a per-user color.
+ */
 .awareness-selection-highlight::before {
   content: "";
-  inset: 2px 0;
-  border-left: 2px solid var(--awareness-user-color);
-  background: linear-gradient(
-    90deg,
-    color-mix(in srgb, var(--awareness-user-color) 30%, transparent),
-    color-mix(in srgb, var(--awareness-user-color) 18%, transparent)
-  );
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--awareness-user-color) 22%, transparent);
+  inset: 1px 0;
+  background: color-mix(in srgb, var(--awareness-user-color) 26%, transparent);
   /*
    * Multiply blend keeps overlaid text readable: the highlight darkens
    * its background but the glyphs beneath retain their original contrast.
    * Falls back gracefully on browsers that don't support it.
    */
   mix-blend-mode: multiply;
-  @apply absolute rounded-[3px];
+  @apply absolute inset-0 rounded-[4px];
 }
 
 @media (prefers-color-scheme: dark) {
   .awareness-selection-highlight::before {
     /* Screen brightens on dark surfaces, the inverse of multiply on light. */
+    background: color-mix(in srgb, var(--awareness-user-color) 40%, transparent);
     mix-blend-mode: screen;
   }
 }
@@ -397,7 +474,7 @@
   );
   box-shadow: var(--shadow-awareness-close);
   text-shadow: 0 1px 1px color-mix(in srgb, black 38%, transparent);
-  @apply absolute bottom-full left-0 mb-[2px] max-w-56 overflow-hidden px-[7px] py-[3px] rounded-md text-white font-awareness text-[11px] tracking-normal leading-[1.2] text-ellipsis whitespace-nowrap;
+  @apply absolute bottom-full left-0 mb-[3px] max-w-56 overflow-hidden px-[7px] py-[3px] rounded-md rounded-bl-none text-white font-awareness text-[11px] tracking-normal leading-[1.2] text-ellipsis whitespace-nowrap;
 }
 
 .awareness-selection-highlight--hoverable {

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -737,4 +737,14 @@
     outline: 2px solid Highlight;
     outline-offset: 2px;
   }
+
+  /*
+   * Same fix for the live cursor's hover/focus affordance: the
+   * `color-mix(...CanvasText...)` box-shadow used as a focus ring above
+   * is suppressed under forced colors, so reinstate a real outline.
+   */
+  .awareness-live-cursor--hoverable:focus-visible {
+    outline: 2px solid CanvasText;
+    outline-offset: 2px;
+  }
 }

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -298,6 +298,29 @@
   @apply text-awareness-muted font-awareness text-[13px] leading-[1.4];
 }
 
+/*
+ * Fixed-position overlay aligned to a host element (textarea, editor
+ * surface, etc.). Children inside use host-local coordinates and the
+ * layer is responsible for translating them into screen space — see
+ * `PresenceLayer` in components/presence-layer.tsx.
+ *
+ * `pointer-events: none` so the layer never steals input from the host;
+ * hoverable cursor/selection labels override this with `auto` on
+ * themselves.
+ */
+.awareness-presence-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+  /*
+   * Layout/style containment lets the browser skip parts of the cascade
+   * when nothing in the layer changes, which matters because the layer
+   * re-renders on every host scroll/resize event.
+   */
+  contain: layout style;
+}
+
 .awareness-live-cursor {
   --awareness-live-cursor-label-x: 0px;
   --awareness-live-cursor-label-y: 3px;

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -445,7 +445,12 @@
  */
 .awareness-selection-highlight::before {
   content: "";
-  inset: 1px 0;
+  /*
+   * 1px breathing room top and bottom keeps stacked highlights from
+   * touching on adjacent lines without visibly shrinking the fill.
+   */
+  inset-block: 1px;
+  inset-inline: 0;
   background: color-mix(in srgb, var(--awareness-user-color) 26%, transparent);
   /*
    * Multiply blend keeps overlaid text readable: the highlight darkens
@@ -453,7 +458,7 @@
    * Falls back gracefully on browsers that don't support it.
    */
   mix-blend-mode: multiply;
-  @apply absolute inset-0 rounded-[4px];
+  @apply absolute rounded-[4px];
 }
 
 @media (prefers-color-scheme: dark) {

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -20,8 +20,17 @@
     sans-serif;
   --color-awareness-surface: color-mix(in srgb, Canvas 96%, CanvasText 4%);
   --color-awareness-border: color-mix(in srgb, CanvasText 16%, transparent);
-  --color-awareness-muted: color-mix(in srgb, CanvasText 56%, transparent);
-  --color-awareness-text: color-mix(in srgb, CanvasText 86%, transparent);
+  /*
+   * Derive secondary/primary text from `currentColor` so the package
+   * adapts to whatever text color the consuming context sets — not just
+   * the OS-driven `CanvasText`. Storybook stories that explicitly use
+   * `color: CanvasText` on their surfaces still render unchanged
+   * (currentColor = CanvasText there); apps with their own theme
+   * (e.g. dark-slate panels with `text-slate-100`) get readable
+   * contrast instead of OS-black-on-dark-slate.
+   */
+  --color-awareness-muted: color-mix(in srgb, currentColor 56%, transparent);
+  --color-awareness-text: color-mix(in srgb, currentColor 86%, transparent);
   --color-awareness-overflow-bg: color-mix(in srgb, Canvas 82%, CanvasText 18%);
   --color-awareness-status-active: #22c55e;
   --color-awareness-status-idle: #f59e0b;

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -214,10 +214,16 @@
     opacity 140ms ease,
     transform 140ms ease;
   /*
-   * Cap so the tooltip never overflows past the viewport when an avatar
-   * sits near a column edge. The name stays on one line; the meta line
-   * is allowed to wrap (see __tooltip-meta below).
+   * Size to the natural content width but never overflow the viewport.
+   * Without `inline-size: max-content` the absolutely-positioned tooltip
+   * inherits a min-content width from its parent layout — combined with
+   * `truncate` on the name (intrinsic min-content = 0) and
+   * `overflow-wrap: anywhere` on the meta line, the column collapses to
+   * a single character and the meta text wraps vertically. Pinning to
+   * `max-content` lets the tooltip lay out at its natural width up to
+   * the cap below.
    */
+  inline-size: max-content;
   max-inline-size: min(14rem, calc(100vw - 1rem));
   @apply absolute bottom-full mb-2 z-20 grid gap-0.5 rounded-md px-2 py-1.5 text-awareness-text font-awareness opacity-0;
 }

--- a/packages/awareness/src/index.ts
+++ b/packages/awareness/src/index.ts
@@ -42,6 +42,7 @@ export {
   PresenceBar,
   type PresenceBarProps,
   PresenceLayer,
+  PresenceLayerContext,
   type PresenceLayerOffset,
   type PresenceLayerProps,
   SelectionHighlight,

--- a/packages/awareness/src/index.ts
+++ b/packages/awareness/src/index.ts
@@ -41,8 +41,12 @@ export {
   type PresenceAvatarSize,
   PresenceBar,
   type PresenceBarProps,
+  PresenceLayer,
+  type PresenceLayerOffset,
+  type PresenceLayerProps,
   SelectionHighlight,
   type SelectionHighlightProps,
+  usePresenceLayerOffset,
 } from "./components";
 export {
   type PeerCursor,

--- a/packages/awareness/src/stories/FullCollaboration.stories.tsx
+++ b/packages/awareness/src/stories/FullCollaboration.stories.tsx
@@ -7,6 +7,7 @@ import { BlockActivityIndicator } from "../components/block-activity-indicator";
 import { ConnectionIndicator } from "../components/connection-indicator";
 import { LiveCursor } from "../components/live-cursor";
 import { PresenceBar } from "../components/presence-bar";
+import { PresenceLayer } from "../components/presence-layer";
 import { SelectionHighlight } from "../components/selection-highlight";
 import type { PresenceUser } from "../types/presence";
 import {
@@ -91,44 +92,61 @@ type Story = StoryObj<typeof meta>;
 export const TrainerHuddle: Story = {
   render: () => (
     <CollaborationSurface>
-      <div style={overlayLayerStyle}>
-        <div style={topRailStyle}>
-          <PresenceBar maxVisible={5} users={collaborators} />
-          <ConnectionIndicator hideWhenConnected={false} state="reconnecting" />
-        </div>
-        <SelectionHighlight
-          rect={{ x: 36, y: 36, width: 172, height: 24 }}
-          selectedText="Collaborative editing keeps"
-          showLabel
-          user={inBlock(charmander, SHARED_BLOCK_ID)}
-        />
-        <LiveCursor
-          labelVisibleMs={60_000}
-          point={{ x: 184, y: 130 }}
-          user={inBlock(pikachu, SHARED_BLOCK_ID)}
-          viewport="none"
-        />
-        <LiveCursor
-          labelVisibleMs={60_000}
-          point={{ x: 96, y: 184 }}
-          showLabel={false}
-          user={inBlock(bulbasaur, SHARED_BLOCK_ID)}
-          viewport="none"
-        />
-        <div style={blockBadgePositionStyle}>
-          <BlockActivityIndicator
-            blockId={SHARED_BLOCK_ID}
-            users={blockUsers}
-          />
-        </div>
-      </div>
-      <div style={activityFootnoteStyle}>
-        <ActivityIndicator
-          activities={recentActivities}
-          maxItems={3}
-          users={usersById}
-        />
-      </div>
+      {(surfaceRef) => (
+        <>
+          {/* Non-overlay UI (presence rail, block badge) keeps the
+           *  surface as its positioning context — they intentionally use
+           *  position:absolute relative to the surface div. */}
+          <div style={overlayLayerStyle}>
+            <div style={topRailStyle}>
+              <PresenceBar maxVisible={5} users={collaborators} />
+              <ConnectionIndicator
+                hideWhenConnected={false}
+                state="reconnecting"
+              />
+            </div>
+            <div style={blockBadgePositionStyle}>
+              <BlockActivityIndicator
+                blockId={SHARED_BLOCK_ID}
+                users={blockUsers}
+              />
+            </div>
+          </div>
+          {/* Cursors and selections go inside the PresenceLayer so their
+           *  host-local coordinates get translated against the surface.
+           *  y≈134 lands on paragraph 1 line 1 inside the demo surface
+           *  (chrome ~37px + page-content padding 26px push the prose
+           *  down from the surface's top-left). */}
+          <PresenceLayer host={surfaceRef}>
+            <SelectionHighlight
+              rect={{ x: 32, y: 134, width: 172, height: 24 }}
+              selectedText="Collaborative editing keeps"
+              showLabel
+              user={inBlock(charmander, SHARED_BLOCK_ID)}
+            />
+            <LiveCursor
+              labelVisibleMs={60_000}
+              point={{ x: 208, y: 134 }}
+              user={inBlock(pikachu, SHARED_BLOCK_ID)}
+              viewport="none"
+            />
+            <LiveCursor
+              labelVisibleMs={60_000}
+              point={{ x: 96, y: 196 }}
+              showLabel={false}
+              user={inBlock(bulbasaur, SHARED_BLOCK_ID)}
+              viewport="none"
+            />
+          </PresenceLayer>
+          <div style={activityFootnoteStyle}>
+            <ActivityIndicator
+              activities={recentActivities}
+              maxItems={3}
+              users={usersById}
+            />
+          </div>
+        </>
+      )}
     </CollaborationSurface>
   ),
   play: async ({ canvas }) => {
@@ -178,27 +196,33 @@ export const SoloEditor: Story = {
     };
     return (
       <CollaborationSurface>
-        <div style={overlayLayerStyle}>
-          <div style={topRailStyle}>
-            <PresenceBar
-              maxVisible={5}
-              users={[lonelyEditor, { ...pikachu, status: "offline" }]}
-            />
-            <ConnectionIndicator state="connected" />
-          </div>
-          <LiveCursor
-            labelVisibleMs={60_000}
-            point={{ x: 220, y: 118 }}
-            user={lonelyEditor}
-            viewport="none"
-          />
-          <div style={blockBadgePositionStyle}>
-            <BlockActivityIndicator
-              blockId={SHARED_BLOCK_ID}
-              users={[lonelyEditor]}
-            />
-          </div>
-        </div>
+        {(surfaceRef) => (
+          <>
+            <div style={overlayLayerStyle}>
+              <div style={topRailStyle}>
+                <PresenceBar
+                  maxVisible={5}
+                  users={[lonelyEditor, { ...pikachu, status: "offline" }]}
+                />
+                <ConnectionIndicator state="connected" />
+              </div>
+              <div style={blockBadgePositionStyle}>
+                <BlockActivityIndicator
+                  blockId={SHARED_BLOCK_ID}
+                  users={[lonelyEditor]}
+                />
+              </div>
+            </div>
+            <PresenceLayer host={surfaceRef}>
+              <LiveCursor
+                labelVisibleMs={60_000}
+                point={{ x: 220, y: 134 }}
+                user={lonelyEditor}
+                viewport="none"
+              />
+            </PresenceLayer>
+          </>
+        )}
       </CollaborationSurface>
     );
   },

--- a/packages/awareness/src/stories/LiveCursor.stories.tsx
+++ b/packages/awareness/src/stories/LiveCursor.stories.tsx
@@ -60,6 +60,38 @@ export const CursorOnly: Story = {
   },
 };
 
+// Design §5.3: "Hover reveals user badge" — same opt-in pattern that
+// SelectionHighlight uses, applied to the caret. The label is rendered into
+// the DOM but hidden (opacity:0) until pointer hover or keyboard focus.
+//
+// As with the selection variant we assert the structural wiring (hoverable
+// class, tabindex, label rendered but hidden by default) rather than the
+// post-:hover computed style: synthetic hover events don't reliably trigger
+// the CSS `:hover` pseudo-class across test browsers.
+export const HoverableLabel: Story = {
+  args: {
+    point: { x: 36, y: 94 },
+    showLabel: "hover",
+    user: bulbasaur,
+  },
+  play: async ({ canvas }) => {
+    const cursor = canvas.getByRole("img", { name: "Bulbasaur cursor" });
+
+    await expect(cursor).toHaveClass("awareness-live-cursor--hoverable");
+    await expect(cursor).toHaveAttribute("tabindex", "0");
+    await expect(cursor).not.toHaveClass(
+      "awareness-live-cursor--label-visible",
+    );
+
+    const label = canvas.getByText("Bulbasaur");
+    await expect(label).toBeInTheDocument();
+    await expect(label).not.toBeVisible();
+
+    cursor.focus();
+    await expect(cursor).toHaveFocus();
+  },
+};
+
 export const AutoHiddenLabel: Story = {
   args: {
     labelVisibleMs: 60,

--- a/packages/awareness/src/stories/LiveCursor.stories.tsx
+++ b/packages/awareness/src/stories/LiveCursor.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, waitFor } from "storybook/test";
 
 import { LiveCursor } from "../components/live-cursor";
+import { PresenceLayer } from "../components/presence-layer";
 import { bulbasaur, charmander, pikachu } from "./awareness-fixtures";
 import { CollaborationSurface } from "./story-layout";
 
@@ -12,14 +13,26 @@ const meta = {
   parameters: {
     layout: "fullscreen",
   },
+  // Points are host-local (surface-card relative). y≈134 lands the caret
+  // on paragraph 1 line 1 inside the demo surface; the chrome bar (~37px)
+  // and page-content padding-top (26px) push the prose down from the
+  // surface's top-left, which is the layer's reference point.
   args: {
     labelVisibleMs: 60_000,
-    point: { x: 36, y: 94 },
+    point: { x: 36, y: 134 },
     user: bulbasaur,
   },
+  // The render function uses CollaborationSurface's render-prop form so
+  // it can hand the surface ref to a `<PresenceLayer>`, which is now
+  // required by `LiveCursor` (the layer translates host-local point
+  // coordinates into screen space).
   render: (args) => (
     <CollaborationSurface>
-      <LiveCursor {...args} />
+      {(surfaceRef) => (
+        <PresenceLayer host={surfaceRef}>
+          <LiveCursor {...args} />
+        </PresenceLayer>
+      )}
     </CollaborationSurface>
   ),
 } satisfies Meta<typeof LiveCursor>;
@@ -29,32 +42,33 @@ type Story = StoryObj<typeof meta>;
 
 export const LabeledCursor: Story = {
   play: async ({ canvas }) => {
-    const cursor = canvas.getByRole("img", { name: "Bulbasaur cursor" });
+    // PresenceLayer's layout effect runs after first commit, so the
+    // overlay only appears in the second render — wait for it.
+    const cursor = await canvas.findByRole("img", {
+      name: "Bulbasaur cursor",
+    });
 
     await expect(cursor).toBeVisible();
     await expect(cursor).toHaveClass("awareness-live-cursor--label-visible");
-    await expect(cursor.getAttribute("style")).toContain(
-      "translate3d(36px, 94px, 0px)",
-    );
+    // Skip a strict transform assertion: the cursor's translate3d is now
+    // host-rect-relative, which depends on viewport layout in a way that
+    // makes hard-coded pixel values brittle.
     await expect(canvas.getByText("Bulbasaur")).toBeVisible();
   },
 };
 
 export const CursorOnly: Story = {
   args: {
-    point: { x: 184, y: 130 },
+    point: { x: 184, y: 134 },
     showLabel: false,
     user: pikachu,
   },
   play: async ({ canvas }) => {
-    const cursor = canvas.getByRole("img", { name: "Pikachu cursor" });
+    const cursor = await canvas.findByRole("img", { name: "Pikachu cursor" });
 
     await expect(cursor).toBeVisible();
     await expect(cursor).not.toHaveClass(
       "awareness-live-cursor--label-visible",
-    );
-    await expect(cursor.getAttribute("style")).toContain(
-      "translate3d(184px, 130px, 0px)",
     );
     await expect(canvas.queryByText("Pikachu")).not.toBeInTheDocument();
   },
@@ -70,12 +84,14 @@ export const CursorOnly: Story = {
 // the CSS `:hover` pseudo-class across test browsers.
 export const HoverableLabel: Story = {
   args: {
-    point: { x: 36, y: 94 },
+    point: { x: 36, y: 134 },
     showLabel: "hover",
     user: bulbasaur,
   },
   play: async ({ canvas }) => {
-    const cursor = canvas.getByRole("img", { name: "Bulbasaur cursor" });
+    const cursor = await canvas.findByRole("img", {
+      name: "Bulbasaur cursor",
+    });
 
     await expect(cursor).toHaveClass("awareness-live-cursor--hoverable");
     await expect(cursor).toHaveAttribute("tabindex", "0");
@@ -95,11 +111,13 @@ export const HoverableLabel: Story = {
 export const AutoHiddenLabel: Story = {
   args: {
     labelVisibleMs: 60,
-    point: { x: 36, y: 94 },
+    point: { x: 36, y: 134 },
     user: bulbasaur,
   },
   play: async ({ canvas }) => {
-    const cursor = canvas.getByRole("img", { name: "Bulbasaur cursor" });
+    const cursor = await canvas.findByRole("img", {
+      name: "Bulbasaur cursor",
+    });
 
     await expect(cursor).toHaveClass("awareness-live-cursor--label-visible");
     await waitFor(
@@ -116,26 +134,30 @@ export const AutoHiddenLabel: Story = {
 export const MultipleCursors: Story = {
   render: () => (
     <CollaborationSurface>
-      <LiveCursor
-        labelVisibleMs={60_000}
-        point={{ x: 160, y: 58 }}
-        showLabel={false}
-        user={pikachu}
-      />
-      <LiveCursor
-        labelVisibleMs={60_000}
-        point={{ x: 176, y: 130 }}
-        showLabel={false}
-        user={charmander}
-      />
+      {(surfaceRef) => (
+        <PresenceLayer host={surfaceRef}>
+          <LiveCursor
+            labelVisibleMs={60_000}
+            point={{ x: 160, y: 95 }}
+            showLabel={false}
+            user={pikachu}
+          />
+          <LiveCursor
+            labelVisibleMs={60_000}
+            point={{ x: 176, y: 134 }}
+            showLabel={false}
+            user={charmander}
+          />
+        </PresenceLayer>
+      )}
     </CollaborationSurface>
   ),
   play: async ({ canvas }) => {
     await expect(
-      canvas.getByRole("img", { name: "Pikachu cursor" }),
+      await canvas.findByRole("img", { name: "Pikachu cursor" }),
     ).toBeVisible();
     await expect(
-      canvas.getByRole("img", { name: "Charmander cursor" }),
+      await canvas.findByRole("img", { name: "Charmander cursor" }),
     ).toBeVisible();
     await expect(canvas.queryByText("Pikachu")).not.toBeInTheDocument();
     await expect(canvas.queryByText("Charmander")).not.toBeInTheDocument();
@@ -143,33 +165,38 @@ export const MultipleCursors: Story = {
 };
 
 // Design §7: "Off-screen cursors not rendered."
-// Two cursors share the same viewport — one inside, one outside — to make the
-// culling decision visible side-by-side.
+// One cursor sits inside the visible window, the other is parked far
+// off-screen via a host-local point that — once the layer adds the
+// surface offset — lands well outside `window.innerWidth/innerHeight`.
+// Default `viewport="window"` culls the off-screen one.
 export const OffScreenCulled: Story = {
   render: () => (
     <CollaborationSurface>
-      <LiveCursor
-        cullMargin={0}
-        labelVisibleMs={60_000}
-        point={{ x: 60, y: 80 }}
-        user={pikachu}
-        viewport={{ x: 0, y: 0, width: 240, height: 200 }}
-      />
-      <LiveCursor
-        cullMargin={0}
-        labelVisibleMs={60_000}
-        point={{ x: 9999, y: 9999 }}
-        user={charmander}
-        viewport={{ x: 0, y: 0, width: 240, height: 200 }}
-      />
+      {(surfaceRef) => (
+        <PresenceLayer host={surfaceRef}>
+          <LiveCursor
+            cullMargin={0}
+            labelVisibleMs={60_000}
+            point={{ x: 60, y: 95 }}
+            user={pikachu}
+          />
+          <LiveCursor
+            cullMargin={0}
+            labelVisibleMs={60_000}
+            point={{ x: 99999, y: 99999 }}
+            user={charmander}
+          />
+        </PresenceLayer>
+      )}
     </CollaborationSurface>
   ),
   play: async ({ canvas }) => {
     await expect(
-      canvas.getByRole("img", { name: "Pikachu cursor" }),
+      await canvas.findByRole("img", { name: "Pikachu cursor" }),
     ).toBeVisible();
-    // The charmander cursor is well outside the bounded viewport and the
-    // component returns null — it should not be in the DOM at all.
+    // The charmander cursor's screen-translated point sits well outside
+    // the window and the component returns null — it should not be in
+    // the DOM at all.
     await expect(
       canvas.queryByRole("img", { name: "Charmander cursor" }),
     ).not.toBeInTheDocument();
@@ -187,7 +214,7 @@ export const CullingDisabled: Story = {
   },
   play: async ({ canvas }) => {
     await expect(
-      canvas.getByRole("img", { name: "Pikachu cursor" }),
+      await canvas.findByRole("img", { name: "Pikachu cursor" }),
     ).toBeVisible();
   },
 };

--- a/packages/awareness/src/stories/PresenceLayer.stories.tsx
+++ b/packages/awareness/src/stories/PresenceLayer.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useRef } from "react";
+import { expect } from "storybook/test";
+
+import { LiveCursor } from "../components/live-cursor";
+import { PresenceLayer } from "../components/presence-layer";
+import { SelectionHighlight } from "../components/selection-highlight";
+import { bulbasaur, charmander } from "./awareness-fixtures";
+import { StoryShowcase } from "./story-layout";
+
+/**
+ * `PresenceLayer` wraps the awareness overlay components and translates
+ * their host-local coordinates into screen space, so consumers no longer
+ * have to wire `getBoundingClientRect()` + scroll/resize listeners
+ * themselves. Children pass coordinates relative to the host's top-left
+ * (post host scroll) and the layer adds the host rect on render.
+ */
+// Loose typing (no `Meta<typeof PresenceLayer>`) because the story
+// renders its own scene rather than spreading args into PresenceLayer —
+// the layer requires a `host` ref that only makes sense to construct
+// inside the render function.
+const meta = {
+  title: "Awareness/PresenceLayer",
+  component: PresenceLayer,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Renders a fake editor card and anchors a cursor + selection to its
+// inner text area via `<PresenceLayer host={...}>`. The point of the
+// story is to demonstrate that the consumer only needs host-local
+// coordinates — no manual `getBoundingClientRect()` math.
+const HostedOverlays = () => {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <StoryShowcase
+      eyebrow="PresenceLayer"
+      subtitle="LiveCursor and SelectionHighlight inside a PresenceLayer use coordinates relative to the host element. The layer handles screen-space translation."
+      title="Anchored to a host element"
+    >
+      <div
+        ref={hostRef}
+        style={{
+          width: "min(520px, calc(100vw - 48px))",
+          minHeight: 180,
+          padding: "20px 24px",
+          border: "1px solid color-mix(in srgb, CanvasText 12%, transparent)",
+          borderRadius: 12,
+          background: "Canvas",
+          fontFamily: "ui-monospace, SFMono-Regular, monospace",
+          fontSize: 14,
+          lineHeight: 1.7,
+          color: "CanvasText",
+          position: "relative",
+        }}
+      >
+        Each peer's caret and selection lives in a fixed-position layer anchored
+        to this card. Resize the window or scroll the story — the overlays
+        follow because the layer tracks the host's bounding rect for you.
+      </div>
+      <PresenceLayer host={hostRef}>
+        <LiveCursor
+          point={{ x: 24, y: 26 }}
+          showLabel={false}
+          user={bulbasaur}
+        />
+        <SelectionHighlight
+          rect={{ x: 24, y: 60, width: 220, height: 22 }}
+          showLabel="hover"
+          user={charmander}
+        />
+      </PresenceLayer>
+    </StoryShowcase>
+  );
+};
+
+// `host` is required by PresenceLayer's prop type, so the type system
+// insists on `args.host` even though the story's `render` ignores args
+// entirely. A noop ref placeholder satisfies the contract.
+const NOOP_HOST_REF = { current: null };
+
+export const HostedToTextarea: Story = {
+  args: { host: NOOP_HOST_REF },
+  render: () => <HostedOverlays />,
+  play: async ({ canvas }) => {
+    // PresenceLayer renders null until its layout effect measures the
+    // host and schedules a re-render with the offset, so use the async
+    // `findBy*` queries to wait for the second commit.
+    const cursor = await canvas.findByRole("img", {
+      name: "Bulbasaur cursor",
+    });
+    const selection = await canvas.findByRole("img", {
+      name: /Charmander selection/,
+    });
+
+    // We don't assert exact pixel positions because the host's bounding
+    // rect depends on viewport layout — the contract under test is that
+    // the layer renders its children once the host has been measured.
+    await expect(cursor).toBeVisible();
+    await expect(selection).toBeInTheDocument();
+
+    // The hover-label selection is rendered with its hover wiring intact.
+    await expect(selection).toHaveClass(
+      "awareness-selection-highlight--hoverable",
+    );
+  },
+};

--- a/packages/awareness/src/stories/PresenceLayer.stories.tsx
+++ b/packages/awareness/src/stories/PresenceLayer.stories.tsx
@@ -15,13 +15,14 @@ import { StoryShowcase } from "./story-layout";
  * themselves. Children pass coordinates relative to the host's top-left
  * (post host scroll) and the layer adds the host rect on render.
  */
-// Loose typing (no `Meta<typeof PresenceLayer>`) because the story
-// renders its own scene rather than spreading args into PresenceLayer —
-// the layer requires a `host` ref that only makes sense to construct
-// inside the render function.
+// `component: PresenceLayer` is intentionally omitted here: the layer
+// requires a `host` ref which can only be constructed inside the render
+// function, and pinning the meta to the component would force every
+// story to supply a placeholder `host` in `args` just to satisfy the
+// type contract. The story still appears under the right title and
+// renders the layer in the docs page below.
 const meta = {
   title: "Awareness/PresenceLayer",
-  component: PresenceLayer,
   tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
@@ -79,13 +80,7 @@ const HostedOverlays = () => {
   );
 };
 
-// `host` is required by PresenceLayer's prop type, so the type system
-// insists on `args.host` even though the story's `render` ignores args
-// entirely. A noop ref placeholder satisfies the contract.
-const NOOP_HOST_REF = { current: null };
-
 export const HostedToTextarea: Story = {
-  args: { host: NOOP_HOST_REF },
   render: () => <HostedOverlays />,
   play: async ({ canvas }) => {
     // PresenceLayer renders null until its layout effect measures the

--- a/packages/awareness/src/stories/SelectionHighlight.stories.tsx
+++ b/packages/awareness/src/stories/SelectionHighlight.stories.tsx
@@ -2,27 +2,32 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { CSSProperties } from "react";
 import { expect } from "storybook/test";
 
+import { PresenceLayer } from "../components/presence-layer";
 import { SelectionHighlight } from "../components/selection-highlight";
 import { charmander, pikachu } from "./awareness-fixtures";
 import { CollaborationSurface } from "./story-layout";
 
+// Coordinates are host-local (surface-card relative). The selection rects
+// below land on paragraph 1 line 1 — "Collaborative editing keeps each
+// trainer visible…" — which sits at y≈134 inside the surface (chrome ~37px
+// + page-content padding-top 26px + docMeta + heading + grid gaps).
 const focusSelection = {
-  rect: { x: 36, y: 36, width: 172, height: 24 },
+  rect: { x: 32, y: 134, width: 172, height: 24 },
   text: "Collaborative editing keeps",
 } as const;
 
 const inlineSelection = {
-  rect: { x: 36, y: 36, width: 96, height: 24 },
+  rect: { x: 32, y: 134, width: 96, height: 24 },
   text: "Collaborative",
 } as const;
 
 const firstLineSelection = {
-  rect: { x: 36, y: 36, width: 172, height: 24 },
+  rect: { x: 32, y: 134, width: 172, height: 24 },
   text: "Collaborative editing keeps",
 } as const;
 
 const overlappingFirstLineSelection = {
-  rect: { x: 126, y: 36, width: 82, height: 24 },
+  rect: { x: 126, y: 134, width: 82, height: 24 },
   text: "editing keeps",
 } as const;
 
@@ -43,9 +48,15 @@ const meta = {
     showLabel: true,
     user: charmander,
   },
+  // SelectionHighlight requires a `<PresenceLayer>` ancestor — the
+  // layer translates host-local rect coordinates into screen space.
   render: (args) => (
     <CollaborationSurface>
-      <SelectionHighlight {...args} />
+      {(surfaceRef) => (
+        <PresenceLayer host={surfaceRef}>
+          <SelectionHighlight {...args} />
+        </PresenceLayer>
+      )}
     </CollaborationSurface>
   ),
 } satisfies Meta<typeof SelectionHighlight>;
@@ -55,15 +66,17 @@ type Story = StoryObj<typeof meta>;
 
 export const LabeledSelection: Story = {
   play: async ({ canvas }) => {
-    const selection = canvas.getByRole("img", {
+    // PresenceLayer renders its children only after measuring the host,
+    // so use the async `findBy*` queries to wait for the second commit.
+    const selection = await canvas.findByRole("img", {
       name: `Charmander selection: ${focusSelection.text}`,
     });
 
     await expect(selection).toBeVisible();
     await expect(selection).toHaveStyle({ height: "24px", width: "172px" });
-    await expect(selection.getAttribute("style")).toContain(
-      "translate3d(36px, 36px, 0px)",
-    );
+    // No strict transform assertion — the rect's translate3d is now
+    // host-rect-relative, which depends on viewport layout in a way that
+    // makes hard-coded pixel values brittle.
     await expect(canvas.getByText("Charmander")).toBeVisible();
   },
 };
@@ -76,15 +89,12 @@ export const InlineSelection: Story = {
     user: pikachu,
   },
   play: async ({ canvas }) => {
-    const selection = canvas.getByRole("img", {
+    const selection = await canvas.findByRole("img", {
       name: `Pikachu selection: ${inlineSelection.text}`,
     });
 
     await expect(selection).toBeVisible();
     await expect(selection).toHaveStyle({ height: "24px", width: "96px" });
-    await expect(selection.getAttribute("style")).toContain(
-      "translate3d(36px, 36px, 0px)",
-    );
     await expect(canvas.queryByText("Pikachu")).not.toBeInTheDocument();
   },
 };
@@ -105,7 +115,7 @@ export const HoverableLabel: Story = {
     selectedText: focusSelection.text,
   },
   play: async ({ canvas }) => {
-    const selection = canvas.getByRole("img", {
+    const selection = await canvas.findByRole("img", {
       name: `Pikachu selection: ${focusSelection.text}`,
     });
 
@@ -130,29 +140,33 @@ export const HoverableLabel: Story = {
 export const OverlappingSelections: Story = {
   render: () => (
     <CollaborationSurface>
-      <SelectionHighlight
-        rect={firstLineSelection.rect}
-        selectedText={firstLineSelection.text}
-        showLabel
-        user={charmander}
-      />
-      <SelectionHighlight
-        rect={overlappingFirstLineSelection.rect}
-        selectedText={overlappingFirstLineSelection.text}
-        showLabel
-        style={raisedSelectionLabelStyle}
-        user={pikachu}
-      />
+      {(surfaceRef) => (
+        <PresenceLayer host={surfaceRef}>
+          <SelectionHighlight
+            rect={firstLineSelection.rect}
+            selectedText={firstLineSelection.text}
+            showLabel
+            user={charmander}
+          />
+          <SelectionHighlight
+            rect={overlappingFirstLineSelection.rect}
+            selectedText={overlappingFirstLineSelection.text}
+            showLabel
+            style={raisedSelectionLabelStyle}
+            user={pikachu}
+          />
+        </PresenceLayer>
+      )}
     </CollaborationSurface>
   ),
   play: async ({ canvas }) => {
     await expect(
-      canvas.getByRole("img", {
+      await canvas.findByRole("img", {
         name: `Charmander selection: ${firstLineSelection.text}`,
       }),
     ).toBeVisible();
     await expect(
-      canvas.getByRole("img", {
+      await canvas.findByRole("img", {
         name: `Pikachu selection: ${overlappingFirstLineSelection.text}`,
       }),
     ).toBeVisible();

--- a/packages/awareness/src/stories/SelectionHighlight.stories.tsx
+++ b/packages/awareness/src/stories/SelectionHighlight.stories.tsx
@@ -31,6 +31,24 @@ const overlappingFirstLineSelection = {
   text: "editing keeps",
 } as const;
 
+// Three-rect selection mirroring the per-line rendering pattern that
+// `apps/playground/src/components/awareness-collab/EditorSurface.tsx`
+// produces from `rectsFor` for wrapped textarea selections — one rect
+// per visible line so the highlight follows the text instead of
+// painting a single bounding box over the unselected content between
+// the wrap boundaries.
+const multiLineSelection = {
+  text: "each trainer visible without pulling focus from the page. Remote cursors anchor activity to the",
+  rects: [
+    // Line 1 partial: from mid-line to the content right edge.
+    { x: 200, y: 134, width: 296, height: 24 },
+    // Line 2 full-width: content left edge to right edge.
+    { x: 32, y: 158, width: 496, height: 24 },
+    // Line 3 partial: content left edge to mid-line.
+    { x: 32, y: 182, width: 220, height: 24 },
+  ],
+} as const;
+
 const raisedSelectionLabelStyle = {
   "--awareness-selection-label-y": "-22px",
 } as CSSProperties;
@@ -134,6 +152,54 @@ export const HoverableLabel: Story = {
     // can also surface the attribution.
     selection.focus();
     await expect(selection).toHaveFocus();
+  },
+};
+
+/**
+ * Wrapped multi-line selection — one `<SelectionHighlight>` per
+ * visible line so the highlight follows the text instead of painting
+ * one giant bounding box across the gap. This is the same per-line
+ * rendering pattern that
+ * `apps/playground/src/components/awareness-collab/EditorSurface.tsx`
+ * builds via `rectsFor`. Only the first rect carries the user-visible
+ * label and the full selectedText aria-label; sibling rects render as
+ * unlabeled continuations of the same logical selection.
+ */
+export const MultiLineSelection: Story = {
+  render: () => (
+    <CollaborationSurface>
+      {(surfaceRef) => (
+        <PresenceLayer host={surfaceRef}>
+          {multiLineSelection.rects.map((rect, i) => (
+            <SelectionHighlight
+              key={`multi-${rect.y}-${rect.x}`}
+              rect={rect}
+              selectedText={i === 0 ? multiLineSelection.text : undefined}
+              showLabel={i === 0}
+              user={charmander}
+            />
+          ))}
+        </PresenceLayer>
+      )}
+    </CollaborationSurface>
+  ),
+  play: async ({ canvas }) => {
+    // The first rect carries the full selectedText; the two
+    // continuations render with the plain "<name> selection" aria so
+    // assistive tech doesn't repeat the long text three times for a
+    // single logical selection.
+    const labelled = await canvas.findByRole("img", {
+      name: `Charmander selection: ${multiLineSelection.text}`,
+    });
+    await expect(labelled).toBeVisible();
+    const continuations = await canvas.findAllByRole("img", {
+      name: "Charmander selection",
+    });
+    await expect(continuations).toHaveLength(
+      multiLineSelection.rects.length - 1,
+    );
+    // Visible name badge appears once (on the first rect only).
+    await expect(canvas.getByText("Charmander")).toBeVisible();
   },
 };
 

--- a/packages/awareness/src/stories/story-layout.tsx
+++ b/packages/awareness/src/stories/story-layout.tsx
@@ -1,4 +1,9 @@
-import type { CSSProperties, ReactNode } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  type RefObject,
+  useRef,
+} from "react";
 
 const pokeballSvg =
   "url(\"data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' fill='none' stroke='%23ef4444' stroke-width='2'%3E%3Ccircle cx='100' cy='100' r='90'/%3E%3Cpath d='M10 100h70a20 20 0 0 1 40 0h70'/%3E%3Ccircle cx='100' cy='100' r='18'/%3E%3Ccircle cx='100' cy='100' r='10' fill='%23ef4444'/%3E%3C/svg%3E\")";
@@ -213,42 +218,58 @@ export const StoryShowcase = ({
   </StoryFrame>
 );
 
+/**
+ * `children` may be either a static `ReactNode` (rendered as a direct
+ * child of the surface) or a function that receives a ref to the
+ * surface div. The function form lets stories wrap awareness overlays in
+ * a `<PresenceLayer host={surfaceRef}>` while still rendering other
+ * absolute-positioned content (presence rail, block badge, etc.) as
+ * direct children, so those overlays' positioning context stays the
+ * surface and not the fixed PresenceLayer.
+ */
+export type CollaborationSurfaceChildren =
+  | ReactNode
+  | ((surfaceRef: RefObject<HTMLDivElement | null>) => ReactNode);
+
 export const CollaborationSurface = ({
   children,
 }: {
-  readonly children: ReactNode;
-}): ReactNode => (
-  <StoryShowcase
-    eyebrow="Pokédex · Live Editing"
-    subtitle="A shared Pokédex draft updated in real time. Cursors and selections show where each trainer is focused."
-    title="Field Notes — collaborative draft"
-  >
-    <div style={surfaceStyle}>
-      <div style={surfaceChromeStyle}>
-        <span aria-hidden="true" style={trafficLightStyle}>
-          <span style={dot("#ef4444")} />
-          <span style={dot("#f59e0b")} />
-          <span style={dot("#22c55e")} />
-        </span>
-        <span>Pokédex Draft · v0.3</span>
+  readonly children: CollaborationSurfaceChildren;
+}): ReactNode => {
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  return (
+    <StoryShowcase
+      eyebrow="Pokédex · Live Editing"
+      subtitle="A shared Pokédex draft updated in real time. Cursors and selections show where each trainer is focused."
+      title="Field Notes — collaborative draft"
+    >
+      <div ref={surfaceRef} style={surfaceStyle}>
+        <div style={surfaceChromeStyle}>
+          <span aria-hidden="true" style={trafficLightStyle}>
+            <span style={dot("#ef4444")} />
+            <span style={dot("#f59e0b")} />
+            <span style={dot("#22c55e")} />
+          </span>
+          <span>Pokédex Draft · v0.3</span>
+        </div>
+        <div style={pageContentStyle}>
+          <p style={docMetaStyle}>Entry · Genus · Habitat</p>
+          <h3 style={docHeadingStyle}>Field guide: tracking wild encounters</h3>
+          <p style={paragraphStyle}>
+            Collaborative editing keeps each trainer visible without pulling
+            focus from the page. Remote cursors anchor activity to the text.
+          </p>
+          <p style={paragraphStyle}>
+            Selections highlight the passage a teammate is reviewing, while
+            avatars summarize who is currently in the document.
+          </p>
+          <p style={paragraphStyle}>
+            Presence updates independently from content, so the page stays
+            responsive even during long research sessions in the tall grass.
+          </p>
+        </div>
+        {typeof children === "function" ? children(surfaceRef) : children}
       </div>
-      <div style={pageContentStyle}>
-        <p style={docMetaStyle}>Entry · Genus · Habitat</p>
-        <h3 style={docHeadingStyle}>Field guide: tracking wild encounters</h3>
-        <p style={paragraphStyle}>
-          Collaborative editing keeps each trainer visible without pulling focus
-          from the page. Remote cursors anchor activity to the text.
-        </p>
-        <p style={paragraphStyle}>
-          Selections highlight the passage a teammate is reviewing, while
-          avatars summarize who is currently in the document.
-        </p>
-        <p style={paragraphStyle}>
-          Presence updates independently from content, so the page stays
-          responsive even during long research sessions in the tall grass.
-        </p>
-      </div>
-      {children}
-    </div>
-  </StoryShowcase>
-);
+    </StoryShowcase>
+  );
+};


### PR DESCRIPTION
## Summary

- **PresenceLayer**: new wrapper that owns the host's bounding rect and translates host-local overlay coords into screen space. `LiveCursor` and `SelectionHighlight` now require it (return `null` + dev warning without one), removing the bug class where consumers anchored to the wrong rect and pushed cursors off the line.
- **Per-line selection rects in playground**: `EditorSurface.rectsFor` returns one `HighlightRect` per visible line for wrapped textarea selections instead of one giant bounding box, so the highlight follows the text. New `MultiLineSelection` story documents the pattern in the awareness package.
- **Theme/contrast fixes**: presence-bar tooltip pinned to `max-content` width (was collapsing to single-character vertical text in tight layouts); `--color-awareness-muted`/`--color-awareness-text` derive from `currentColor` instead of OS-driven `CanvasText` so they adapt to the consuming page's text color; playground awareness panel sets `text-slate-100` so the empty state is readable on dark slate.
- **Hover-reveal cursor labels** + visual polish (cursor caret height, label easing, tooltip positioning).

## Test plan

- [x] `pnpm --filter @softmaple/awareness test` — 326 passing
- [x] `pnpm --filter @softmaple/awareness typecheck` — clean
- [x] `pnpm --filter @softmaple/playground typecheck` — clean
- [ ] Storybook visual check — open each story, confirm cursors/selections sit on prose lines (not in chrome bar / padding gap):
  - `awareness-livecursor--*`
  - `awareness-selectionhighlight--*` (incl. new `multi-line-selection`)
  - `awareness-fullcollaboration--*`
  - `awareness-presencelayer--hosted-to-textarea`
- [ ] Playground smoke test — open two tabs as different trainers:
  - Multi-line selection renders one highlight per visible line (not a giant bounding box)
  - "No collaborators online" empty state is readable on the dark slate panel
  - Hovering an avatar shows a horizontal tooltip (not vertical one-character-per-line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PresenceLayer component for improved positioning of remote user presence indicators
  * Enhanced live cursor with hover-to-reveal label option for better clarity
  * Improved multi-line selection highlighting with per-line rendering

* **Style**
  * Enhanced visual styling for cursors and selection highlights with better color and spacing
  * Updated presence indicator appearance with improved hover interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/702)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->