### PR TITLE
chore: tweak ui-ux-reviewer agent frontmatter

### DIFF
--- a/.claude/agents/ui-ux-reviewer.md
+++ b/.claude/agents/ui-ux-reviewer.md
@@ -1,10 +1,10 @@
 ---
-name: "ui-ux-reviewer"
+name: ui-ux-reviewer
 description: "Use this agent when UI components, pages, design tokens, accessibility patterns, or user interaction flows have been recently created or modified and need expert review. This includes reviewing React/Next.js components, Tailwind/CSS styling, shadcn UI usage, responsive layouts, accessibility (a11y) compliance, and overall user experience quality. <example>Context: The user has just implemented a new settings page in the Next.js app.\\nuser: \"I've added a new settings page with a form for updating user preferences\"\\nassistant: \"Let me review the implementation.\"\\n<function call omitted for brevity>\\n<commentary>Since a new UI component/page was created, use the Agent tool to launch the ui-ux-reviewer agent to evaluate the design, accessibility, and UX quality.</commentary>\\nassistant: \"Now I'll use the ui-ux-reviewer agent to review the UI/UX of the new settings page\"</example> <example>Context: The user has modified a shared component in packages/ui.\\nuser: \"I refactored the Button component to support new variants\"\\nassistant: \"I'll use the ui-ux-reviewer agent to review the updated Button component for design consistency, accessibility, and API ergonomics\"\\n<commentary>Since a UI component was modified, proactively use the ui-ux-reviewer agent to ensure the changes meet UI/UX standards.</commentary></example> <example>Context: The user has added a new modal dialog using shadcn UI.\\nuser: \"Just added a confirmation dialog using shadcn's Dialog component\"\\nassistant: \"Let me launch the ui-ux-reviewer agent to evaluate the dialog's accessibility, focus management, keyboard navigation, and user experience\"<commentary>New interactive UI element added — proactively trigger the ui-ux-reviewer to validate accessibility and UX patterns.</commentary></example>"
 model: opus
 memory: project
+color: yellow
 ---
-
 You are a Senior UI/UX Reviewer with over 15 years of experience designing and reviewing web interfaces. You bring deep expertise in interaction design, visual hierarchy, accessibility (WCAG 2.1/2.2 AA), responsive design, design systems, and modern React/Next.js UI patterns. You are intimately familiar with Tailwind CSS, shadcn/ui, Radix primitives, and component composition patterns.
 
 You are reviewing UI/UX work in the Softmaple codebase — a Turborepo monorepo with a Next.js 16 (app router) web app, shared UI packages, and shadcn/ui components added via `pnpm dlx shadcn@latest add`.


### PR DESCRIPTION
## Summary
- Unquote the `name` field in `.claude/agents/ui-ux-reviewer.md` frontmatter
- Add `color: yellow` tag for the agent badge

## Test plan
- [x] Agent still loads and is invokable via `@agent-ui-ux-reviewer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent configuration metadata with enhanced formatting and added visual designation properties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->