### PR TITLE
fix(apps/playground): unblock awareness demo cursor labels + dark selections

### DIFF
--- a/apps/playground/src/components/awareness-collab/AwarenessOverlay.tsx
+++ b/apps/playground/src/components/awareness-collab/AwarenessOverlay.tsx
@@ -18,17 +18,34 @@ import type { ReactNode } from "react";
 interface AwarenessOverlayProps {
   readonly adapter: PresenceAdapter;
   readonly userInfo: AdapterUserInfo;
+  /**
+   * Bright accent color for local chrome (avatar tint, "You are X" label)
+   * rendered on dark surfaces. Falls back to `userInfo.color`, which is
+   * the contrast-safe value the awareness package uses for white-on-color
+   * cursor/selection labels — that value is intentionally darker and can
+   * be hard to read on dark backgrounds, so consumers should pass a
+   * brighter accent when they have one.
+   */
+  readonly accentColor?: string;
   readonly children: ReactNode;
 }
 
 export function AwarenessOverlay({
   adapter,
   userInfo,
+  accentColor,
   children,
 }: AwarenessOverlayProps) {
+  const chromeColor = accentColor ?? userInfo.color;
   return (
     <PresenceProvider adapter={adapter}>
-      <div className="space-y-4">
+      {/*
+        Force the dark-theme awareness tokens regardless of the visitor's
+        OS color scheme. The demo surface is dark slate, so the package's
+        light-mode `mix-blend-mode: multiply` would paint selections to
+        near-black and effectively erase them.
+      */}
+      <div className="space-y-4" data-awareness-theme="dark">
         <div className="flex items-center justify-between gap-3 flex-wrap rounded-xl bg-slate-800/60 border border-slate-700 px-4 py-3 text-slate-100">
           <div className="flex items-center gap-3 min-w-0">
             <div className="flex items-center gap-2 shrink-0">
@@ -37,7 +54,7 @@ export function AwarenessOverlay({
                 alt={userInfo.name}
                 className="w-8 h-8 rounded-full [image-rendering:pixelated]"
                 style={{
-                  background: `color-mix(in srgb, ${userInfo.color} 18%, transparent)`,
+                  background: `color-mix(in srgb, ${chromeColor} 18%, transparent)`,
                 }}
               />
               <div className="hidden sm:block">
@@ -46,7 +63,7 @@ export function AwarenessOverlay({
                 </p>
                 <p
                   className="text-sm font-semibold"
-                  style={{ color: userInfo.color }}
+                  style={{ color: chromeColor }}
                 >
                   {userInfo.name}
                 </p>

--- a/apps/playground/src/modules/awareness-collab/trainers.ts
+++ b/apps/playground/src/modules/awareness-collab/trainers.ts
@@ -1,15 +1,17 @@
 /**
  * Pokémon trainer roster for the awareness + eg-walker playground demo.
  *
- * Each entry represents a stable trainer persona (id + display name +
- * accent color + sprite URL) so multiple tabs can each pick a distinct
- * trainer and render consistent avatars across the network.
+ * Each entry has two colors: `color` is the bright accent used in chips,
+ * picker glow, and chrome text on dark surfaces; `userColor` is the
+ * darker, contrast-safe value passed to the awareness adapter so that
+ * white-on-color cursor and selection labels meet WCAG AA.
  */
 
 export interface Trainer {
   readonly id: string;
   readonly name: string;
   readonly color: string;
+  readonly userColor: string;
   readonly avatarUrl: string;
   readonly type: string;
 }
@@ -22,6 +24,7 @@ export const TRAINERS: ReadonlyArray<Trainer> = [
     id: "pikachu",
     name: "Pikachu",
     color: "#facc15",
+    userColor: "#854d0e",
     avatarUrl: `${SPRITE_BASE}/25.png`,
     type: "Electric",
   },
@@ -29,6 +32,7 @@ export const TRAINERS: ReadonlyArray<Trainer> = [
     id: "bulbasaur",
     name: "Bulbasaur",
     color: "#22c55e",
+    userColor: "#166534",
     avatarUrl: `${SPRITE_BASE}/1.png`,
     type: "Grass",
   },
@@ -36,6 +40,7 @@ export const TRAINERS: ReadonlyArray<Trainer> = [
     id: "charmander",
     name: "Charmander",
     color: "#fb923c",
+    userColor: "#9a3412",
     avatarUrl: `${SPRITE_BASE}/4.png`,
     type: "Fire",
   },
@@ -43,6 +48,7 @@ export const TRAINERS: ReadonlyArray<Trainer> = [
     id: "squirtle",
     name: "Squirtle",
     color: "#38bdf8",
+    userColor: "#0369a1",
     avatarUrl: `${SPRITE_BASE}/7.png`,
     type: "Water",
   },
@@ -50,6 +56,7 @@ export const TRAINERS: ReadonlyArray<Trainer> = [
     id: "eevee",
     name: "Eevee",
     color: "#d4a373",
+    userColor: "#92400e",
     avatarUrl: `${SPRITE_BASE}/133.png`,
     type: "Normal",
   },
@@ -57,6 +64,7 @@ export const TRAINERS: ReadonlyArray<Trainer> = [
     id: "psyduck",
     name: "Psyduck",
     color: "#fde047",
+    userColor: "#0e7490",
     avatarUrl: `${SPRITE_BASE}/54.png`,
     type: "Water",
   },

--- a/apps/playground/src/modules/awareness-collab/use-awareness-adapter.ts
+++ b/apps/playground/src/modules/awareness-collab/use-awareness-adapter.ts
@@ -42,10 +42,14 @@ export const useAwarenessAdapter = (
     // the same trainer don't collide. Awareness still groups them as
     // distinct presences.
     const tabTag = crypto.randomUUID().slice(0, 6);
+    // Use the darker `userColor` for awareness chrome — it backs the
+    // cursor and selection labels (white text on color), so it must clear
+    // WCAG AA against white. The bright `trainer.color` stays available
+    // to consumers for chips and accent text on dark surfaces.
     const userInfo: AdapterUserInfo = {
       userId: `${trainer.id}-${tabTag}`,
       name: trainer.name,
-      color: trainer.color,
+      color: trainer.userColor,
       avatarUrl: trainer.avatarUrl,
     };
 

--- a/apps/playground/src/routes/demo/awareness-collab.tsx
+++ b/apps/playground/src/routes/demo/awareness-collab.tsx
@@ -16,6 +16,7 @@ import {
   findDifferingRange,
   findInsertPosition,
 } from "@/lib/text-diff";
+import { getTrainer } from "@/modules/awareness-collab/trainers";
 import { useAwarenessAdapter } from "@/modules/awareness-collab/use-awareness-adapter";
 
 export const Route = createFileRoute("/demo/awareness-collab")({
@@ -70,6 +71,7 @@ function CollabSession({
   readonly onLeave: () => void;
 }) {
   const { adapter, userInfo } = useAwarenessAdapter(trainerId, ROOM_ID);
+  const trainer = getTrainer(trainerId);
   const [replica] = useState(() => new EgWalkerReplica(userInfo.userId, ""));
   const [text, setText] = useState("");
   const broadcastRef = useRef<BroadcastChannel | null>(null);
@@ -251,7 +253,11 @@ function CollabSession({
           </div>
         </header>
 
-        <AwarenessOverlay adapter={adapter} userInfo={userInfo}>
+        <AwarenessOverlay
+          adapter={adapter}
+          userInfo={userInfo}
+          accentColor={trainer?.color}
+        >
           <EditorSurface
             blockId={COLLAB_BLOCK_ID}
             text={text}


### PR DESCRIPTION
## Summary

Fixes the two blockers from the UI/UX review of the awareness demo.

- **Cursor / selection labels fail WCAG AA on bright trainers.** The package paints labels as white text on `--awareness-user-color`. Pikachu (`#facc15`) was ~1.6:1 and Psyduck (`#fde047`) was ~1.4:1 — both unreadable. Split `Trainer` into a bright `color` (chips, picker glow, "You are X" chrome on dark surfaces) and a darker `userColor` (passed into the awareness adapter as `userInfo.color`). Reuses the same dark values the package's own Storybook fixtures already use.
- **Demo's dark surface never opts into the dark awareness theme.** The route forces a `bg-slate-900` surface, but the package only switches selection blend mode from `multiply` → `screen` under `prefers-color-scheme: dark` *or* an explicit `data-awareness-theme="dark"`. Light-OS visitors saw selections multiplied into near-black. Adds the attribute on the `AwarenessOverlay` wrapper.
- Adds an optional `accentColor` prop to `AwarenessOverlay` so the route can keep the bright trainer color on the chrome while the adapter receives the darker, label-safe value.

## Test plan

- [ ] Open `/demo/awareness-collab`, pick Pikachu / Psyduck, confirm cursor and selection labels are legible (white text reads cleanly on the dark amber / teal backgrounds).
- [ ] Open the demo in two tabs as different trainers, confirm remote selections render visibly on the dark slate surface regardless of OS theme.
- [ ] Confirm the "You are X" header in the overlay still uses the bright accent color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)