### PR TITLE
fix(packages/awareness, apps/playground): a11y pass on presence chrome

### DIFF
--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -281,6 +281,14 @@ export function EditorSurface({
        *  `trackHostScroll` folds the textarea's internal scroll into
        *  the offset so we hand over textarea-content-relative values
        *  without subtracting `scrollLeft` / `scrollTop` ourselves. */}
+      {/*
+       *  Cursor and selection overlays explicitly opt OUT of the keyboard
+       *  tab order. With N peers, the default `focusable={showLabel === "hover"}`
+       *  inserts up to 2N tab stops between the textarea and the rest of
+       *  the page. Keyboard users discover peer attribution through the
+       *  `<PresenceBar>` roster instead; sighted users still get the
+       *  hover label.
+       */}
       <PresenceLayer host={textareaRef} trackHostScroll>
         {others.map((peer) => {
           if (peer.cursor && peer.cursor.blockId === blockId) {
@@ -292,6 +300,7 @@ export function EditorSurface({
                 user={peer}
                 point={point}
                 showLabel="hover"
+                focusable={false}
               />
             );
           }
@@ -307,15 +316,14 @@ export function EditorSurface({
             peer.selection.from,
             peer.selection.to,
           );
-          // Only the first rect carries the user-visible label, the
-          // full selectedText aria-label, and an opt-in tab stop;
-          // sibling rects render as unlabeled, non-focusable
-          // continuations so a single wrapped selection doesn't burn
-          // 3 tab stops on the host.
+          // Only the first rect carries the user-visible label and the
+          // full selectedText aria-label; sibling rects render as
+          // unlabeled continuations. None are focusable here — keyboard
+          // attribution lives in the PresenceBar.
           return rects.map((rect, i) => (
             <SelectionHighlight
               key={`sel-${peer.userId}-${i}`}
-              focusable={i === 0}
+              focusable={false}
               user={peer}
               rect={rect}
               selectedText={i === 0 ? selectedText : undefined}

--- a/packages/awareness/src/__tests__/internal-utilities.test.tsx
+++ b/packages/awareness/src/__tests__/internal-utilities.test.tsx
@@ -286,7 +286,7 @@ describe("PresenceBar without context", () => {
     ).toBe(3);
   });
 
-  it("makes items keyboard-focusable and adds a tooltip when interactive", () => {
+  it("wraps the avatar in a focusable button and adds a tooltip when interactive", () => {
     const ada: PresenceUser = {
       userId: "ada",
       name: "Ada",
@@ -295,12 +295,14 @@ describe("PresenceBar without context", () => {
       lastActiveAt: 0,
     };
     const html = renderToStaticMarkup(<PresenceBar users={[ada]} />);
-    expect(html).toContain('tabindex="0"');
+    expect(html).toContain("awareness-presence-bar__button");
+    expect(html).toContain('aria-label="Ada"');
+    expect(html).toContain("aria-describedby=");
     expect(html).toContain('role="tooltip"');
     expect(html).toContain("awareness-presence-bar__item--interactive");
   });
 
-  it("omits tooltip + tabIndex when interactive=false", () => {
+  it("omits the button + tooltip when interactive=false", () => {
     const ada: PresenceUser = {
       userId: "ada",
       name: "Ada",
@@ -311,7 +313,7 @@ describe("PresenceBar without context", () => {
     const html = renderToStaticMarkup(
       <PresenceBar interactive={false} users={[ada]} />,
     );
-    expect(html).not.toContain('tabindex="0"');
+    expect(html).not.toContain("awareness-presence-bar__button");
     expect(html).not.toContain('role="tooltip"');
   });
 });

--- a/packages/awareness/src/components/block-activity-indicator.tsx
+++ b/packages/awareness/src/components/block-activity-indicator.tsx
@@ -48,6 +48,15 @@ export interface BlockActivityIndicatorProps {
   readonly formatLabel?: (users: ReadonlyArray<PresenceUser>) => string;
   readonly className?: string;
   readonly "aria-label"?: string;
+  /**
+   * Politeness for the underlying live region. Defaults to `"off"` —
+   * cursor enter/exit churn would otherwise stream "Pikachu is editing
+   * here" → "2 trainers editing here" announcements through every screen
+   * reader, drowning out the user's own editing flow. Sighted users
+   * still see the visible pill. Pass `"polite"` if you want the
+   * transitions announced anyway.
+   */
+  readonly ariaLive?: "off" | "polite" | "assertive";
 }
 
 const isUserInBlock = (user: PresenceUser, blockId: string): boolean =>
@@ -72,6 +81,7 @@ export const BlockActivityIndicator = ({
   formatLabel = defaultFormatLabel,
   className,
   "aria-label": ariaLabel,
+  ariaLive = "off",
 }: BlockActivityIndicatorProps): ReactNode => {
   const context = useContext(PresenceContext);
   // Narrow the memo deps so unrelated context churn (e.g. a new
@@ -104,7 +114,7 @@ export const BlockActivityIndicator = ({
     // biome-ignore lint/a11y/useSemanticElements: <output> is for form-calculated values; this is presence telemetry, so a div with role="status" is the semantically appropriate live region.
     <div
       aria-label={ariaLabel ?? label}
-      aria-live="polite"
+      aria-live={ariaLive}
       className={cx("awareness-block-activity-indicator", className)}
       role="status"
       style={

--- a/packages/awareness/src/components/live-cursor.tsx
+++ b/packages/awareness/src/components/live-cursor.tsx
@@ -141,31 +141,52 @@ export const LiveCursor = ({
     };
   }, [viewport]);
 
-  // `point.x` / `point.y` are intentional dependencies: every move re-arms
-  // the auto-fade so the label re-appears at the new location, matching
-  // design §6 ("label visible while cursor is active, then fades").
+  // One auto-hide timer survives across many coord updates. Using a ref
+  // (rather than scheduling inside the effect cleanup) lets us *not*
+  // re-arm the fade on every sub-second move during sustained typing —
+  // the previous behavior kept the label permanently visible whenever a
+  // peer was actively editing, defeating §6's "label fades when active"
+  // promise. Now the label flashes once per burst and only re-shows
+  // after the prior burst has fully faded.
+  const labelHideTimeoutRef = useRef<number | null>(null);
+  const isInitialLabelMountRef = useRef(true);
+
   useEffect(() => {
     if (showLabel !== true) {
       setIsLabelVisible(false);
+      if (labelHideTimeoutRef.current !== null) {
+        window.clearTimeout(labelHideTimeoutRef.current);
+        labelHideTimeoutRef.current = null;
+      }
       return;
     }
+
+    const isInitial = isInitialLabelMountRef.current;
+    isInitialLabelMountRef.current = false;
 
     const previousPoint = previousPointRef.current;
     const moved = previousPoint.x !== point.x || previousPoint.y !== point.y;
     previousPointRef.current = { x: point.x, y: point.y };
 
-    if (moved) {
-      setIsLabelVisible(true);
-    }
+    // Nothing changed — no need to touch the label.
+    if (!isInitial && !moved) return;
+    // A burst is already in flight — let it fade naturally.
+    if (labelHideTimeoutRef.current !== null) return;
 
-    const timeoutId = setTimeout(() => {
+    setIsLabelVisible(true);
+    labelHideTimeoutRef.current = window.setTimeout(() => {
       setIsLabelVisible(false);
+      labelHideTimeoutRef.current = null;
     }, labelVisibleMs);
-
-    return () => {
-      clearTimeout(timeoutId);
-    };
   }, [labelVisibleMs, point.x, point.y, showLabel]);
+
+  useEffect(() => {
+    return () => {
+      if (labelHideTimeoutRef.current !== null) {
+        window.clearTimeout(labelHideTimeoutRef.current);
+      }
+    };
+  }, []);
 
   if (layerOffset === null) {
     warnMissingPresenceLayerOnce("LiveCursor");

--- a/packages/awareness/src/components/presence-bar.tsx
+++ b/packages/awareness/src/components/presence-bar.tsx
@@ -67,28 +67,41 @@ export const PresenceBar = ({
 
   if (loading) {
     return (
-      <ul
-        aria-busy="true"
-        aria-label={ariaLabel}
-        className={cx("awareness-presence-bar", className)}
-      >
-        {Array.from({ length: maxVisible }).map((_, index) => (
-          <li
-            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no stable identity.
-            key={`skeleton-${index}`}
-            className={cx(
-              "awareness-presence-bar__item",
-              "awareness-presence-bar__item--skeleton",
-              `awareness-presence-bar__item--skeleton-${size}`,
-            )}
-          >
-            <span
+      <>
+        {/*
+          AT-only loading status. The skeleton dots intentionally don't
+          animate (design §6) and convey nothing without a label, so we
+          surface "Loading collaborators…" via a sibling status region
+          and aria-hide the placeholder list items.
+        */}
+        {/* biome-ignore lint/a11y/useSemanticElements: <output> is for form-calculated values; this is a loading state for an inert chrome region, so a span with role="status" is the appropriate live region (mirrors block-activity-indicator). */}
+        <span className="awareness-sr-only" role="status">
+          Loading collaborators…
+        </span>
+        <ul
+          aria-busy="true"
+          aria-label={ariaLabel}
+          className={cx("awareness-presence-bar", className)}
+        >
+          {Array.from({ length: maxVisible }).map((_, index) => (
+            <li
               aria-hidden="true"
-              className="awareness-presence-bar__skeleton"
-            />
-          </li>
-        ))}
-      </ul>
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no stable identity.
+              key={`skeleton-${index}`}
+              className={cx(
+                "awareness-presence-bar__item",
+                "awareness-presence-bar__item--skeleton",
+                `awareness-presence-bar__item--skeleton-${size}`,
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className="awareness-presence-bar__skeleton"
+              />
+            </li>
+          ))}
+        </ul>
+      </>
     );
   }
 
@@ -103,15 +116,29 @@ export const PresenceBar = ({
           const summary = formatPresenceSummary(user);
           return (
             <li
-              aria-describedby={interactive ? tooltipId : undefined}
               className={cx(
                 "awareness-presence-bar__item",
                 interactive && "awareness-presence-bar__item--interactive",
               )}
               key={user.userId}
-              tabIndex={interactive ? 0 : undefined}
             >
-              <PresenceAvatar size={size} user={user} />
+              {interactive ? (
+                // <button> gives us a real focusable element with the
+                // right AT semantics (announces as "Pikachu, button"
+                // not "list item"). The tooltip text is wired through
+                // aria-describedby so AT reads name first, then the
+                // status + last-active meta.
+                <button
+                  aria-describedby={tooltipId}
+                  aria-label={user.name}
+                  className="awareness-presence-bar__button"
+                  type="button"
+                >
+                  <PresenceAvatar size={size} user={user} />
+                </button>
+              ) : (
+                <PresenceAvatar size={size} user={user} />
+              )}
               {interactive ? (
                 <span
                   className="awareness-presence-bar__tooltip"

--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -147,6 +147,23 @@
   @apply bg-awareness-status-offline;
 }
 
+/*
+ * Visually hidden but exposed to assistive tech. Used for status
+ * messages whose visible counterpart is non-textual (skeletons, icons).
+ */
+.awareness-sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 .awareness-presence-bar {
   isolation: isolate;
   max-width: 100%;
@@ -184,7 +201,7 @@
 }
 
 .awareness-presence-bar__item:hover,
-.awareness-presence-bar__item--interactive:focus-visible {
+.awareness-presence-bar__item--interactive:focus-within {
   filter: saturate(1.06);
   transform: translateY(-1px);
   outline: none;
@@ -192,18 +209,37 @@
 }
 
 .awareness-presence-bar__item:hover .awareness-avatar,
-.awareness-presence-bar__item--interactive:focus-visible .awareness-avatar {
+.awareness-presence-bar__item--interactive:focus-within .awareness-avatar {
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--awareness-user-color) 44%, transparent),
     0 6px 16px color-mix(in srgb, var(--awareness-user-color) 28%, transparent);
 }
 
-.awareness-presence-bar__item--interactive:focus-visible .awareness-avatar {
+.awareness-presence-bar__item--interactive:focus-within .awareness-avatar {
   /* Visible focus ring composed on top of the user-color glow. */
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--awareness-user-color) 44%, transparent),
     0 0 0 3px color-mix(in srgb, CanvasText 60%, transparent),
     0 6px 16px color-mix(in srgb, var(--awareness-user-color) 28%, transparent);
+}
+
+/*
+ * Reset the inner <button> so it inherits the item's layout and the
+ * avatar continues to drive the visual; the button just contributes
+ * focusability and AT semantics.
+ */
+.awareness-presence-bar__button {
+  background: none;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  @apply inline-flex items-center;
+}
+
+.awareness-presence-bar__button:focus {
+  outline: none;
 }
 
 .awareness-presence-bar__tooltip {
@@ -238,7 +274,7 @@
 }
 
 .awareness-presence-bar__item:hover .awareness-presence-bar__tooltip,
-.awareness-presence-bar__item--interactive:focus-visible
+.awareness-presence-bar__item--interactive:focus-within
   .awareness-presence-bar__tooltip {
   transform: translate3d(var(--awareness-tooltip-x), 0, 0);
   @apply opacity-100;
@@ -768,7 +804,7 @@
    * are stripped, leaving `outline: none` with nothing in its place.
    * Restore a system-color outline so keyboard focus stays visible.
    */
-  .awareness-presence-bar__item--interactive:focus-visible {
+  .awareness-presence-bar__item--interactive:focus-within {
     outline: 2px solid Highlight;
     outline-offset: 2px;
   }


### PR DESCRIPTION
## Summary

Addresses findings from the UI/UX review of the awareness package.

- **LiveCursor label re-arms on every coord update** (`live-cursor.tsx`) — switch the auto-fade from a per-effect-cycle `setTimeout` to a ref-managed timer that doesn't re-arm during a burst. The label now flashes once per move-burst and fades naturally; previously it stayed permanently visible during sustained typing.
- **PresenceBar tooltip wraps a `<li tabIndex={0}>`** (`presence-bar.tsx`, `global.css`) — wrap the avatar in a real `<button type="button" aria-label={user.name} aria-describedby={tooltipId}>` so AT announces "Pikachu, button" rather than "list item". CSS swaps the matching `:focus-visible` selectors to `:focus-within` so the inner button still drives the avatar glow + tooltip reveal.
- **Loading skeleton has no AT signal** (`presence-bar.tsx`, `global.css`) — render a sibling `role="status"` "Loading collaborators…" using a new `awareness-sr-only` utility, and `aria-hidden` the placeholder list items.
- **BlockActivityIndicator chatters via `aria-live="polite"`** (`block-activity-indicator.tsx`) — default `aria-live` to `"off"`; cursor enter/exit churn would otherwise stream presence announcements through every screen reader. New `ariaLive` prop lets consumers opt back into `"polite"`. `ConnectionIndicator` and `ActivityIndicator` left alone — transport state and the activity log are genuinely informative.
- **LiveCursor + SelectionHighlight default `focusable={true}` adds 2N tab stops** (`apps/playground/EditorSurface.tsx`) — pass `focusable={false}` for both in the playground demo. Keyboard users discover peer attribution through the PresenceBar roster; the package defaults are unchanged so existing consumers still get keyboard-discoverable badges.

Test updates:
- Replaced the `internal-utilities.test.tsx` PresenceBar test that asserted the old `<li tabindex="0">` shape with assertions on the new `<button aria-label="…" aria-describedby="…">` structure.
- All 342 awareness tests pass; 42 playground tests pass; type-check clean across both packages.

## Test plan

- [ ] Open `/demo/awareness-collab`, type continuously in one tab, confirm remote cursor labels fade after 3s instead of staying pinned to the caret.
- [ ] Tab through the demo with the keyboard, confirm cursor and selection overlays no longer steal tab stops.
- [ ] Tab into the PresenceBar roster, confirm focus lands on the avatar buttons and the tooltip appears on focus (not just hover).
- [ ] With a screen reader, confirm `BlockActivityIndicator` no longer announces every cursor enter/exit.
- [ ] Storybook `PresenceBar > Loading` story renders skeletons + an sr-only "Loading collaborators…" status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)