### PR TITLE
perf(packages/awareness, apps/playground): memoize textarea rect work and refresh stale tooltip times

### DIFF
--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -221,14 +221,21 @@ export function EditorSurface({
   //
   // Both helpers under the hood mount + measure + unmount a mirror
   // <div> per call, so calling them inside the JSX (once per peer per
-  // render) churns the DOM each time `useOthers` ticks. Memoizing here
-  // means the mirror element only runs when the keyed inputs (peer
-  // offsets, selection ranges, current text) actually changed.
-  // Single pass per render: `getTextareaSelectionRects` doesn't read
-  // `text` itself (it measures the live DOM), but a local edit shifts
-  // the textarea's measured geometry, so `text` is a real cache key
-  // for both maps. Computing them together keeps that key honest in
-  // one place instead of duplicating it across two memos.
+  // render) churned the DOM on every render. Memoize them in a single
+  // pass keyed on `others`, `blockId`, and `text`. `text` isn't read
+  // by `getTextareaSelectionRects` (which measures the live DOM), but
+  // a local edit shifts the textarea's measured geometry, so it's a
+  // real cache key for both maps; computing them together keeps that
+  // key honest in one place.
+  //
+  // Trade-off: `useOthers` returns a new array reference on every
+  // presence tick, so the cache invalidates whenever ANY peer moves
+  // (not just peers in this block). At N=6 demo peers the win is
+  // already worthwhile — we move from O(N) mirror mounts per render
+  // to O(N) per tick — and a per-peer ref-cache keyed on `(userId,
+  // offset)` would eliminate the over-invalidation but adds a manual
+  // invalidation pass on text change. Skipped here pending a real
+  // need.
   const { cursorPoints, selectionRects } = useMemo(() => {
     const el = textareaRef.current;
     const cursors = new Map<string, { x: number; y: number }>();

--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -338,6 +338,11 @@ export function EditorSurface({
         })}
         {others.flatMap((peer) => {
           const rects = selectionRects.get(peer.userId);
+          // The cache invariant guarantees `peer.selection` is defined
+          // whenever `rects` is set (it's the gate that puts the entry
+          // into the map). The extra `!peer.selection` check is for
+          // the type narrower so the `peer.selection.from` / `.to`
+          // reads below don't need a non-null assertion.
           if (!rects || !peer.selection) return [];
           const selectedText = text.slice(
             peer.selection.from,

--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -7,6 +7,7 @@
 import {
   getTextareaCaretRect,
   getTextareaSelectionRects,
+  type HighlightRect,
   LiveCursor,
   PresenceLayer,
   SelectionHighlight,
@@ -16,7 +17,7 @@ import {
   useUpdateSelection,
   useUpdateTyping,
 } from "@softmaple/awareness";
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { BlockActivityBadge } from "./BlockActivityBadge";
 
 /**
@@ -217,12 +218,37 @@ export function EditorSurface({
   // other consumer building a textarea-backed editor gets the same
   // implementation — and the same set of tests — instead of
   // reinventing it with subtly different bugs.
-  const pointFor = (offset: number) => {
+  //
+  // Both helpers under the hood mount + measure + unmount a mirror
+  // <div> per call, so calling them inside the JSX (once per peer per
+  // render) churns the DOM each time `useOthers` ticks. Memoizing here
+  // means the mirror element only runs when the keyed inputs (peer
+  // offsets, selection ranges, current text) actually changed.
+  // Single pass per render: `getTextareaSelectionRects` doesn't read
+  // `text` itself (it measures the live DOM), but a local edit shifts
+  // the textarea's measured geometry, so `text` is a real cache key
+  // for both maps. Computing them together keeps that key honest in
+  // one place instead of duplicating it across two memos.
+  const { cursorPoints, selectionRects } = useMemo(() => {
     const el = textareaRef.current;
-    if (!el) return null;
-    const local = getTextareaCaretRect(el, Math.min(offset, text.length));
-    return { x: local.left, y: local.top };
-  };
+    const cursors = new Map<string, { x: number; y: number }>();
+    const selections = new Map<string, ReadonlyArray<HighlightRect>>();
+    if (!el) return { cursorPoints: cursors, selectionRects: selections };
+    for (const peer of others) {
+      if (peer.cursor?.blockId === blockId) {
+        const local = getTextareaCaretRect(
+          el,
+          Math.min(peer.cursor.offset, text.length),
+        );
+        cursors.set(peer.userId, { x: local.left, y: local.top });
+      }
+      if (peer.selection?.blockId === blockId) {
+        const rects = getTextareaSelectionRects(el, peer.selection);
+        if (rects.length > 0) selections.set(peer.userId, rects);
+      }
+    }
+    return { cursorPoints: cursors, selectionRects: selections };
+  }, [others, blockId, text, textareaRef]);
 
   return (
     <div className="relative">
@@ -291,27 +317,21 @@ export function EditorSurface({
        */}
       <PresenceLayer host={textareaRef} trackHostScroll>
         {others.map((peer) => {
-          if (peer.cursor && peer.cursor.blockId === blockId) {
-            const point = pointFor(peer.cursor.offset);
-            if (!point) return null;
-            return (
-              <LiveCursor
-                key={`cursor-${peer.userId}`}
-                user={peer}
-                point={point}
-                showLabel="hover"
-                focusable={false}
-              />
-            );
-          }
-          return null;
+          const point = cursorPoints.get(peer.userId);
+          if (!point) return null;
+          return (
+            <LiveCursor
+              key={`cursor-${peer.userId}`}
+              user={peer}
+              point={point}
+              showLabel="hover"
+              focusable={false}
+            />
+          );
         })}
         {others.flatMap((peer) => {
-          if (!peer.selection || peer.selection.blockId !== blockId) return [];
-          const el = textareaRef.current;
-          if (!el) return [];
-          const rects = getTextareaSelectionRects(el, peer.selection);
-          if (rects.length === 0) return [];
+          const rects = selectionRects.get(peer.userId);
+          if (!rects || !peer.selection) return [];
           const selectedText = text.slice(
             peer.selection.from,
             peer.selection.to,

--- a/packages/awareness/src/components/presence-bar.tsx
+++ b/packages/awareness/src/components/presence-bar.tsx
@@ -2,8 +2,10 @@ import {
   type ContextType,
   type ReactNode,
   useContext,
+  useEffect,
   useId,
   useMemo,
+  useReducer,
 } from "react";
 import { PresenceContext } from "../providers/presence-context";
 import type { PresenceUser } from "../types/presence";
@@ -64,6 +66,24 @@ export const PresenceBar = ({
   const shownUsers = visibleUsers.slice(0, maxVisible);
   const overflowUsers = visibleUsers.slice(maxVisible);
   const overflowLabel = overflowUsers.map((user) => user.name).join(", ");
+
+  // The tooltip summary for idle / offline peers reads "last active
+  // 3m ago" — a relative time computed at render with `Date.now()`.
+  // Without a periodic re-render the phrase ages with the tab and
+  // freezes at whatever it said when the user list last changed.
+  // Tick only when at least one shown peer is in a stale-able status;
+  // active peers say "Active now" / "Typing now" and never go stale.
+  const hasStaleableSummary = shownUsers.some(
+    (user) => user.status === "idle" || user.status === "offline",
+  );
+  const [, refreshSummaries] = useReducer((tick: number) => tick + 1, 0);
+  useEffect(() => {
+    if (!hasStaleableSummary) return;
+    const id = window.setInterval(refreshSummaries, 30_000);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [hasStaleableSummary]);
 
   if (loading) {
     return (

--- a/packages/awareness/src/components/presence-rendering.test.tsx
+++ b/packages/awareness/src/components/presence-rendering.test.tsx
@@ -608,9 +608,16 @@ describe("presence components", () => {
 
     expect(tooltipMeta()).toBe("Idle · last active 6m ago");
 
+    // The interval should be the only pending timer at this point;
+    // unmounting must clear it. Without the cleanup, a stray tick
+    // would queue a setState on the unmounted tree.
+    expect(vi.getTimerCount()).toBe(1);
+
     await act(async () => {
       root.unmount();
     });
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("hides the initial LiveCursor label after the configured timeout", async () => {

--- a/packages/awareness/src/components/presence-rendering.test.tsx
+++ b/packages/awareness/src/components/presence-rendering.test.tsx
@@ -569,6 +569,50 @@ describe("presence components", () => {
     warn.mockRestore();
   });
 
+  it("refreshes PresenceBar tooltip relative times on its 30s tick", async () => {
+    vi.useFakeTimers();
+    // Anchor wall time so the relative phrase math is deterministic.
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // Idle peer whose `lastActiveAt` is 5 minutes behind the anchor.
+    // `formatPresenceSummary` for idle status reads
+    // "Idle · last active <relative>", and the relative phrase falls
+    // into the "Xm ago" bucket here. Active peers say "Active now" /
+    // "Typing now" — they never go stale and don't arm the timer.
+    const idleUser = createUser("1", {
+      name: "Slacker",
+      status: "idle",
+      lastActiveAt: Date.now() - 5 * 60_000,
+    });
+
+    await act(async () => {
+      root.render(<PresenceBar users={[idleUser]} />);
+    });
+
+    const tooltipMeta = () =>
+      container.querySelector(".awareness-presence-bar__tooltip-meta")
+        ?.textContent;
+    expect(tooltipMeta()).toBe("Idle · last active 5m ago");
+
+    // Advance past one 30s tick — the interval the bar arms when at
+    // least one user is in a stale-able status should fire, queue a
+    // re-render, and the tooltip should pick up the new relative
+    // phrase from `formatRelativeTime(Date.now())`.
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(tooltipMeta()).toBe("Idle · last active 6m ago");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("hides the initial LiveCursor label after the configured timeout", async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Summary

Addresses the two perf findings from the UI/UX review of the awareness package and demo.

- **Memoize per-peer rect computation in `EditorSurface`.** `getTextareaCaretRect` and `getTextareaSelectionRects` mount + measure + unmount a mirror `<div>` on every call; they were running inside the JSX once per peer per render, which fired on every awareness tick AND on every text change. Cache cursor points and selection rects together in a single `useMemo`, keyed on `others`, `blockId`, and `text`. **Trade-off**: `useOthers` returns a new array reference on every presence tick, so the cache invalidates whenever any peer moves (not just peers in this block). The win is moving from O(N) mirror mounts per render → O(N) per tick — meaningful at N=6 demo peers, with a per-peer ref-cache flagged in a code comment as the next step if higher peer counts ever appear.
- **Refresh stale tooltip timestamps in `PresenceBar`.** The tooltip summary for idle / offline peers reads `last active 3m ago` — a relative time computed at render with `Date.now()`. Without a periodic re-render, the phrase ages with the tab and freezes at whatever it said when the user list last changed. Add a 30 s tick that re-renders the bar, gated on at least one shown peer being in a stale-able status. Active peers say "Active now" / "Typing now" so the timer stays off in the common case.

Both helpers' surface APIs and the `PresenceBar` props are unchanged.

## Test plan

- [x] New vitest in `presence-rendering.test.tsx` uses `vi.useFakeTimers()` + `vi.setSystemTime()` to mount the bar with an idle peer, advance the clock 60s, and assert the tooltip refreshes from "5m ago" to "6m ago".
- [ ] Type continuously in the demo with multiple tabs open; confirm the cursor and selection overlays still track in real time.
- [ ] In a tab where a peer goes idle, leave it open for several minutes and confirm their tooltip relative time updates instead of staying frozen at "just now".
- [ ] Open devtools Performance and confirm the textarea mirror `<div>` no longer mounts on every EditorSurface render when `others` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)