### PR TITLE
[codex] Fix presence tooltip contrast in playground

### DIFF
--- a/packages/awareness/src/global.css
+++ b/packages/awareness/src/global.css
@@ -248,6 +248,12 @@
   background: color-mix(in srgb, Canvas 92%, CanvasText 8%);
   border: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
   box-shadow: var(--shadow-awareness);
+  /*
+   * The tooltip surface is anchored to Canvas/CanvasText instead of the
+   * surrounding app panel. Keep the foreground on the same color pair so
+   * dark custom panels don't inherit light text onto a light Canvas tooltip.
+   */
+  color: CanvasText;
   left: 50%;
   pointer-events: none;
   transform: translate3d(
@@ -270,7 +276,7 @@
    */
   inline-size: max-content;
   max-inline-size: min(14rem, calc(100vw - 1rem));
-  @apply absolute bottom-full mb-2 z-20 grid gap-0.5 rounded-md px-2 py-1.5 text-awareness-text font-awareness opacity-0;
+  @apply absolute bottom-full mb-2 z-20 grid gap-0.5 rounded-md px-2 py-1.5 font-awareness opacity-0;
 }
 
 .awareness-presence-bar__item:hover .awareness-presence-bar__tooltip,


### PR DESCRIPTION
## Summary

Fixes the `PresenceBar` tooltip foreground so it stays readable in the playground awareness demo. The tooltip surface already uses the system `Canvas`/`CanvasText` pair, but its text inherited the surrounding dark panel color through `text-awareness-text`, which made the content disappear on a light system tooltip surface.

## Changes

- Set the `PresenceBar` tooltip foreground to `CanvasText`.
- Remove the inherited `text-awareness-text` utility from the tooltip container so tooltip text and metadata are derived from the same surface color pair as the tooltip background.

## Validation

- `pnpm --filter @softmaple/awareness check`
- `pnpm --filter @softmaple/awareness build`
- `pnpm --filter @softmaple/awareness test`
- `pnpm --filter @softmaple/playground build`
- Verified the playground awareness demo with two local Playwright tabs: hovered/focused the Bulbasaur `PresenceBar` avatar and confirmed the tooltip rendered with `color: rgb(0, 0, 0)`, `background: color(srgb 0.92 0.92 0.92)`, and `opacity: 1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tooltip text readability and contrast on custom panels for improved visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->