### PR TITLE
refactor(packages/eg-walker): type replica persistence metadata schema

### DIFF
--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -59,6 +59,42 @@ interface CriticalCheckpoint {
 const MAX_RETAINED_CHECKPOINTS = 32;
 
 /**
+ * Persistence schema the replica writes into (and reads from) the event
+ * graph's free-form metadata bag. The graph itself is codec-agnostic and
+ * stores arbitrary `Record<string, unknown>`; centralising the known fields
+ * here keeps the schema in one place and turns the previous inline
+ * `typeof` guards into a single typed surface.
+ */
+interface ReplicaPersistenceMetadata {
+  readonly initialText?: string;
+  readonly nextSequenceNumber?: number;
+}
+
+const readReplicaMetadata = (graph: EventGraph): ReplicaPersistenceMetadata => {
+  const raw = graph.getMetadata();
+  const rawInitialText = raw.initialText;
+  const rawNextSequenceNumber = raw.nextSequenceNumber;
+  return {
+    initialText:
+      typeof rawInitialText === "string" ? rawInitialText : undefined,
+    nextSequenceNumber:
+      typeof rawNextSequenceNumber === "number"
+        ? rawNextSequenceNumber
+        : undefined,
+  };
+};
+
+const writeReplicaMetadata = (
+  graph: EventGraph,
+  metadata: ReplicaPersistenceMetadata,
+): void => {
+  graph.setMetadata({
+    ...graph.getMetadata(),
+    ...metadata,
+  });
+};
+
+/**
  * Public replica for Eg-walker.
  * Strictly index-based, no CRDT exposure.
  */
@@ -145,8 +181,7 @@ export class EgWalkerReplica {
    * Serialize the document state (text + event graph)
    */
   serialize(): { text: string; eventGraph: SerializedGraphOutput } {
-    this.eventGraph.setMetadata({
-      ...this.eventGraph.getMetadata(),
+    writeReplicaMetadata(this.eventGraph, {
       initialText: this.initialText,
       nextSequenceNumber: this.nextSequenceNumber,
     });
@@ -169,16 +204,13 @@ export class EgWalkerReplica {
     }
 
     const graph = EventGraph.deserialize(serialized.eventGraph);
-    const metadata = graph.getMetadata();
+    const metadata = readReplicaMetadata(graph);
     const initialText =
-      typeof metadata.initialText === "string"
-        ? metadata.initialText
-        : graph.getAllEvents().length === 0
-          ? serialized.text
-          : "";
+      metadata.initialText ??
+      (graph.getAllEvents().length === 0 ? serialized.text : "");
     const replica = new EgWalkerReplica(replicaId, initialText, graph);
 
-    if (typeof metadata.nextSequenceNumber === "number") {
+    if (metadata.nextSequenceNumber !== undefined) {
       replica.nextSequenceNumber = metadata.nextSequenceNumber;
     }
 


### PR DESCRIPTION
## Summary
- Add a private `ReplicaPersistenceMetadata` interface in `core/replica.ts` documenting the two schema fields the replica owns (`initialText?: string`, `nextSequenceNumber?: number`).
- Add module-level `readReplicaMetadata(graph)` / `writeReplicaMetadata(graph, metadata)` helpers — the single seam that translates between `EventGraph`'s codec-agnostic `Record<string, unknown>` bag and the typed schema.
- `serialize` now delegates to `writeReplicaMetadata`; `deserialize` now delegates to `readReplicaMetadata` and uses `??` / `!== undefined` on the typed result instead of inline `typeof === "string"` / `typeof === "number"` guards.

## Why
Follow-up from the architectural review: the schema for replica persistence metadata was implicit, scattered across two inline `typeof` checks in `deserialize`, and asymmetric with the spread-and-set in `serialize`. Centralising it in one typed surface makes future migrations (adding a field, renaming one) a single-file change instead of a multi-call-site coordination, and removes the per-read narrowing as a place where a typo could silently drop a field. `EventGraph.setMetadata`'s `Record<string, unknown>` signature stays as-is so the graph remains codec-agnostic.

No behaviour change — serialize writes the same two fields, deserialize reads them with identical narrowing semantics (`??` on string still treats `""` as present; `!== undefined` on number still accepts `0`). Public dist surface unchanged at 8.83 KB — the new types stay private to the module.

## Test plan
- [x] `pnpm --filter @softmaple/eg-walker lint` (clean)
- [x] `pnpm --filter @softmaple/eg-walker typecheck` (clean)
- [x] `pnpm --filter @softmaple/eg-walker test -- --run` (254/254 pass)
- [x] `pnpm --filter @softmaple/eg-walker build` (success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)