### PR TITLE
refactor(packages/eg-walker): narrow SerializedVersionInput to iterables only

### DIFF
--- a/packages/eg-walker/src/graph/event-graph.ts
+++ b/packages/eg-walker/src/graph/event-graph.ts
@@ -16,12 +16,11 @@ import { compareEventIds } from "./event-id";
 /**
  * Coerce a deserialized parent-version value into an array of event IDs.
  *
- * Tolerates the JSON-safe array form, in-memory `Set` instances, and generic
- * iterables. The final `Object.keys` branch is a defensive landing zone for
- * payloads produced by `JSON.stringify`ing a `Set` (which produces `{}`) — it
- * cannot recover the original IDs in that case and returns `[]`, but it
- * prevents a hard crash on malformed legacy data. Pre-1.0 callers that may
- * still hold such payloads must re-serialize through the current code path.
+ * Tolerates the three forms `SerializedVersionInput` documents (JSON-safe
+ * array, in-memory `Set`, generic iterable). The parameter is typed as
+ * `unknown` because deserialize ingests JSON-parsed data: malformed payloads
+ * are filtered to `[]` rather than crashing, but no recovery is attempted for
+ * non-iterable objects.
  */
 const normalizeEventIds = (value: unknown): EventId[] => {
   if (Array.isArray(value)) {
@@ -41,11 +40,6 @@ const normalizeEventIds = (value: unknown): EventId[] => {
         (id): id is EventId => typeof id === "string",
       );
     }
-
-    // Last resort: payload shape is a non-iterable object. The most common
-    // source is JSON.stringify(new Set(...)) producing `{}`; recovery is
-    // impossible from this shape.
-    return Object.keys(value);
   }
 
   return [];

--- a/packages/eg-walker/src/test/event-graph.test.ts
+++ b/packages/eg-walker/src/test/event-graph.test.ts
@@ -943,20 +943,14 @@ describe("EventGraph", () => {
       expect(graph.getEvent("child")?.parentVersion).toEqual(new Set(["root"]));
     });
 
-    it("falls back to [] for legacy JSON.stringify(Set) → {} payloads", () => {
-      // Hits the Object.keys defensive branch: a non-iterable plain object
-      // cannot recover the original IDs, so the deserialized event ends up
-      // with no parents. Verifies the fallback does not crash.
-      const graph = EventGraph.deserialize({
-        version: [],
-        events: [root()] as never,
-        // Stand-alone root with parentVersion === {} (empty plain object).
-      });
+    it("falls back to [] for non-iterable object parentVersion payloads", () => {
+      // A non-iterable plain object (e.g. the `{}` produced by accidentally
+      // JSON.stringify-ing a Set in pre-1.0 code) deserializes to an event
+      // with no parents instead of crashing.
       const isolated = EventGraph.deserialize({
         version: [],
         events: [{ ...root(), parentVersion: {} } as never] as never,
       });
-      expect(graph.getEvent("root")?.parentVersion).toEqual(new Set());
       expect(isolated.getEvent("root")?.parentVersion).toEqual(new Set());
     });
 

--- a/packages/eg-walker/src/types/index.ts
+++ b/packages/eg-walker/src/types/index.ts
@@ -63,16 +63,15 @@ export interface GraphEvent {
 export type SerializedVersionOutput = ReadonlyArray<EventId>;
 
 /**
- * Serialized version input: tolerant shape accepted by `EventGraph.deserialize()`.
- * Covers the JSON-safe array form, in-memory `Set` instances, generic
- * iterables, and (defensively) plain objects produced by accidentally
- * `JSON.stringify`ing a `Set` from older code.
+ * Serialized version input: shape accepted by `EventGraph.deserialize()`.
+ * Covers the JSON-safe array form, in-memory `Set` instances, and generic
+ * iterables. (`Set` and `ReadonlyArray` are themselves `Iterable`; the three
+ * entries are listed separately for documentation.)
  */
 export type SerializedVersionInput =
   | ReadonlyArray<EventId>
   | ReadonlySet<EventId>
-  | Iterable<EventId>
-  | Record<string, unknown>;
+  | Iterable<EventId>;
 
 export interface SerializedGraphEventOutput {
   readonly id: EventId;


### PR DESCRIPTION
## Summary
- Drop the `Record<string, unknown>` branch from `SerializedVersionInput` (`types/index.ts:71-75`). The type is now `ReadonlyArray<EventId> | ReadonlySet<EventId> | Iterable<EventId>`.
- Remove the `Object.keys(value)` recovery branch from `normalizeEventIds` (`graph/event-graph.ts:45-48`). Non-iterable objects now fall through to the bottom `return []` instead.
- Collapse the legacy test in `event-graph.test.ts` to one case verifying `{}` still deserializes to `[]` without crashing; runtime safety on JSON-parsed malformed input is preserved.

## Why
Follow-up from the architectural review: the `Record<string, unknown>` branch was a defensive landing zone for `JSON.stringify(new Set(...))` payloads (which produce `{}`). Recovery from that shape was already impossible — the branch could only return `[]` for true `{}` or *garbage* IDs for `{"foo": "bar"}`-shaped accidents. Narrowing the public input type catches misuse at compile time; removing the misleading recovery makes the runtime path honestly return `[]` for malformed objects rather than fabricating IDs from object keys.

**Behaviour:**
- Type-level (breaking for consumers passing plain objects): a `parentVersion: {}` now produces a compile error instead of being silently typed.
- Runtime: `{}` and other non-iterable objects still deserialize to `[]` (no crash) — just via the bottom fallback instead of `Object.keys`. `{"foo": "bar"}` previously returned `["foo"]`; now returns `[]`.

This was the deferred review item; greenlit after confirming no persisted payloads in the wild rely on the legacy fallback.

## Test plan
- [x] `pnpm --filter @softmaple/eg-walker lint` (clean)
- [x] `pnpm --filter @softmaple/eg-walker typecheck` (clean)
- [x] `pnpm --filter @softmaple/eg-walker test -- --run` (254/254 pass)
- [x] `pnpm --filter @softmaple/eg-walker build` (success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)