### PR TITLE
refactor(packages/eg-walker): type criticalCheckpoints as ReadonlyArray

### DIFF
--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -112,7 +112,7 @@ export class EgWalkerReplica {
   private incrementalApplyCount = 0;
   private readonly criticalAnalyzer = new CriticalVersionAnalyzer();
   private readonly partialReplayer = new PartialReplayManager();
-  private readonly criticalCheckpoints: CriticalCheckpoint[] = [];
+  private criticalCheckpoints: ReadonlyArray<CriticalCheckpoint> = [];
 
   constructor(
     private readonly replicaId: string,
@@ -497,15 +497,25 @@ export class EgWalkerReplica {
     if (last && this.versionsEqual(last.version, frontier)) {
       return;
     }
-    this.criticalCheckpoints.push({
+    this.appendCheckpoint({
       version: new Set(frontier),
       text: this.document,
     });
-    // Evict the oldest entries one at a time so a future change that pushes
-    // multiple checkpoints in a single tick still ends the call bounded.
-    while (this.criticalCheckpoints.length > MAX_RETAINED_CHECKPOINTS) {
-      this.criticalCheckpoints.shift();
-    }
+  }
+
+  /**
+   * Single seam for growing {@link criticalCheckpoints}. Routing every write
+   * through here makes the {@link MAX_RETAINED_CHECKPOINTS} cap a structural
+   * invariant of the array rather than a per-call-site convention, so a
+   * future mutation site cannot drift past the bound by forgetting an
+   * eviction loop.
+   */
+  private appendCheckpoint(checkpoint: CriticalCheckpoint): void {
+    const next = [...this.criticalCheckpoints, checkpoint];
+    this.criticalCheckpoints =
+      next.length <= MAX_RETAINED_CHECKPOINTS
+        ? next
+        : next.slice(next.length - MAX_RETAINED_CHECKPOINTS);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Field type: `private readonly criticalCheckpoints: CriticalCheckpoint[]` → `private criticalCheckpoints: ReadonlyArray<CriticalCheckpoint>` in `core/replica.ts`. Drops the field-level `readonly` (the array reference now gets replaced); the array contents are immutable at the type level.
- New private `appendCheckpoint(checkpoint)` method — single mutation seam that always reassigns the field to a cap-trimmed array. `MAX_RETAINED_CHECKPOINTS = 32` is now a structural invariant of the array shape, not a per-call-site loop.
- `maybeAdvanceCheckpoint` calls `appendCheckpoint(...)` instead of the inline `.push` + `while .shift()` pattern.

## Why
Follow-up from the architectural review (optional polish item): the 32-entry cap was previously enforced only by a `while` loop next to a `.push` call. A future mutation site that forgot the eviction loop would silently grow the checkpoint list unbounded. Routing all writes through `appendCheckpoint` makes the bound a structural property of the type (`ReadonlyArray` + single setter) rather than a convention.

**No behaviour change** — eviction policy (drop oldest first) is preserved. Per-checkpoint cost goes from amortized-O(1) `.push` to O(n) array-spread, but n ≤ 32 and critical versions arrive infrequently (a few per editing session), so the difference is negligible — and the original eviction path already paid for an O(n) `.shift()` loop. `dist/index.d.ts` grew 8.83 → 9.19 KB because TypeScript emits private members for class-structure compat; public API surface unchanged.

## Test plan
- [x] `pnpm --filter @softmaple/eg-walker lint` (clean)
- [x] `pnpm --filter @softmaple/eg-walker typecheck` (clean)
- [x] `pnpm --filter @softmaple/eg-walker test -- --run` (254/254 pass)
- [x] `pnpm --filter @softmaple/eg-walker build` (success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)