### PR TITLE
refactor(packages/eg-walker): split large files into focused internals

### DIFF
--- a/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
+++ b/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
@@ -1,0 +1,72 @@
+import type { CriticalVersionAnalyzer } from "../../engine/critical-version";
+import type { ReplayCheckpoint } from "../../engine/partial-replay";
+import type { EventGraph } from "../../graph/event-graph";
+import type { EventId } from "../../types";
+
+const MAX_RETAINED_CHECKPOINTS = 32;
+
+export type CriticalCheckpoint = ReplayCheckpoint;
+
+export class CriticalCheckpointStore {
+  private checkpoints: ReadonlyArray<CriticalCheckpoint> = [];
+
+  constructor(private readonly analyzer: CriticalVersionAnalyzer) {}
+
+  get count(): number {
+    return this.checkpoints.length;
+  }
+
+  maybeAdvance(graph: EventGraph, document: string): void {
+    const frontier = graph.getFrontier();
+    if (frontier.size !== 1) {
+      return;
+    }
+    if (!this.analyzer.isCritical(graph, frontier)) {
+      return;
+    }
+    const last = this.checkpoints[this.checkpoints.length - 1];
+    if (last && versionsEqual(last.version, frontier)) {
+      return;
+    }
+    this.append({
+      version: new Set(frontier),
+      text: document,
+    });
+  }
+
+  pickFor(graph: EventGraph): CriticalCheckpoint | null {
+    for (let i = this.checkpoints.length - 1; i >= 0; i--) {
+      const candidate = this.checkpoints[i];
+      if (!candidate) {
+        continue;
+      }
+      if (this.analyzer.isCritical(graph, candidate.version)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private append(checkpoint: CriticalCheckpoint): void {
+    const next = [...this.checkpoints, checkpoint];
+    this.checkpoints =
+      next.length <= MAX_RETAINED_CHECKPOINTS
+        ? next
+        : next.slice(next.length - MAX_RETAINED_CHECKPOINTS);
+  }
+}
+
+const versionsEqual = (
+  left: ReadonlySet<EventId>,
+  right: ReadonlySet<EventId>,
+): boolean => {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const id of left) {
+    if (!right.has(id)) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/packages/eg-walker/src/core/internals/persistence-metadata.ts
+++ b/packages/eg-walker/src/core/internals/persistence-metadata.ts
@@ -1,0 +1,32 @@
+import type { EventGraph } from "../../graph/event-graph";
+
+export interface ReplicaPersistenceMetadata {
+  readonly initialText?: string;
+  readonly nextSequenceNumber?: number;
+}
+
+export const readReplicaMetadata = (
+  graph: EventGraph,
+): ReplicaPersistenceMetadata => {
+  const raw = graph.getMetadata();
+  const rawInitialText = raw.initialText;
+  const rawNextSequenceNumber = raw.nextSequenceNumber;
+  return {
+    initialText:
+      typeof rawInitialText === "string" ? rawInitialText : undefined,
+    nextSequenceNumber:
+      typeof rawNextSequenceNumber === "number"
+        ? rawNextSequenceNumber
+        : undefined,
+  };
+};
+
+export const writeReplicaMetadata = (
+  graph: EventGraph,
+  metadata: ReplicaPersistenceMetadata,
+): void => {
+  graph.setMetadata({
+    ...graph.getMetadata(),
+    ...metadata,
+  });
+};

--- a/packages/eg-walker/src/core/internals/remote-event-buffer.ts
+++ b/packages/eg-walker/src/core/internals/remote-event-buffer.ts
@@ -16,10 +16,26 @@ export class RemoteEventBuffer {
 
   constructor(private readonly deps: RemoteEventBufferDeps) {}
 
+  /**
+   * Number of remote events currently held back awaiting their causal parents.
+   *
+   * @returns {number} count of buffered events.
+   */
   get pendingCount(): number {
     return this.bufferedEventIds.size;
   }
 
+  /**
+   * Apply a remote event, or buffer it until its missing parents arrive.
+   *
+   * If `event` is already in the graph or already buffered it is ignored.
+   * If any parent is unknown the event is queued against the missing parent
+   * id; the queue is flushed when that parent is later accepted. Otherwise
+   * the event is added to the graph and `deps.advanceWithEvent` is invoked,
+   * then any waiters queued on this event's id are recursively accepted.
+   *
+   * @param {GraphEvent} event remote event to accept or buffer.
+   */
   tryAccept(event: GraphEvent): void {
     const { graph } = this.deps;
     if (graph.hasEvent(event.id) || this.bufferedEventIds.has(event.id)) {

--- a/packages/eg-walker/src/core/internals/remote-event-buffer.ts
+++ b/packages/eg-walker/src/core/internals/remote-event-buffer.ts
@@ -1,0 +1,74 @@
+import {
+  EventAlreadyExistsError,
+  MissingParentError,
+  type EventGraph,
+} from "../../graph/event-graph";
+import type { EventId, GraphEvent } from "../../types";
+
+interface RemoteEventBufferDeps {
+  readonly graph: EventGraph;
+  readonly advanceWithEvent: (event: GraphEvent) => void;
+}
+
+export class RemoteEventBuffer {
+  private readonly pendingByMissingParent = new Map<EventId, GraphEvent[]>();
+  private readonly bufferedEventIds = new Set<EventId>();
+
+  constructor(private readonly deps: RemoteEventBufferDeps) {}
+
+  get pendingCount(): number {
+    return this.bufferedEventIds.size;
+  }
+
+  tryAccept(event: GraphEvent): void {
+    const { graph } = this.deps;
+    if (graph.hasEvent(event.id) || this.bufferedEventIds.has(event.id)) {
+      return;
+    }
+
+    const missingParent = this.findMissingParent(event);
+    if (missingParent !== null) {
+      const queue = this.pendingByMissingParent.get(missingParent) ?? [];
+      queue.push(event);
+      this.pendingByMissingParent.set(missingParent, queue);
+      this.bufferedEventIds.add(event.id);
+      return;
+    }
+
+    try {
+      graph.addEvent(event);
+    } catch (error) {
+      if (
+        error instanceof EventAlreadyExistsError ||
+        error instanceof MissingParentError
+      ) {
+        return;
+      }
+      throw error;
+    }
+
+    this.deps.advanceWithEvent(event);
+    this.flushPendingChildrenOf(event.id);
+  }
+
+  private findMissingParent(event: GraphEvent): EventId | null {
+    for (const parentId of event.parentVersion) {
+      if (!this.deps.graph.hasEvent(parentId)) {
+        return parentId;
+      }
+    }
+    return null;
+  }
+
+  private flushPendingChildrenOf(parentId: EventId): void {
+    const waiters = this.pendingByMissingParent.get(parentId);
+    if (!waiters) {
+      return;
+    }
+    this.pendingByMissingParent.delete(parentId);
+    for (const waiter of waiters) {
+      this.bufferedEventIds.delete(waiter.id);
+      this.tryAccept(waiter);
+    }
+  }
+}

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -18,81 +18,23 @@ import type {
   SerializedGraphOutput,
 } from "../types";
 import {
+  CriticalCheckpointStore,
+  type CriticalCheckpoint,
+} from "./internals/critical-checkpoint-store";
+import {
   assertRemoteEventWellFormed,
   assertWellFormedUtf16,
   createDocumentState,
 } from "./invariants";
-import {
-  EventGraph,
-  EventAlreadyExistsError,
-  MissingParentError,
-} from "../graph/event-graph";
+import { EventGraph, EventAlreadyExistsError } from "../graph/event-graph";
 import { EgWalkerEngine } from "../engine/eg-walker-engine";
 import { CriticalVersionAnalyzer } from "../engine/critical-version";
 import { PartialReplayManager } from "../engine/partial-replay";
-
-interface CriticalCheckpoint {
-  readonly version: Version;
-  readonly text: string;
-}
-
-/**
- * Upper bound on retained critical checkpoints.
- *
- * Section 3.5/3.6 of the Eg-walker paper requires *some* critical-version
- * snapshot in scope to skip the full-replay path when a concurrent branch
- * arrives; the latest dominating checkpoint is always the cheapest one to
- * replay from, and any older checkpoint is only useful when a concurrent
- * branch is rooted earlier than every retained checkpoint. Capping the
- * retained list at this many newest entries keeps replica memory O(1) in
- * history length without sacrificing the common-case partial-replay path
- * (the worst case — a concurrent branch rooted before the oldest retained
- * checkpoint — falls back to {@link fullReplay}, which is already the
- * pre-checkpoint behaviour).
- *
- * The value is empirical: 32 is comfortably above the number of distinct
- * critical versions any single editing session is expected to materialise
- * between concurrent merges, while bounding each checkpoint's per-replica
- * cost (a frontier `Set` plus a snapshot text string) at a few KB worst
- * case for ordinary documents.
- */
-const MAX_RETAINED_CHECKPOINTS = 32;
-
-/**
- * Persistence schema the replica writes into (and reads from) the event
- * graph's free-form metadata bag. The graph itself is codec-agnostic and
- * stores arbitrary `Record<string, unknown>`; centralising the known fields
- * here keeps the schema in one place and turns the previous inline
- * `typeof` guards into a single typed surface.
- */
-interface ReplicaPersistenceMetadata {
-  readonly initialText?: string;
-  readonly nextSequenceNumber?: number;
-}
-
-const readReplicaMetadata = (graph: EventGraph): ReplicaPersistenceMetadata => {
-  const raw = graph.getMetadata();
-  const rawInitialText = raw.initialText;
-  const rawNextSequenceNumber = raw.nextSequenceNumber;
-  return {
-    initialText:
-      typeof rawInitialText === "string" ? rawInitialText : undefined,
-    nextSequenceNumber:
-      typeof rawNextSequenceNumber === "number"
-        ? rawNextSequenceNumber
-        : undefined,
-  };
-};
-
-const writeReplicaMetadata = (
-  graph: EventGraph,
-  metadata: ReplicaPersistenceMetadata,
-): void => {
-  graph.setMetadata({
-    ...graph.getMetadata(),
-    ...metadata,
-  });
-};
+import {
+  readReplicaMetadata,
+  writeReplicaMetadata,
+} from "./internals/persistence-metadata";
+import { RemoteEventBuffer } from "./internals/remote-event-buffer";
 
 /**
  * Public replica for Eg-walker.
@@ -105,14 +47,15 @@ export class EgWalkerReplica {
   private currentVersion: Version = new Set();
   private nextSequenceNumber = 0;
   private engine: EgWalkerEngine | null = null;
-  private readonly pendingByMissingParent = new Map<EventId, GraphEvent[]>();
-  private readonly bufferedEventIds = new Set<EventId>();
+  private readonly remoteEvents: RemoteEventBuffer;
   private fullReplayCount = 0;
   private partialReplayCount = 0;
   private incrementalApplyCount = 0;
   private readonly criticalAnalyzer = new CriticalVersionAnalyzer();
+  private readonly criticalCheckpoints = new CriticalCheckpointStore(
+    this.criticalAnalyzer,
+  );
   private readonly partialReplayer = new PartialReplayManager();
-  private criticalCheckpoints: ReadonlyArray<CriticalCheckpoint> = [];
 
   constructor(
     private readonly replicaId: string,
@@ -123,6 +66,10 @@ export class EgWalkerReplica {
     this.document = initialText;
     this.initialText = initialText;
     this.eventGraph = eventGraph ?? new EventGraph();
+    this.remoteEvents = new RemoteEventBuffer({
+      graph: this.eventGraph,
+      advanceWithEvent: (event) => this.advanceWithEvent(event),
+    });
     this.currentVersion = this.eventGraph.getFrontier();
     this.nextSequenceNumber = this.inferNextSequenceNumber();
     if (this.eventGraph.getAllEvents().length > 0) {
@@ -254,7 +201,7 @@ export class EgWalkerReplica {
    */
   applyRemoteEvent(event: GraphEvent): void {
     assertRemoteEventWellFormed(event);
-    this.tryAcceptRemoteEvent(event);
+    this.remoteEvents.tryAccept(event);
   }
 
   /**
@@ -262,7 +209,7 @@ export class EgWalkerReplica {
    * Exposed primarily for tests and diagnostics.
    */
   getPendingRemoteCount(): number {
-    return this.bufferedEventIds.size;
+    return this.remoteEvents.pendingCount;
   }
 
   /**
@@ -292,7 +239,7 @@ export class EgWalkerReplica {
       incrementalApplies: this.incrementalApplyCount,
       engineRetreats: engineStats?.retreatCount ?? 0,
       engineAdvances: engineStats?.advanceCount ?? 0,
-      checkpointCount: this.criticalCheckpoints.length,
+      checkpointCount: this.criticalCheckpoints.count,
       sequenceRecordCount: engineStats?.sequenceRecordCount ?? 0,
     };
   }
@@ -442,7 +389,7 @@ export class EgWalkerReplica {
       return;
     }
 
-    const checkpoint = this.pickCheckpoint();
+    const checkpoint = this.criticalCheckpoints.pickFor(this.eventGraph);
     if (checkpoint) {
       this.partialReplayFromCheckpoint(checkpoint);
     } else {
@@ -473,69 +420,8 @@ export class EgWalkerReplica {
     return true;
   }
 
-  /**
-   * Snapshot the current (version, text) pair when the graph's frontier is a
-   * single-element critical version. These checkpoints let later concurrent
-   * branches partial-replay only the post-checkpoint suffix instead of the
-   * whole graph.
-   *
-   * The retained list is capped at {@link MAX_RETAINED_CHECKPOINTS} entries —
-   * a long linear history evicts the oldest checkpoints, keeping replica
-   * memory O(1) in history length. A concurrent branch rooted before every
-   * retained checkpoint falls back to {@link fullReplay}, the same path the
-   * replica took before checkpoints existed at all.
-   */
   private maybeAdvanceCheckpoint(): void {
-    const frontier = this.eventGraph.getFrontier();
-    if (frontier.size !== 1) {
-      return;
-    }
-    if (!this.criticalAnalyzer.isCritical(this.eventGraph, frontier)) {
-      return;
-    }
-    const last = this.criticalCheckpoints[this.criticalCheckpoints.length - 1];
-    if (last && this.versionsEqual(last.version, frontier)) {
-      return;
-    }
-    this.appendCheckpoint({
-      version: new Set(frontier),
-      text: this.document,
-    });
-  }
-
-  /**
-   * Single seam for growing {@link criticalCheckpoints}. Routing every write
-   * through here makes the {@link MAX_RETAINED_CHECKPOINTS} cap a structural
-   * invariant of the array rather than a per-call-site convention, so a
-   * future mutation site cannot drift past the bound by forgetting an
-   * eviction loop.
-   */
-  private appendCheckpoint(checkpoint: CriticalCheckpoint): void {
-    const next = [...this.criticalCheckpoints, checkpoint];
-    this.criticalCheckpoints =
-      next.length <= MAX_RETAINED_CHECKPOINTS
-        ? next
-        : next.slice(next.length - MAX_RETAINED_CHECKPOINTS);
-  }
-
-  /**
-   * Latest checkpoint that is still a critical version of the current graph.
-   * Critical versions are causally ordered, so scanning newest-first returns
-   * the deepest dominating checkpoint.
-   */
-  private pickCheckpoint(): CriticalCheckpoint | null {
-    for (let i = this.criticalCheckpoints.length - 1; i >= 0; i--) {
-      const candidate = this.criticalCheckpoints[i];
-      if (!candidate) {
-        continue;
-      }
-      if (
-        this.criticalAnalyzer.isCritical(this.eventGraph, candidate.version)
-      ) {
-        return candidate;
-      }
-    }
-    return null;
+    this.criticalCheckpoints.maybeAdvance(this.eventGraph, this.document);
   }
 
   private partialReplayFromCheckpoint(checkpoint: CriticalCheckpoint): void {
@@ -549,75 +435,6 @@ export class EgWalkerReplica {
     this.document = result.text;
     this.currentVersion = frontier;
     this.partialReplayCount++;
-  }
-
-  private versionsEqual(
-    left: ReadonlySet<EventId>,
-    right: ReadonlySet<EventId>,
-  ): boolean {
-    if (left.size !== right.size) {
-      return false;
-    }
-    for (const id of left) {
-      if (!right.has(id)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private tryAcceptRemoteEvent(event: GraphEvent): void {
-    if (
-      this.eventGraph.hasEvent(event.id) ||
-      this.bufferedEventIds.has(event.id)
-    ) {
-      return;
-    }
-
-    const missingParent = this.findMissingParent(event);
-    if (missingParent !== null) {
-      const queue = this.pendingByMissingParent.get(missingParent) ?? [];
-      queue.push(event);
-      this.pendingByMissingParent.set(missingParent, queue);
-      this.bufferedEventIds.add(event.id);
-      return;
-    }
-
-    try {
-      this.eventGraph.addEvent(event);
-    } catch (error) {
-      if (
-        error instanceof EventAlreadyExistsError ||
-        error instanceof MissingParentError
-      ) {
-        return;
-      }
-      throw error;
-    }
-
-    this.advanceWithEvent(event);
-    this.flushPendingChildrenOf(event.id);
-  }
-
-  private findMissingParent(event: GraphEvent): EventId | null {
-    for (const parentId of event.parentVersion) {
-      if (!this.eventGraph.hasEvent(parentId)) {
-        return parentId;
-      }
-    }
-    return null;
-  }
-
-  private flushPendingChildrenOf(parentId: EventId): void {
-    const waiters = this.pendingByMissingParent.get(parentId);
-    if (!waiters) {
-      return;
-    }
-    this.pendingByMissingParent.delete(parentId);
-    for (const waiter of waiters) {
-      this.bufferedEventIds.delete(waiter.id);
-      this.tryAcceptRemoteEvent(waiter);
-    }
   }
 
   private inferNextSequenceNumber(): number {

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -412,7 +412,7 @@ export class EgWalkerEngine {
       .sort((left, right) =>
         left.order !== right.order
           ? right.order - left.order
-          : compareEventIds(right.id, left.id),
+          : this.compareByTopologicalOrder(right.id, left.id),
       )
       .map(({ id }) => id);
     const advance = Array.from(onlyInRight)
@@ -423,7 +423,7 @@ export class EgWalkerEngine {
       .sort((left, right) =>
         left.order !== right.order
           ? left.order - right.order
-          : compareEventIds(left.id, right.id),
+          : this.compareByTopologicalOrder(left.id, right.id),
       )
       .map(({ id }) => id);
 

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -1,9 +1,10 @@
 import { OPERATION_TYPE } from "../constants/operation-types";
 import { EventGraph } from "../graph/event-graph";
-import { compareEventIds, parseEventId } from "../graph/event-id";
+import { compareEventIds } from "../graph/event-id";
 import type { EventId, ExternalOperation, GraphEvent } from "../types";
 import { IndexedSequence } from "./indexed-sequence";
 import { DeleteTargetIndex } from "./internals/delete-target-index";
+import { applyDelete } from "./internals/delete-handler";
 import {
   PLACEHOLDER_EVENT_ID,
   PLACEHOLDER_ID_PREFIX,
@@ -12,18 +13,12 @@ import {
   type GeneratedDocument,
   type GenerateOptions,
   type IncrementalApplyResult,
-  type TypedRun,
 } from "./internals/engine-types";
+import { applyInsert } from "./internals/insert-handler";
 import { OriginLeftIndex } from "./internals/origin-left-index";
 import { PendingInsertBuffer } from "./internals/pending-insert-buffer";
 import { RecordSplitter } from "./internals/record-splitter";
-import {
-  coalesceDeleteRuns,
-  deleteText,
-  spliceText,
-  stringCodeUnits,
-} from "./internals/text-utils";
-import { findIntegrationPosition } from "./internals/yata-integration";
+import { spliceText } from "./internals/text-utils";
 
 export type {
   EngineStats,
@@ -291,337 +286,36 @@ export class EgWalkerEngine {
     const operation = event.operation;
 
     if (operation.type === OPERATION_TYPE.INSERT) {
-      return this.applyInsert(event, operation);
+      return applyInsert(event, operation, {
+        sequence: this.sequence,
+        itemsById: this.itemsById,
+        eventItems: this.eventItems,
+        originLeftIndex: this.originLeftIndex,
+        recordSplitter: this.recordSplitter,
+        pendingInsert: this.pendingInsert,
+        applyPendingSplice: this.applyPendingSplice,
+        flushPendingInsert: () => this.flushPendingInsert(),
+        itemToEffectIndex: (target) => this.itemToEffectIndex(target),
+        requireItem: (itemId) => this.requireItem(itemId),
+        getResultingText: () => this.resultingText,
+        setResultingText: (text) => {
+          this.resultingText = text;
+        },
+      });
     }
 
-    return this.applyDelete(event, operation);
-  }
-
-  private applyInsert(
-    event: GraphEvent,
-    operation: Extract<
-      ExternalOperation,
-      { type: typeof OPERATION_TYPE.INSERT }
-    >,
-  ): ExternalOperation[] {
-    if (operation.text.length === 0) {
-      this.eventItems.set(event.id, []);
-      return [];
-    }
-
-    const landing = this.sequence.prepareIndexToPositionAndOffset(
-      operation.index,
-      true,
-    );
-    const firstInsertPosition =
-      landing.offsetInRecord > 0
-        ? this.recordSplitter.splitRecordAt(
-            landing.position,
-            landing.offsetInRecord,
-          )
-        : landing.position;
-    // YATA-style origins: anchor against the records visible in the
-    // event's parent version (prepare-state >= 1), NOT against whichever
-    // concurrent records happen to be sitting in the sequence right now.
-    // Without this filter the engine would assign different origins to
-    // the same event depending on which concurrent siblings were
-    // integrated first, breaking traversal-order independence.
-    const originLeftPosition =
-      this.sequence.previousPrepareVisiblePosition(firstInsertPosition);
-    const originLeft =
-      originLeftPosition === null
-        ? null
-        : (this.sequence.at(originLeftPosition)?.id ?? null);
-    const originRightPosition =
-      this.sequence.nextPrepareVisiblePosition(firstInsertPosition);
-    const originRight =
-      originRightPosition === null
-        ? null
-        : (this.sequence.at(originRightPosition)?.id ?? null);
-
-    // Section 3.4 internal-document fast path for the first item.
-    //
-    // The YATA integration scan walks the sequence positions strictly
-    // between `originLeft` and `originRight`. When that range is empty
-    // (no retreated, deleted, or otherwise non-prepare-visible records
-    // sit in it) the scan is provably a no-op, so we can place the
-    // first item at `firstInsertPosition` without invoking it. The
-    // dominant case for this is a non-conflicting run: no concurrent
-    // siblings have been integrated near the insertion point, so the
-    // previous-prepare-visible record is the literal neighbour of
-    // `firstInsertPosition`.
-    const leftBound = originLeftPosition ?? -1;
-    const rightBound = originRightPosition ?? this.sequence.length;
-    const conflictRegionEmpty =
-      leftBound + 1 === firstInsertPosition &&
-      firstInsertPosition === rightBound;
-
-    // Section 3.4 "smaller" lever: typed-run coalescing.
-    //
-    // When a single-character INSERT lands at the right boundary of an
-    // adjacent typed-run record from the same author whose run extends by
-    // exactly one sequence number, append to that record's content
-    // instead of allocating a new CRDT item. The columnar codec already
-    // groups events into id-runs by (replicaId, contiguous sequence) for
-    // wire encoding; mirroring that grouping in the ranked B-tree
-    // collapses a 20k-character linear single-author trace to ~1 record
-    // (down from one per code unit) while leaving multi-author / multi-event
-    // ordering unchanged — split-on-demand carves the run when a
-    // concurrent insert or delete anchors inside it.
-    const parsed = parseEventId(event.id);
-    if (
-      conflictRegionEmpty &&
-      operation.text.length === 1 &&
-      parsed !== null &&
-      originLeftPosition !== null &&
-      originLeftPosition === firstInsertPosition - 1
-    ) {
-      const leftRecord = this.sequence.at(originLeftPosition);
-      if (
-        leftRecord !== undefined &&
-        leftRecord.run !== null &&
-        leftRecord.run.replicaId === parsed.replicaId &&
-        leftRecord.run.startSequence + leftRecord.content.length ===
-          parsed.sequence &&
-        leftRecord.prepareState === 1 &&
-        !leftRecord.everDeleted &&
-        // Don't extend a run that already has items anchored to its right
-        // boundary — those items chose this id as their `originLeft` at a
-        // moment when the record ended one code unit earlier, and stretching
-        // the content would shift the boundary they were anchored to.
-        !this.originLeftIndex.has(leftRecord.id)
-      ) {
-        const effectIndex =
-          this.itemToEffectIndex(leftRecord) + leftRecord.content.length;
-        leftRecord.content += operation.text;
-        this.sequence.updateItem(leftRecord);
-        this.eventItems.set(event.id, [leftRecord.id]);
-        // Defer the splice on {@link resultingText} into the
-        // pending-insert buffer so a long single-author typed run doesn't
-        // pay an O(document length) string realloc per keystroke.
-        // {@link flushPendingInsert} materialises the buffer before any
-        // non-coalesced read or write of the document text.
-        this.pendingInsert.append(
-          effectIndex,
-          operation.text,
-          this.applyPendingSplice,
-        );
-
-        return [
-          {
-            type: OPERATION_TYPE.INSERT,
-            index: effectIndex,
-            text: operation.text,
-          },
-        ];
-      }
-    }
-
-    const codeUnits = stringCodeUnits(operation.text);
-    const insertedIds: EventId[] = [];
-    let left = originLeft;
-
-    // First code unit: pay the full integration scan if the conflict region
-    // isn't empty. Single-character INSERTs from a canonical
-    // `replicaId:sequence` author seed a typed-run record so that later
-    // contiguous events from the same author can extend it in-place (the
-    // coalescing branch above). Multi-character INSERTs and IDs that don't
-    // parse keep `run = null` and behave like the pre-coalescing engine.
-    const firstRun: TypedRun | null =
-      parsed !== null && operation.text.length === 1
-        ? { replicaId: parsed.replicaId, startSequence: parsed.sequence }
-        : null;
-    const firstItem: AugmentedCRDTItem = {
-      id: `${event.id}:0`,
-      eventId: event.id,
-      content: codeUnits[0] ?? "",
-      originLeft: left,
-      originRight,
-      everDeleted: false,
-      prepareState: 1,
-      run: firstRun,
-    };
-    let actualFirstPosition: number;
-    if (conflictRegionEmpty) {
-      actualFirstPosition = firstInsertPosition;
-      this.sequence.insert(actualFirstPosition, firstItem);
-    } else {
-      actualFirstPosition = findIntegrationPosition(
-        firstItem,
-        this.sequence,
-        this.itemsById,
-      );
-      this.sequence.insert(actualFirstPosition, firstItem);
-    }
-    this.itemsById.set(firstItem.id, firstItem);
-    this.originLeftIndex.track(firstItem.id, firstItem.originLeft);
-    insertedIds.push(firstItem.id);
-    left = firstItem.id;
-
-    // Multi-character inserts: every subsequent item is chained off the
-    // previous item via `originLeft`. No record that existed before this
-    // event can reference that brand-new id, so the YATA scan for chars
-    // 1..N terminates on its first iteration and the integration
-    // position is unconditionally `previous + 1`. We bypass the scan
-    // and place them at sequential positions instead of paying
-    // `findIntegrationPosition`'s setup cost per character. The items
-    // stay `run = null` because typed-run coalescing operates on
-    // single-character events from contiguous sequence numbers, not on
-    // the per-code-unit fragments of one multi-character INSERT.
-    for (let offset = 1; offset < codeUnits.length; offset++) {
-      const item: AugmentedCRDTItem = {
-        id: `${event.id}:${offset}`,
-        eventId: event.id,
-        content: codeUnits[offset] ?? "",
-        originLeft: left,
-        originRight,
-        everDeleted: false,
-        prepareState: 1,
-        run: null,
-      };
-      this.sequence.insert(actualFirstPosition + offset, item);
-      this.itemsById.set(item.id, item);
-      this.originLeftIndex.track(item.id, item.originLeft);
-      insertedIds.push(item.id);
-      left = item.id;
-    }
-
-    this.eventItems.set(event.id, insertedIds);
-
-    const firstInserted = this.requireItem(insertedIds[0] ?? event.id);
-    const effectIndex = this.itemToEffectIndex(firstInserted);
-    // A non-coalesced insert (multi-character event, new typed-run seed,
-    // or non-empty conflict region) must observe the current document so
-    // {@link effectIndex} aligns with {@link resultingText}. Drain any
-    // open typed-run buffer before splicing. Hoist the empty-buffer check
-    // inline because this is the per-event hot path for non-coalescing
-    // inserts and the buffer is empty on every full-replay event.
-    if (!this.pendingInsert.isEmpty()) {
-      this.flushPendingInsert();
-    }
-    this.resultingText = spliceText(
-      this.resultingText,
-      effectIndex,
-      operation.text,
-    );
-
-    return [
-      {
-        type: OPERATION_TYPE.INSERT,
-        index: effectIndex,
-        text: operation.text,
+    return applyDelete(event, operation, {
+      sequence: this.sequence,
+      deleteTargets: this.deleteTargets,
+      recordSplitter: this.recordSplitter,
+      pendingInsert: this.pendingInsert,
+      flushPendingInsert: () => this.flushPendingInsert(),
+      itemToEffectIndex: (target) => this.itemToEffectIndex(target),
+      getResultingText: () => this.resultingText,
+      setResultingText: (text) => {
+        this.resultingText = text;
       },
-    ];
-  }
-
-  private applyDelete(
-    event: GraphEvent,
-    operation: Extract<
-      ExternalOperation,
-      { type: typeof OPERATION_TYPE.DELETE }
-    >,
-  ): ExternalOperation[] {
-    // Any concurrent insert or delete breaks the typed-run we may have
-    // been coalescing into the pending-insert buffer. Flush before we
-    // start carving records and slicing the document text so the per-slot
-    // {@link effectIndex} arithmetic below operates on the materialised
-    // document. Hoist the empty-buffer check inline because `applyDelete`
-    // is on the per-event hot path and the buffer is empty on every
-    // non-coalescing trace, so the inline check saves a function call on
-    // the common case.
-    if (!this.pendingInsert.isEmpty()) {
-      this.flushPendingInsert();
-    }
-    const deletedItemIds: EventId[] = [];
-    const outputDeleteIndexes: number[] = [];
-    let remaining = operation.length;
-
-    while (remaining > 0) {
-      // A delete event whose `length` runs past the prepare-visible items at
-      // the engine's current parent version legitimately stops short — this
-      // is exercised by the "deletes that run past visible prepare items"
-      // test. The previous implementation wrapped the throwing
-      // `prepareIndexToPositionAndOffset` in a catch-all try/catch, which
-      // also swallowed real bugs (e.g. ranked-B-tree aggregate corruption).
-      // Use the explicit non-throwing variant for the expected end-of-text
-      // case, and let other errors surface.
-      const landing = this.sequence.tryPrepareIndexToPositionAndOffset(
-        operation.index,
-        false,
-      );
-      if (!landing) {
-        break;
-      }
-      const candidate = this.sequence.at(landing.position);
-      if (!candidate) {
-        // The ranked B-tree just told us the prepare-weight prefix sum lands
-        // on `landing.position`, so a missing record there means the tree's
-        // aggregates disagree with its children — a structural bug we want
-        // to surface, not silently truncate the delete around.
-        throw new Error(
-          `Engine bug: prepare-index ${operation.index} landed at sequence position ` +
-            `${landing.position} but no record exists there (remaining=${remaining}).`,
-        );
-      }
-
-      // Multi-character records (placeholders and typed-run leaves coalesced
-      // by Section 3.4) are split on demand so the deleted slice is its own
-      // record. Single-character records and per-code-unit paste fragments
-      // skip the split entirely and are marked in place.
-      const isMultiCharRecord =
-        (candidate.eventId === PLACEHOLDER_EVENT_ID ||
-          candidate.run !== null) &&
-        candidate.content.length > 1;
-      if (isMultiCharRecord) {
-        const availableInRecord =
-          candidate.content.length - landing.offsetInRecord;
-        const toDelete = Math.min(remaining, availableInRecord);
-        const middle = this.recordSplitter.splitRecordForDelete(
-          landing.position,
-          landing.offsetInRecord,
-          toDelete,
-        );
-
-        deletedItemIds.push(middle.id);
-        // A concurrent delete that lands on an already-effect-deleted slice
-        // (e.g. after retreating an overlapping sibling) must NOT remove
-        // characters from the text again. Without this, two concurrent
-        // deletes of the same region replay to a shorter string than full
-        // replay produces.
-        if (!middle.everDeleted) {
-          const effectIndex = this.itemToEffectIndex(middle);
-          for (let k = 0; k < toDelete; k++) {
-            outputDeleteIndexes.push(effectIndex);
-          }
-          this.resultingText = deleteText(
-            this.resultingText,
-            effectIndex,
-            toDelete,
-          );
-        }
-
-        middle.everDeleted = true;
-        middle.prepareState += 1;
-        this.sequence.updateItem(middle);
-        remaining -= toDelete;
-        continue;
-      }
-
-      deletedItemIds.push(candidate.id);
-      if (!candidate.everDeleted) {
-        const effectIndex = this.itemToEffectIndex(candidate);
-        outputDeleteIndexes.push(effectIndex);
-        this.resultingText = deleteText(this.resultingText, effectIndex, 1);
-      }
-      candidate.everDeleted = true;
-      candidate.prepareState += 1;
-      this.sequence.updateItem(candidate);
-      remaining -= 1;
-    }
-
-    this.deleteTargets.record(event.id, deletedItemIds);
-
-    return coalesceDeleteRuns(outputDeleteIndexes);
+    });
   }
 
   private retreat(eventId: EventId): void {
@@ -710,12 +404,28 @@ export class EgWalkerEngine {
       targetVersion,
     );
 
-    const retreat = Array.from(onlyInLeft).sort((left, right) =>
-      this.compareByTopologicalOrder(right, left),
-    );
-    const advance = Array.from(onlyInRight).sort((left, right) =>
-      this.compareByTopologicalOrder(left, right),
-    );
+    const retreat = Array.from(onlyInLeft)
+      .map((id) => ({
+        id,
+        order: this.eventOrder.get(id) ?? Number.MAX_SAFE_INTEGER,
+      }))
+      .sort((left, right) =>
+        left.order !== right.order
+          ? right.order - left.order
+          : compareEventIds(right.id, left.id),
+      )
+      .map(({ id }) => id);
+    const advance = Array.from(onlyInRight)
+      .map((id) => ({
+        id,
+        order: this.eventOrder.get(id) ?? Number.MAX_SAFE_INTEGER,
+      }))
+      .sort((left, right) =>
+        left.order !== right.order
+          ? left.order - right.order
+          : compareEventIds(left.id, right.id),
+      )
+      .map(({ id }) => id);
 
     return { retreat, advance };
   }

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -428,9 +428,7 @@ export class EgWalkerEngine {
   // Pre-materialise the topological rank per id so the sort comparator
   // doesn't pay two `eventOrder.get()` calls per comparison. When two ids
   // share a rank (unknown ids both default to MAX_SAFE_INTEGER), fall back
-  // to {@link compareEventIds} directly instead of round-tripping through
-  // {@link compareByTopologicalOrder} — the inner method would just repeat
-  // the same map lookups before falling through to the same compare.
+  // to {@link compareEventIds} for a stable lex tiebreak.
   private sortByEventOrder(
     ids: Iterable<EventId>,
     descending: boolean,
@@ -448,15 +446,6 @@ export class EgWalkerEngine {
         : compareEventIds(left.id, right.id);
     });
     return ranked.map(({ id }) => id);
-  }
-
-  private compareByTopologicalOrder(left: EventId, right: EventId): number {
-    const leftOrder = this.eventOrder.get(left) ?? Number.MAX_SAFE_INTEGER;
-    const rightOrder = this.eventOrder.get(right) ?? Number.MAX_SAFE_INTEGER;
-    if (leftOrder !== rightOrder) {
-      return leftOrder - rightOrder;
-    }
-    return compareEventIds(left, right);
   }
 
   private requireItem(itemId: EventId): AugmentedCRDTItem {

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -4,7 +4,10 @@ import { compareEventIds } from "../graph/event-id";
 import type { EventId, ExternalOperation, GraphEvent } from "../types";
 import { IndexedSequence } from "./indexed-sequence";
 import { DeleteTargetIndex } from "./internals/delete-target-index";
-import { applyDelete } from "./internals/delete-handler";
+import {
+  applyDelete,
+  type DeleteHandlerDeps,
+} from "./internals/delete-handler";
 import {
   PLACEHOLDER_EVENT_ID,
   PLACEHOLDER_ID_PREFIX,
@@ -14,7 +17,10 @@ import {
   type GenerateOptions,
   type IncrementalApplyResult,
 } from "./internals/engine-types";
-import { applyInsert } from "./internals/insert-handler";
+import {
+  applyInsert,
+  type InsertHandlerDeps,
+} from "./internals/insert-handler";
 import { OriginLeftIndex } from "./internals/origin-left-index";
 import { PendingInsertBuffer } from "./internals/pending-insert-buffer";
 import { RecordSplitter } from "./internals/record-splitter";
@@ -286,36 +292,10 @@ export class EgWalkerEngine {
     const operation = event.operation;
 
     if (operation.type === OPERATION_TYPE.INSERT) {
-      return applyInsert(event, operation, {
-        sequence: this.sequence,
-        itemsById: this.itemsById,
-        eventItems: this.eventItems,
-        originLeftIndex: this.originLeftIndex,
-        recordSplitter: this.recordSplitter,
-        pendingInsert: this.pendingInsert,
-        applyPendingSplice: this.applyPendingSplice,
-        flushPendingInsert: () => this.flushPendingInsert(),
-        itemToEffectIndex: (target) => this.itemToEffectIndex(target),
-        requireItem: (itemId) => this.requireItem(itemId),
-        getResultingText: () => this.resultingText,
-        setResultingText: (text) => {
-          this.resultingText = text;
-        },
-      });
+      return applyInsert(event, operation, this.insertDeps);
     }
 
-    return applyDelete(event, operation, {
-      sequence: this.sequence,
-      deleteTargets: this.deleteTargets,
-      recordSplitter: this.recordSplitter,
-      pendingInsert: this.pendingInsert,
-      flushPendingInsert: () => this.flushPendingInsert(),
-      itemToEffectIndex: (target) => this.itemToEffectIndex(target),
-      getResultingText: () => this.resultingText,
-      setResultingText: (text) => {
-        this.resultingText = text;
-      },
-    });
+    return applyDelete(event, operation, this.deleteDeps);
   }
 
   private retreat(eventId: EventId): void {
@@ -391,6 +371,41 @@ export class EgWalkerEngine {
     this.resultingText = spliceText(this.resultingText, effectIndex, text);
   };
 
+  // Built once per engine instance so {@link processEvent} doesn't allocate a
+  // fresh deps object plus a handful of arrow closures on every applied event.
+  // The captured references (sequence, itemsById, etc.) are stable for the
+  // lifetime of the engine; mutations happen through the references, not by
+  // swapping them out, so a one-shot snapshot at construction is sound.
+  private readonly insertDeps: InsertHandlerDeps = {
+    sequence: this.sequence,
+    itemsById: this.itemsById,
+    eventItems: this.eventItems,
+    originLeftIndex: this.originLeftIndex,
+    recordSplitter: this.recordSplitter,
+    pendingInsert: this.pendingInsert,
+    applyPendingSplice: this.applyPendingSplice,
+    flushPendingInsert: () => this.flushPendingInsert(),
+    itemToEffectIndex: (target) => this.itemToEffectIndex(target),
+    requireItem: (itemId) => this.requireItem(itemId),
+    getResultingText: () => this.resultingText,
+    setResultingText: (text) => {
+      this.resultingText = text;
+    },
+  };
+
+  private readonly deleteDeps: DeleteHandlerDeps = {
+    sequence: this.sequence,
+    deleteTargets: this.deleteTargets,
+    recordSplitter: this.recordSplitter,
+    pendingInsert: this.pendingInsert,
+    flushPendingInsert: () => this.flushPendingInsert(),
+    itemToEffectIndex: (target) => this.itemToEffectIndex(target),
+    getResultingText: () => this.resultingText,
+    setResultingText: (text) => {
+      this.resultingText = text;
+    },
+  };
+
   private flushPendingInsert(): void {
     this.pendingInsert.flush(this.applyPendingSplice);
   }
@@ -404,30 +419,35 @@ export class EgWalkerEngine {
       targetVersion,
     );
 
-    const retreat = Array.from(onlyInLeft)
-      .map((id) => ({
-        id,
-        order: this.eventOrder.get(id) ?? Number.MAX_SAFE_INTEGER,
-      }))
-      .sort((left, right) =>
-        left.order !== right.order
-          ? right.order - left.order
-          : this.compareByTopologicalOrder(right.id, left.id),
-      )
-      .map(({ id }) => id);
-    const advance = Array.from(onlyInRight)
-      .map((id) => ({
-        id,
-        order: this.eventOrder.get(id) ?? Number.MAX_SAFE_INTEGER,
-      }))
-      .sort((left, right) =>
-        left.order !== right.order
-          ? left.order - right.order
-          : this.compareByTopologicalOrder(left.id, right.id),
-      )
-      .map(({ id }) => id);
+    return {
+      retreat: this.sortByEventOrder(onlyInLeft, true),
+      advance: this.sortByEventOrder(onlyInRight, false),
+    };
+  }
 
-    return { retreat, advance };
+  // Pre-materialise the topological rank per id so the sort comparator
+  // doesn't pay two `eventOrder.get()` calls per comparison. When two ids
+  // share a rank (unknown ids both default to MAX_SAFE_INTEGER), fall back
+  // to {@link compareEventIds} directly instead of round-tripping through
+  // {@link compareByTopologicalOrder} — the inner method would just repeat
+  // the same map lookups before falling through to the same compare.
+  private sortByEventOrder(
+    ids: Iterable<EventId>,
+    descending: boolean,
+  ): EventId[] {
+    const ranked = Array.from(ids, (id) => ({
+      id,
+      order: this.eventOrder.get(id) ?? Number.MAX_SAFE_INTEGER,
+    }));
+    ranked.sort((left, right) => {
+      if (left.order !== right.order) {
+        return descending ? right.order - left.order : left.order - right.order;
+      }
+      return descending
+        ? compareEventIds(right.id, left.id)
+        : compareEventIds(left.id, right.id);
+    });
+    return ranked.map(({ id }) => id);
   }
 
   private compareByTopologicalOrder(left: EventId, right: EventId): number {

--- a/packages/eg-walker/src/engine/indexed-sequence.ts
+++ b/packages/eg-walker/src/engine/indexed-sequence.ts
@@ -1,5 +1,13 @@
-const LEAF_CAPACITY = 64;
-const BRANCH_FACTOR = 32;
+import {
+  BRANCH_FACTOR,
+  LEAF_CAPACITY,
+  createInternal,
+  createLeaf,
+  type IndexedNode,
+  type InternalNode,
+  type ItemLocation,
+  type LeafNode,
+} from "./internals/indexed-sequence-node";
 
 /**
  * Sentinel thrown by the ranked B-tree's prepare/effect index lookups when
@@ -15,84 +23,6 @@ export class IndexOutOfRangeError extends Error {
     this.name = "IndexOutOfRangeError";
   }
 }
-
-type IndexedNode<T extends object> = LeafNode<T> | InternalNode<T>;
-
-interface NodeBase<T extends object> {
-  parent: InternalNode<T> | null;
-  // Cached position within `parent.children`. Kept in sync by every code
-  // path that mutates a parent's child list so {@link positionOfNode}
-  // can walk up without scanning siblings linearly. Meaningless when
-  // `parent` is `null`; we leave it at 0 in that case.
-  childIndex: number;
-  size: number;
-  prepareSum: number;
-  effectSum: number;
-}
-
-interface LeafNode<T extends object> extends NodeBase<T> {
-  readonly kind: "leaf";
-  readonly items: T[];
-  readonly prepareWeights: number[];
-  readonly effectWeights: number[];
-}
-
-interface InternalNode<T extends object> extends NodeBase<T> {
-  readonly kind: "internal";
-  readonly children: IndexedNode<T>[];
-}
-
-interface ItemLocation<T extends object> {
-  leaf: LeafNode<T>;
-  // Cached offset of the item within `leaf.items`. Maintained by every
-  // splice on `leaf.items` so {@link IndexedSequence.positionOf} and
-  // {@link IndexedSequence.updateItem} can skip the O(leaf capacity)
-  // `Array.indexOf` scan.
-  offsetInLeaf: number;
-}
-
-const createLeaf = <T extends object>(): LeafNode<T> => ({
-  kind: "leaf",
-  parent: null,
-  childIndex: 0,
-  items: [],
-  prepareWeights: [],
-  effectWeights: [],
-  size: 0,
-  prepareSum: 0,
-  effectSum: 0,
-});
-
-const createInternal = <T extends object>(
-  children: IndexedNode<T>[],
-): InternalNode<T> => {
-  let size = 0;
-  let prepareSum = 0;
-  let effectSum = 0;
-  for (const child of children) {
-    size += child.size;
-    prepareSum += child.prepareSum;
-    effectSum += child.effectSum;
-  }
-  const node: InternalNode<T> = {
-    kind: "internal",
-    parent: null,
-    childIndex: 0,
-    children,
-    size,
-    prepareSum,
-    effectSum,
-  };
-  for (let index = 0; index < children.length; index++) {
-    const child = children[index];
-    if (!child) {
-      continue;
-    }
-    child.parent = node;
-    child.childIndex = index;
-  }
-  return node;
-};
 
 /**
  * Ranked B-tree for Eg-walker's mutable CRDT sequence.
@@ -470,13 +400,14 @@ export class IndexedSequence<T extends object> {
     let node = this.root;
     let remaining = index;
     while (node.kind === "internal") {
-      const child = node.children.find((candidate) => {
+      let child: IndexedNode<T> | undefined;
+      for (const candidate of node.children) {
         if (remaining < candidate.size) {
-          return true;
+          child = candidate;
+          break;
         }
         remaining -= candidate.size;
-        return false;
-      });
+      }
       if (!child) {
         throw new Error(`Index ${index} out of bounds`);
       }
@@ -532,14 +463,15 @@ export class IndexedSequence<T extends object> {
     let total = 0;
 
     while (node.kind === "internal") {
-      const child = node.children.find((candidate) => {
+      let child: IndexedNode<T> | undefined;
+      for (const candidate of node.children) {
         if (remaining <= candidate.size) {
-          return true;
+          child = candidate;
+          break;
         }
         remaining -= candidate.size;
         total += this.weightSum(candidate, kind);
-        return false;
-      });
+      }
       if (!child) {
         return total;
       }
@@ -589,15 +521,16 @@ export class IndexedSequence<T extends object> {
     let node: IndexedNode<T> = this.root;
 
     while (node.kind === "internal") {
-      const child = node.children.find((candidate) => {
+      let child: IndexedNode<T> | undefined;
+      for (const candidate of node.children) {
         const childSum = this.weightSum(candidate, kind);
         if (remaining < childSum) {
-          return true;
+          child = candidate;
+          break;
         }
         remaining -= childSum;
         position += candidate.size;
-        return false;
-      });
+      }
       if (!child) {
         // Structural-invariant violation: the prepareSum/effectSum
         // aggregate said `index` was reachable, but no child claimed

--- a/packages/eg-walker/src/engine/internals/delete-handler.ts
+++ b/packages/eg-walker/src/engine/internals/delete-handler.ts
@@ -1,0 +1,109 @@
+import { OPERATION_TYPE } from "../../constants/operation-types";
+import type { EventId, ExternalOperation, GraphEvent } from "../../types";
+import type { IndexedSequence } from "../indexed-sequence";
+import { DeleteTargetIndex } from "./delete-target-index";
+import { PLACEHOLDER_EVENT_ID, type AugmentedCRDTItem } from "./engine-types";
+import { PendingInsertBuffer } from "./pending-insert-buffer";
+import { RecordSplitter } from "./record-splitter";
+import { coalesceDeleteRuns, deleteText } from "./text-utils";
+
+type DeleteOperation = Extract<
+  ExternalOperation,
+  { type: typeof OPERATION_TYPE.DELETE }
+>;
+
+export interface DeleteHandlerDeps {
+  readonly sequence: IndexedSequence<AugmentedCRDTItem>;
+  readonly deleteTargets: DeleteTargetIndex;
+  readonly recordSplitter: RecordSplitter;
+  readonly pendingInsert: PendingInsertBuffer;
+  readonly flushPendingInsert: () => void;
+  readonly itemToEffectIndex: (target: AugmentedCRDTItem) => number;
+  readonly getResultingText: () => string;
+  readonly setResultingText: (text: string) => void;
+}
+
+export const applyDelete = (
+  event: GraphEvent,
+  operation: DeleteOperation,
+  deps: DeleteHandlerDeps,
+): ExternalOperation[] => {
+  const {
+    sequence,
+    deleteTargets,
+    recordSplitter,
+    pendingInsert,
+    flushPendingInsert,
+    itemToEffectIndex,
+    getResultingText,
+    setResultingText,
+  } = deps;
+
+  if (!pendingInsert.isEmpty()) {
+    flushPendingInsert();
+  }
+  const deletedItemIds: EventId[] = [];
+  const outputDeleteIndexes: number[] = [];
+  let remaining = operation.length;
+
+  while (remaining > 0) {
+    const landing = sequence.tryPrepareIndexToPositionAndOffset(
+      operation.index,
+      false,
+    );
+    if (!landing) {
+      break;
+    }
+    const candidate = sequence.at(landing.position);
+    if (!candidate) {
+      throw new Error(
+        `Engine bug: prepare-index ${operation.index} landed at sequence position ` +
+          `${landing.position} but no record exists there (remaining=${remaining}).`,
+      );
+    }
+
+    const isMultiCharRecord =
+      (candidate.eventId === PLACEHOLDER_EVENT_ID || candidate.run !== null) &&
+      candidate.content.length > 1;
+    if (isMultiCharRecord) {
+      const availableInRecord =
+        candidate.content.length - landing.offsetInRecord;
+      const toDelete = Math.min(remaining, availableInRecord);
+      const middle = recordSplitter.splitRecordForDelete(
+        landing.position,
+        landing.offsetInRecord,
+        toDelete,
+      );
+
+      deletedItemIds.push(middle.id);
+      if (!middle.everDeleted) {
+        const effectIndex = itemToEffectIndex(middle);
+        for (let k = 0; k < toDelete; k++) {
+          outputDeleteIndexes.push(effectIndex);
+        }
+        setResultingText(deleteText(getResultingText(), effectIndex, toDelete));
+      }
+
+      middle.everDeleted = true;
+      middle.prepareState += 1;
+      sequence.updateItem(middle);
+      remaining -= toDelete;
+      continue;
+    }
+
+    deletedItemIds.push(candidate.id);
+    if (!candidate.everDeleted) {
+      const effectIndex = itemToEffectIndex(candidate);
+      outputDeleteIndexes.push(effectIndex);
+      setResultingText(deleteText(getResultingText(), effectIndex, 1));
+    }
+    candidate.everDeleted = true;
+    candidate.prepareState += 1;
+    sequence.updateItem(candidate);
+    remaining -= 1;
+  }
+
+  deleteTargets.record(event.id, deletedItemIds);
+
+  return coalesceDeleteRuns(outputDeleteIndexes);
+};

--- a/packages/eg-walker/src/engine/internals/delete-handler.ts
+++ b/packages/eg-walker/src/engine/internals/delete-handler.ts
@@ -39,6 +39,13 @@ export const applyDelete = (
     setResultingText,
   } = deps;
 
+  // Any concurrent insert or delete breaks the typed-run we may have been
+  // coalescing into the pending-insert buffer. Flush before we start carving
+  // records and slicing the document text so the per-slot {@link effectIndex}
+  // arithmetic below operates on the materialised document. Hoist the
+  // empty-buffer check inline because `applyDelete` is on the per-event hot
+  // path and the buffer is empty on every non-coalescing trace, so the
+  // inline check saves a function call on the common case.
   if (!pendingInsert.isEmpty()) {
     flushPendingInsert();
   }
@@ -47,6 +54,14 @@ export const applyDelete = (
   let remaining = operation.length;
 
   while (remaining > 0) {
+    // A delete event whose `length` runs past the prepare-visible items at
+    // the engine's current parent version legitimately stops short — this is
+    // exercised by the "deletes that run past visible prepare items" test.
+    // The previous implementation wrapped the throwing
+    // `prepareIndexToPositionAndOffset` in a catch-all try/catch, which also
+    // swallowed real bugs (e.g. ranked-B-tree aggregate corruption). Use the
+    // explicit non-throwing variant for the expected end-of-text case, and
+    // let other errors surface.
     const landing = sequence.tryPrepareIndexToPositionAndOffset(
       operation.index,
       false,
@@ -56,12 +71,20 @@ export const applyDelete = (
     }
     const candidate = sequence.at(landing.position);
     if (!candidate) {
+      // The ranked B-tree just told us the prepare-weight prefix sum lands
+      // on `landing.position`, so a missing record there means the tree's
+      // aggregates disagree with its children — a structural bug we want to
+      // surface, not silently truncate the delete around.
       throw new Error(
         `Engine bug: prepare-index ${operation.index} landed at sequence position ` +
           `${landing.position} but no record exists there (remaining=${remaining}).`,
       );
     }
 
+    // Multi-character records (placeholders and typed-run leaves coalesced
+    // by Section 3.4) are split on demand so the deleted slice is its own
+    // record. Single-character records and per-code-unit paste fragments
+    // skip the split entirely and are marked in place.
     const isMultiCharRecord =
       (candidate.eventId === PLACEHOLDER_EVENT_ID || candidate.run !== null) &&
       candidate.content.length > 1;
@@ -76,6 +99,11 @@ export const applyDelete = (
       );
 
       deletedItemIds.push(middle.id);
+      // A concurrent delete that lands on an already-effect-deleted slice
+      // (e.g. after retreating an overlapping sibling) must NOT remove
+      // characters from the text again. Without this, two concurrent
+      // deletes of the same region replay to a shorter string than full
+      // replay produces.
       if (!middle.everDeleted) {
         const effectIndex = itemToEffectIndex(middle);
         for (let k = 0; k < toDelete; k++) {

--- a/packages/eg-walker/src/engine/internals/indexed-sequence-node.ts
+++ b/packages/eg-walker/src/engine/internals/indexed-sequence-node.ts
@@ -1,0 +1,72 @@
+export const LEAF_CAPACITY = 64;
+export const BRANCH_FACTOR = 32;
+
+export type IndexedNode<T extends object> = LeafNode<T> | InternalNode<T>;
+
+interface NodeBase<T extends object> {
+  parent: InternalNode<T> | null;
+  childIndex: number;
+  size: number;
+  prepareSum: number;
+  effectSum: number;
+}
+
+export interface LeafNode<T extends object> extends NodeBase<T> {
+  readonly kind: "leaf";
+  readonly items: T[];
+  readonly prepareWeights: number[];
+  readonly effectWeights: number[];
+}
+
+export interface InternalNode<T extends object> extends NodeBase<T> {
+  readonly kind: "internal";
+  readonly children: IndexedNode<T>[];
+}
+
+export interface ItemLocation<T extends object> {
+  leaf: LeafNode<T>;
+  offsetInLeaf: number;
+}
+
+export const createLeaf = <T extends object>(): LeafNode<T> => ({
+  kind: "leaf",
+  parent: null,
+  childIndex: 0,
+  items: [],
+  prepareWeights: [],
+  effectWeights: [],
+  size: 0,
+  prepareSum: 0,
+  effectSum: 0,
+});
+
+export const createInternal = <T extends object>(
+  children: IndexedNode<T>[],
+): InternalNode<T> => {
+  let size = 0;
+  let prepareSum = 0;
+  let effectSum = 0;
+  for (const child of children) {
+    size += child.size;
+    prepareSum += child.prepareSum;
+    effectSum += child.effectSum;
+  }
+  const node: InternalNode<T> = {
+    kind: "internal",
+    parent: null,
+    childIndex: 0,
+    children,
+    size,
+    prepareSum,
+    effectSum,
+  };
+  for (let index = 0; index < children.length; index++) {
+    const child = children[index];
+    if (!child) {
+      continue;
+    }
+    child.parent = node;
+    child.childIndex = index;
+  }
+  return node;
+};

--- a/packages/eg-walker/src/engine/internals/indexed-sequence-node.ts
+++ b/packages/eg-walker/src/engine/internals/indexed-sequence-node.ts
@@ -5,6 +5,10 @@ export type IndexedNode<T extends object> = LeafNode<T> | InternalNode<T>;
 
 interface NodeBase<T extends object> {
   parent: InternalNode<T> | null;
+  // Cached position within `parent.children`. Kept in sync by every code path
+  // that mutates a parent's child list so {@link IndexedSequence} can walk
+  // up without scanning siblings linearly. Meaningless when `parent` is
+  // `null`; we leave it at 0 in that case.
   childIndex: number;
   size: number;
   prepareSum: number;
@@ -25,6 +29,10 @@ export interface InternalNode<T extends object> extends NodeBase<T> {
 
 export interface ItemLocation<T extends object> {
   leaf: LeafNode<T>;
+  // Cached offset of the item within `leaf.items`. Maintained by every splice
+  // on `leaf.items` so {@link IndexedSequence.positionOf} and
+  // {@link IndexedSequence.updateItem} can skip the O(leaf capacity)
+  // `Array.indexOf` scan.
   offsetInLeaf: number;
 }
 

--- a/packages/eg-walker/src/engine/internals/insert-handler.ts
+++ b/packages/eg-walker/src/engine/internals/insert-handler.ts
@@ -1,0 +1,188 @@
+import { OPERATION_TYPE } from "../../constants/operation-types";
+import { parseEventId } from "../../graph/event-id";
+import type { EventId, ExternalOperation, GraphEvent } from "../../types";
+import type { IndexedSequence } from "../indexed-sequence";
+import type { AugmentedCRDTItem, TypedRun } from "./engine-types";
+import { OriginLeftIndex } from "./origin-left-index";
+import { PendingInsertBuffer } from "./pending-insert-buffer";
+import { RecordSplitter } from "./record-splitter";
+import { spliceText, stringCodeUnits } from "./text-utils";
+import { findIntegrationPosition } from "./yata-integration";
+
+type InsertOperation = Extract<
+  ExternalOperation,
+  { type: typeof OPERATION_TYPE.INSERT }
+>;
+
+export interface InsertHandlerDeps {
+  readonly sequence: IndexedSequence<AugmentedCRDTItem>;
+  readonly itemsById: Map<EventId, AugmentedCRDTItem>;
+  readonly eventItems: Map<EventId, EventId[]>;
+  readonly originLeftIndex: OriginLeftIndex;
+  readonly recordSplitter: RecordSplitter;
+  readonly pendingInsert: PendingInsertBuffer;
+  readonly applyPendingSplice: (effectIndex: number, text: string) => void;
+  readonly flushPendingInsert: () => void;
+  readonly itemToEffectIndex: (target: AugmentedCRDTItem) => number;
+  readonly requireItem: (itemId: EventId) => AugmentedCRDTItem;
+  readonly getResultingText: () => string;
+  readonly setResultingText: (text: string) => void;
+}
+
+export const applyInsert = (
+  event: GraphEvent,
+  operation: InsertOperation,
+  deps: InsertHandlerDeps,
+): ExternalOperation[] => {
+  const {
+    sequence,
+    itemsById,
+    eventItems,
+    originLeftIndex,
+    recordSplitter,
+    pendingInsert,
+    applyPendingSplice,
+    flushPendingInsert,
+    itemToEffectIndex,
+    requireItem,
+    getResultingText,
+    setResultingText,
+  } = deps;
+
+  if (operation.text.length === 0) {
+    eventItems.set(event.id, []);
+    return [];
+  }
+
+  const landing = sequence.prepareIndexToPositionAndOffset(
+    operation.index,
+    true,
+  );
+  const firstInsertPosition =
+    landing.offsetInRecord > 0
+      ? recordSplitter.splitRecordAt(landing.position, landing.offsetInRecord)
+      : landing.position;
+  const originLeftPosition =
+    sequence.previousPrepareVisiblePosition(firstInsertPosition);
+  const originLeft =
+    originLeftPosition === null
+      ? null
+      : (sequence.at(originLeftPosition)?.id ?? null);
+  const originRightPosition =
+    sequence.nextPrepareVisiblePosition(firstInsertPosition);
+  const originRight =
+    originRightPosition === null
+      ? null
+      : (sequence.at(originRightPosition)?.id ?? null);
+
+  const leftBound = originLeftPosition ?? -1;
+  const rightBound = originRightPosition ?? sequence.length;
+  const conflictRegionEmpty =
+    leftBound + 1 === firstInsertPosition && firstInsertPosition === rightBound;
+
+  const parsed = parseEventId(event.id);
+  if (
+    conflictRegionEmpty &&
+    operation.text.length === 1 &&
+    parsed !== null &&
+    originLeftPosition !== null &&
+    originLeftPosition === firstInsertPosition - 1
+  ) {
+    const leftRecord = sequence.at(originLeftPosition);
+    if (
+      leftRecord !== undefined &&
+      leftRecord.run !== null &&
+      leftRecord.run.replicaId === parsed.replicaId &&
+      leftRecord.run.startSequence + leftRecord.content.length ===
+        parsed.sequence &&
+      leftRecord.prepareState === 1 &&
+      !leftRecord.everDeleted &&
+      !originLeftIndex.has(leftRecord.id)
+    ) {
+      const effectIndex =
+        itemToEffectIndex(leftRecord) + leftRecord.content.length;
+      leftRecord.content += operation.text;
+      sequence.updateItem(leftRecord);
+      eventItems.set(event.id, [leftRecord.id]);
+      pendingInsert.append(effectIndex, operation.text, applyPendingSplice);
+
+      return [
+        {
+          type: OPERATION_TYPE.INSERT,
+          index: effectIndex,
+          text: operation.text,
+        },
+      ];
+    }
+  }
+
+  const codeUnits = stringCodeUnits(operation.text);
+  const insertedIds: EventId[] = [];
+  let left = originLeft;
+
+  const firstRun: TypedRun | null =
+    parsed !== null && operation.text.length === 1
+      ? { replicaId: parsed.replicaId, startSequence: parsed.sequence }
+      : null;
+  const firstItem: AugmentedCRDTItem = {
+    id: `${event.id}:0`,
+    eventId: event.id,
+    content: codeUnits[0] ?? "",
+    originLeft: left,
+    originRight,
+    everDeleted: false,
+    prepareState: 1,
+    run: firstRun,
+  };
+  let actualFirstPosition: number;
+  if (conflictRegionEmpty) {
+    actualFirstPosition = firstInsertPosition;
+    sequence.insert(actualFirstPosition, firstItem);
+  } else {
+    actualFirstPosition = findIntegrationPosition(
+      firstItem,
+      sequence,
+      itemsById,
+    );
+    sequence.insert(actualFirstPosition, firstItem);
+  }
+  itemsById.set(firstItem.id, firstItem);
+  originLeftIndex.track(firstItem.id, firstItem.originLeft);
+  insertedIds.push(firstItem.id);
+  left = firstItem.id;
+
+  for (let offset = 1; offset < codeUnits.length; offset++) {
+    const item: AugmentedCRDTItem = {
+      id: `${event.id}:${offset}`,
+      eventId: event.id,
+      content: codeUnits[offset] ?? "",
+      originLeft: left,
+      originRight,
+      everDeleted: false,
+      prepareState: 1,
+      run: null,
+    };
+    sequence.insert(actualFirstPosition + offset, item);
+    itemsById.set(item.id, item);
+    originLeftIndex.track(item.id, item.originLeft);
+    insertedIds.push(item.id);
+    left = item.id;
+  }
+
+  eventItems.set(event.id, insertedIds);
+
+  const firstInserted = requireItem(insertedIds[0] ?? event.id);
+  const effectIndex = itemToEffectIndex(firstInserted);
+  if (!pendingInsert.isEmpty()) {
+    flushPendingInsert();
+  }
+  setResultingText(spliceText(getResultingText(), effectIndex, operation.text));
+
+  return [
+    {
+      type: OPERATION_TYPE.INSERT,
+      index: effectIndex,
+      text: operation.text,
+    },
+  ];
+};

--- a/packages/eg-walker/src/engine/internals/insert-handler.ts
+++ b/packages/eg-walker/src/engine/internals/insert-handler.ts
@@ -62,6 +62,12 @@ export const applyInsert = (
     landing.offsetInRecord > 0
       ? recordSplitter.splitRecordAt(landing.position, landing.offsetInRecord)
       : landing.position;
+  // YATA-style origins: anchor against the records visible in the event's
+  // parent version (prepare-state >= 1), NOT against whichever concurrent
+  // records happen to be sitting in the sequence right now. Without this
+  // filter the engine would assign different origins to the same event
+  // depending on which concurrent siblings were integrated first, breaking
+  // traversal-order independence.
   const originLeftPosition =
     sequence.previousPrepareVisiblePosition(firstInsertPosition);
   const originLeft =
@@ -75,11 +81,33 @@ export const applyInsert = (
       ? null
       : (sequence.at(originRightPosition)?.id ?? null);
 
+  // Section 3.4 internal-document fast path for the first item.
+  //
+  // The YATA integration scan walks the sequence positions strictly between
+  // `originLeft` and `originRight`. When that range is empty (no retreated,
+  // deleted, or otherwise non-prepare-visible records sit in it) the scan
+  // is provably a no-op, so we can place the first item at
+  // `firstInsertPosition` without invoking it. The dominant case for this
+  // is a non-conflicting run: no concurrent siblings have been integrated
+  // near the insertion point, so the previous-prepare-visible record is
+  // the literal neighbour of `firstInsertPosition`.
   const leftBound = originLeftPosition ?? -1;
   const rightBound = originRightPosition ?? sequence.length;
   const conflictRegionEmpty =
     leftBound + 1 === firstInsertPosition && firstInsertPosition === rightBound;
 
+  // Section 3.4 "smaller" lever: typed-run coalescing.
+  //
+  // When a single-character INSERT lands at the right boundary of an
+  // adjacent typed-run record from the same author whose run extends by
+  // exactly one sequence number, append to that record's content instead
+  // of allocating a new CRDT item. The columnar codec already groups
+  // events into id-runs by (replicaId, contiguous sequence) for wire
+  // encoding; mirroring that grouping in the ranked B-tree collapses a
+  // 20k-character linear single-author trace to ~1 record (down from one
+  // per code unit) while leaving multi-author / multi-event ordering
+  // unchanged — split-on-demand carves the run when a concurrent insert
+  // or delete anchors inside it.
   const parsed = parseEventId(event.id);
   if (
     conflictRegionEmpty &&
@@ -97,6 +125,10 @@ export const applyInsert = (
         parsed.sequence &&
       leftRecord.prepareState === 1 &&
       !leftRecord.everDeleted &&
+      // Don't extend a run that already has items anchored to its right
+      // boundary — those items chose this id as their `originLeft` at a
+      // moment when the record ended one code unit earlier, and stretching
+      // the content would shift the boundary they were anchored to.
       !originLeftIndex.has(leftRecord.id)
     ) {
       const effectIndex =
@@ -104,6 +136,11 @@ export const applyInsert = (
       leftRecord.content += operation.text;
       sequence.updateItem(leftRecord);
       eventItems.set(event.id, [leftRecord.id]);
+      // Defer the splice on the engine's resulting text into the
+      // pending-insert buffer so a long single-author typed run doesn't
+      // pay an O(document length) string realloc per keystroke.
+      // {@link flushPendingInsert} materialises the buffer before any
+      // non-coalesced read or write of the document text.
       pendingInsert.append(effectIndex, operation.text, applyPendingSplice);
 
       return [
@@ -120,6 +157,12 @@ export const applyInsert = (
   const insertedIds: EventId[] = [];
   let left = originLeft;
 
+  // First code unit: pay the full integration scan if the conflict region
+  // isn't empty. Single-character INSERTs from a canonical
+  // `replicaId:sequence` author seed a typed-run record so that later
+  // contiguous events from the same author can extend it in-place (the
+  // coalescing branch above). Multi-character INSERTs and IDs that don't
+  // parse keep `run = null` and behave like the pre-coalescing engine.
   const firstRun: TypedRun | null =
     parsed !== null && operation.text.length === 1
       ? { replicaId: parsed.replicaId, startSequence: parsed.sequence }
@@ -151,6 +194,16 @@ export const applyInsert = (
   insertedIds.push(firstItem.id);
   left = firstItem.id;
 
+  // Multi-character inserts: every subsequent item is chained off the
+  // previous item via `originLeft`. No record that existed before this
+  // event can reference that brand-new id, so the YATA scan for chars
+  // 1..N terminates on its first iteration and the integration position
+  // is unconditionally `previous + 1`. We bypass the scan and place them
+  // at sequential positions instead of paying `findIntegrationPosition`'s
+  // setup cost per character. The items stay `run = null` because
+  // typed-run coalescing operates on single-character events from
+  // contiguous sequence numbers, not on the per-code-unit fragments of
+  // one multi-character INSERT.
   for (let offset = 1; offset < codeUnits.length; offset++) {
     const item: AugmentedCRDTItem = {
       id: `${event.id}:${offset}`,
@@ -173,6 +226,12 @@ export const applyInsert = (
 
   const firstInserted = requireItem(insertedIds[0] ?? event.id);
   const effectIndex = itemToEffectIndex(firstInserted);
+  // A non-coalesced insert (multi-character event, new typed-run seed,
+  // or non-empty conflict region) must observe the current document so
+  // {@link effectIndex} aligns with the engine's resulting text. Drain
+  // any open typed-run buffer before splicing. Hoist the empty-buffer
+  // check inline because this is the per-event hot path for non-coalescing
+  // inserts and the buffer is empty on every full-replay event.
   if (!pendingInsert.isEmpty()) {
     flushPendingInsert();
   }

--- a/packages/eg-walker/src/graph/columnar-codec.ts
+++ b/packages/eg-walker/src/graph/columnar-codec.ts
@@ -2,6 +2,14 @@ import { OPERATION_TYPE } from "../constants/operation-types";
 import { EventGraph } from "./event-graph";
 import { parseEventId } from "./event-id";
 import lz4 from "lz4js";
+import {
+  BINARY_MAGIC,
+  BinaryReader,
+  BinaryWriter,
+  decodeText,
+  encodeText,
+  toUint8Array,
+} from "./internals/binary-io";
 import type {
   EventId,
   ExternalOperation,
@@ -62,13 +70,6 @@ export interface ColumnarEventGraph {
 // The in-memory `ColumnarEventGraph` / `OperationRun` / `IdRun` shapes are
 // unchanged; only the binary wire format is more compact. EGW2 and EGW1
 // payloads are rejected at decode.
-const BINARY_MAGIC = new Uint8Array([0x45, 0x47, 0x57, 0x33]); // EGW3
-const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
-
-const toUint8Array = (bytes: ReadonlyArray<number> | Uint8Array): Uint8Array =>
-  bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-
 const operationTextLength = (operation: ExternalOperation): number =>
   operation.type === OPERATION_TYPE.INSERT ? operation.text.length : 0;
 
@@ -137,18 +138,6 @@ const finalizeOperationRuns = (
     return { ...run, startIndex, textLength };
   });
 
-/**
- * Zigzag encoding maps signed integers to non-negative integers:
- * `0 → 0, -1 → 1, 1 → 2, -2 → 3, 2 → 4, ...`. Uses safe-integer arithmetic
- * rather than bitwise ops so values beyond ±2^31 (timestamps in ms since epoch
- * are ~1.7×10^12) round-trip correctly.
- */
-const zigzagEncode = (value: number): number =>
-  value >= 0 ? value * 2 : value * -2 - 1;
-
-const zigzagDecode = (value: number): number =>
-  value % 2 === 0 ? value / 2 : -((value + 1) / 2);
-
 export class ColumnarEventGraphCodec {
   encode(graph: EventGraph): ColumnarEventGraph {
     const events = graph.getTopologicalOrder();
@@ -215,9 +204,7 @@ export class ColumnarEventGraphCodec {
     writer.writeZigZagDeltaArray(encoded.operationIndexes);
     writer.writeVarintArray(encoded.operationLengths);
     // textLengths intentionally omitted: derivable from operationRuns + operationLengths.
-    writer.writeBytes(
-      lz4.compress(textEncoder.encode(encoded.insertedContent)),
-    );
+    writer.writeBytes(lz4.compress(encodeText(encoded.insertedContent)));
     this.writeParentOverrides(writer, encoded.parentOverrides);
     this.writeIdRuns(writer, encoded.idRuns);
     writer.writeZigZagDeltaArray(encoded.timestamps);
@@ -262,7 +249,7 @@ export class ColumnarEventGraphCodec {
     const decompressed = toUint8Array(
       lz4.decompress(compressed, maxInsertedBytes),
     );
-    const insertedContent = textDecoder.decode(decompressed);
+    const insertedContent = decodeText(decompressed);
     if (insertedContent.length !== expectedInsertedSize) {
       throw new Error(
         `Decompressed inserted-content size mismatch (expected ${expectedInsertedSize} UTF-16 code units, got ${insertedContent.length})`,
@@ -590,161 +577,5 @@ export class ColumnarEventGraphCodec {
     }
 
     return parents;
-  }
-}
-
-class BinaryWriter {
-  private buffer = new Uint8Array(256);
-  private size = 0;
-
-  writeVarint(value: number): void {
-    if (!Number.isSafeInteger(value) || value < 0) {
-      throw new Error(`Cannot encode invalid varint value ${value}`);
-    }
-
-    let remaining = value;
-    while (remaining >= 0x80) {
-      this.writeByte((remaining % 0x80) + 0x80);
-      remaining = Math.floor(remaining / 0x80);
-    }
-    this.writeByte(remaining);
-  }
-
-  writeVarintArray(values: ReadonlyArray<number>): void {
-    this.writeVarint(values.length);
-    for (const value of values) {
-      this.writeVarint(value);
-    }
-  }
-
-  /**
-   * Write a signed integer using zigzag varint encoding. Allows negative
-   * deltas (e.g. document positions that move backwards on delete) while
-   * keeping the common small-delta case at one byte.
-   */
-  writeZigZagVarint(value: number): void {
-    if (!Number.isSafeInteger(value)) {
-      throw new Error(`Cannot encode invalid zigzag varint value ${value}`);
-    }
-    this.writeVarint(zigzagEncode(value));
-  }
-
-  /**
-   * Write a numeric array as a zigzag-delta varint array: a count followed by
-   * `zigzag(values[i] - values[i-1])` for each entry (the first entry is
-   * relative to `0`). For monotonically increasing or near-stationary columns
-   * (timestamps, document positions in a linear trace) this compresses to
-   * ~1 byte per value.
-   */
-  writeZigZagDeltaArray(values: ReadonlyArray<number>): void {
-    this.writeVarint(values.length);
-    let previous = 0;
-    for (const value of values) {
-      this.writeZigZagVarint(value - previous);
-      previous = value;
-    }
-  }
-
-  writeString(value: string): void {
-    this.writeBytes(textEncoder.encode(value));
-  }
-
-  writeStringArray(values: ReadonlyArray<string>): void {
-    this.writeVarint(values.length);
-    for (const value of values) {
-      this.writeString(value);
-    }
-  }
-
-  writeBytes(bytes: Uint8Array): void {
-    this.writeVarint(bytes.length);
-    this.ensureCapacity(this.size + bytes.length);
-    this.buffer.set(bytes, this.size);
-    this.size += bytes.length;
-  }
-
-  toUint8Array(): Uint8Array {
-    return this.buffer.slice(0, this.size);
-  }
-
-  private writeByte(byte: number): void {
-    this.ensureCapacity(this.size + 1);
-    this.buffer[this.size++] = byte;
-  }
-
-  private ensureCapacity(required: number): void {
-    if (required <= this.buffer.length) {
-      return;
-    }
-    let nextCapacity = this.buffer.length * 2;
-    while (nextCapacity < required) {
-      nextCapacity *= 2;
-    }
-    const next = new Uint8Array(nextCapacity);
-    next.set(this.buffer);
-    this.buffer = next;
-  }
-}
-
-class BinaryReader {
-  private offset = 0;
-
-  constructor(private readonly bytes: Uint8Array) {}
-
-  readVarint(): number {
-    let value = 0;
-    let multiplier = 1;
-
-    while (true) {
-      const byte = this.bytes[this.offset++];
-      if (byte === undefined) {
-        throw new Error("Unexpected end of varint");
-      }
-
-      value += (byte & 0x7f) * multiplier;
-      if ((byte & 0x80) === 0) {
-        return value;
-      }
-      multiplier *= 0x80;
-    }
-  }
-
-  readVarintArray(): number[] {
-    const length = this.readVarint();
-    return Array.from({ length }, () => this.readVarint());
-  }
-
-  readZigZagVarint(): number {
-    return zigzagDecode(this.readVarint());
-  }
-
-  readZigZagDeltaArray(): number[] {
-    const length = this.readVarint();
-    const values: number[] = new Array<number>(length);
-    let previous = 0;
-    for (let i = 0; i < length; i++) {
-      const value = previous + this.readZigZagVarint();
-      values[i] = value;
-      previous = value;
-    }
-    return values;
-  }
-
-  readString(): string {
-    return textDecoder.decode(this.readBytes(this.readVarint()));
-  }
-
-  readStringArray(): string[] {
-    const length = this.readVarint();
-    return Array.from({ length }, () => this.readString());
-  }
-
-  readBytes(length: number): Uint8Array {
-    if (this.offset + length > this.bytes.length) {
-      throw new Error("Unexpected end of binary eg-walker graph");
-    }
-    const result = this.bytes.slice(this.offset, this.offset + length);
-    this.offset += length;
-    return result;
   }
 }

--- a/packages/eg-walker/src/graph/event-graph-errors.ts
+++ b/packages/eg-walker/src/graph/event-graph-errors.ts
@@ -1,0 +1,21 @@
+import type { EventId } from "../types";
+
+export class EventAlreadyExistsError extends Error {
+  readonly eventId: EventId;
+
+  constructor(eventId: EventId) {
+    super(`Event ${eventId} already exists`);
+    this.name = "EventAlreadyExistsError";
+    this.eventId = eventId;
+  }
+}
+
+export class MissingParentError extends Error {
+  readonly parentId: EventId;
+
+  constructor(parentId: EventId) {
+    super(`Missing parent event: ${parentId}`);
+    this.name = "MissingParentError";
+    this.parentId = parentId;
+  }
+}

--- a/packages/eg-walker/src/graph/event-graph.ts
+++ b/packages/eg-walker/src/graph/event-graph.ts
@@ -11,145 +11,21 @@ import type {
   SerializedGraphInput,
   SerializedGraphOutput,
 } from "../types";
-import { compareEventIds } from "./event-id";
+import {
+  EventAlreadyExistsError,
+  MissingParentError,
+} from "./event-graph-errors";
+import { diffVersions as diffVersionSets } from "./internals/diff-versions";
+import { deserializeEventGraph } from "./internals/event-graph-serialization";
+import {
+  getBranchPreservingTopologicalOrder as computeBranchPreservingTopologicalOrder,
+  getTopologicalOrder as computeTopologicalOrder,
+} from "./internals/topological-order";
 
-/**
- * Coerce a deserialized parent-version value into an array of event IDs.
- *
- * Tolerates the three forms `SerializedVersionInput` documents (JSON-safe
- * array, in-memory `Set`, generic iterable). The parameter is typed as
- * `unknown` because deserialize ingests JSON-parsed data: malformed payloads
- * are filtered to `[]` rather than crashing, but no recovery is attempted for
- * non-iterable objects.
- */
-const normalizeEventIds = (value: unknown): EventId[] => {
-  if (Array.isArray(value)) {
-    return value.filter((id): id is EventId => typeof id === "string");
-  }
-
-  if (value instanceof Set) {
-    return Array.from(value).filter(
-      (id): id is EventId => typeof id === "string",
-    );
-  }
-
-  if (value && typeof value === "object") {
-    const maybeIterable = value as { [Symbol.iterator]?: unknown };
-    if (typeof maybeIterable[Symbol.iterator] === "function") {
-      return Array.from(value as Iterable<unknown>).filter(
-        (id): id is EventId => typeof id === "string",
-      );
-    }
-  }
-
-  return [];
-};
-
-export class EventAlreadyExistsError extends Error {
-  readonly eventId: EventId;
-
-  constructor(eventId: EventId) {
-    super(`Event ${eventId} already exists`);
-    this.name = "EventAlreadyExistsError";
-    this.eventId = eventId;
-  }
-}
-
-export class MissingParentError extends Error {
-  readonly parentId: EventId;
-
-  constructor(parentId: EventId) {
-    super(`Missing parent event: ${parentId}`);
-    this.name = "MissingParentError";
-    this.parentId = parentId;
-  }
-}
-
-/**
- * Bit flags used by `diffVersions` to colour events while running the
- * priority-queue diff. `LEFT` means "reachable from the left frontier",
- * `RIGHT` means "reachable from the right frontier", and `COMMON = LEFT | RIGHT`
- * means the event is a shared ancestor.
- */
-const DIFF_COLOR = {
-  LEFT: 1,
-  RIGHT: 2,
-  COMMON: 3,
-} as const;
-
-/**
- * Minimal binary max-heap. The eg-walker package does not depend on a
- * priority-queue library, and `diffVersions` is the only consumer, so we
- * keep a small inline implementation rather than pulling in a dependency.
- */
-class MaxHeap<T> {
-  private readonly items: T[] = [];
-
-  constructor(private readonly compare: (left: T, right: T) => number) {}
-
-  get size(): number {
-    return this.items.length;
-  }
-
-  push(value: T): void {
-    this.items.push(value);
-    this.siftUp(this.items.length - 1);
-  }
-
-  pop(): T | undefined {
-    if (this.items.length === 0) {
-      return undefined;
-    }
-    const top = this.items[0]!;
-    const last = this.items.pop()!;
-    if (this.items.length > 0) {
-      this.items[0] = last;
-      this.siftDown(0);
-    }
-    return top;
-  }
-
-  private siftUp(index: number): void {
-    while (index > 0) {
-      const parent = (index - 1) >> 1;
-      if (this.compare(this.items[index]!, this.items[parent]!) <= 0) {
-        return;
-      }
-      const tmp = this.items[index]!;
-      this.items[index] = this.items[parent]!;
-      this.items[parent] = tmp;
-      index = parent;
-    }
-  }
-
-  private siftDown(index: number): void {
-    const length = this.items.length;
-    while (true) {
-      const left = 2 * index + 1;
-      const right = 2 * index + 2;
-      let largest = index;
-      if (
-        left < length &&
-        this.compare(this.items[left]!, this.items[largest]!) > 0
-      ) {
-        largest = left;
-      }
-      if (
-        right < length &&
-        this.compare(this.items[right]!, this.items[largest]!) > 0
-      ) {
-        largest = right;
-      }
-      if (largest === index) {
-        return;
-      }
-      const tmp = this.items[index]!;
-      this.items[index] = this.items[largest]!;
-      this.items[largest] = tmp;
-      index = largest;
-    }
-  }
-}
+export {
+  EventAlreadyExistsError,
+  MissingParentError,
+} from "./event-graph-errors";
 
 /**
  * Event graph for storing operation history
@@ -159,6 +35,7 @@ export class EventGraph {
   private readonly events: Map<EventId, GraphEvent> = new Map();
   private readonly childrenMap: Map<EventId, Set<EventId>> = new Map();
   private readonly parentsMap: Map<EventId, Set<EventId>> = new Map();
+  private readonly frontier: Set<EventId> = new Set();
   /**
    * Monotonically increasing rank assigned to each event in the order it was
    * inserted into the graph. Because `addEvent` rejects events whose parents
@@ -201,6 +78,7 @@ export class EventGraph {
     this.childrenMap.clear();
     this.parentsMap.clear();
     this.insertionRank.clear();
+    this.frontier.clear();
     this.metadata = {};
     this.invalidateDerivedCaches();
   }
@@ -221,11 +99,13 @@ export class EventGraph {
 
     this.events.set(event.id, event);
     this.insertionRank.set(event.id, this.insertionRank.size);
+    this.frontier.add(event.id);
 
     for (const parentId of event.parentVersion) {
       const children = this.childrenMap.get(parentId) ?? new Set();
       children.add(event.id);
       this.childrenMap.set(parentId, children);
+      this.frontier.delete(parentId);
 
       const parents = this.parentsMap.get(event.id) ?? new Set();
       parents.add(parentId);
@@ -274,16 +154,7 @@ export class EventGraph {
    * Get the frontier version: events with no known children.
    */
   getFrontier(): Set<EventId> {
-    const frontier = new Set<EventId>();
-
-    for (const eventId of this.events.keys()) {
-      const children = this.childrenMap.get(eventId);
-      if (!children || children.size === 0) {
-        frontier.add(eventId);
-      }
-    }
-
-    return frontier;
+    return new Set(this.frontier);
   }
 
   /**
@@ -338,79 +209,11 @@ export class EventGraph {
     left: ReadonlySet<EventId>,
     right: ReadonlySet<EventId>,
   ): { readonly onlyInLeft: Set<EventId>; readonly onlyInRight: Set<EventId> } {
-    const onlyInLeft = new Set<EventId>();
-    const onlyInRight = new Set<EventId>();
-
-    const color = new Map<EventId, number>();
-    const heap = new MaxHeap<EventId>(
-      (a, b) =>
-        (this.insertionRank.get(a) ?? -1) - (this.insertionRank.get(b) ?? -1),
-    );
-
-    /**
-     * Count of events currently in the heap whose colour is not yet
-     * `COMMON`. Once this drops to zero, every remaining heap entry is
-     * a common ancestor and its own ancestors must be common as well, so
-     * the traversal can terminate early.
-     */
-    let pendingDivergent = 0;
-
-    const paint = (id: EventId, addedColor: number): void => {
-      if (!this.events.has(id)) {
-        return;
-      }
-      const existing = color.get(id) ?? 0;
-      const merged = existing | addedColor;
-      if (merged === existing) {
-        return;
-      }
-      color.set(id, merged);
-      if (existing === 0) {
-        heap.push(id);
-        if (merged !== DIFF_COLOR.COMMON) {
-          pendingDivergent++;
-        }
-      } else if (
-        existing !== DIFF_COLOR.COMMON &&
-        merged === DIFF_COLOR.COMMON
-      ) {
-        // The event was queued as divergent earlier but a second-frontier
-        // descendant has just revealed that it is in fact common. It is
-        // still in the heap, so adjust the divergent counter without
-        // pushing a duplicate entry.
-        pendingDivergent--;
-      }
-    };
-
-    for (const id of left) {
-      paint(id, DIFF_COLOR.LEFT);
-    }
-    for (const id of right) {
-      paint(id, DIFF_COLOR.RIGHT);
-    }
-
-    while (heap.size > 0 && pendingDivergent > 0) {
-      const id = heap.pop()!;
-      const finalColor = color.get(id) ?? 0;
-
-      if (finalColor === DIFF_COLOR.LEFT) {
-        onlyInLeft.add(id);
-        pendingDivergent--;
-      } else if (finalColor === DIFF_COLOR.RIGHT) {
-        onlyInRight.add(id);
-        pendingDivergent--;
-      }
-      // COMMON events fall through; their colour is propagated below so
-      // that ancestors reachable only through this path are also marked
-      // as common rather than being mis-classified as one-sided.
-
-      const parents = this.getParents(id);
-      for (const parent of parents) {
-        paint(parent, finalColor);
-      }
-    }
-
-    return { onlyInLeft, onlyInRight };
+    return diffVersionSets(left, right, {
+      getParents: (id) => this.getParents(id),
+      hasEvent: (id) => this.hasEvent(id),
+      insertionRankOf: (id) => this.insertionRank.get(id),
+    });
   }
 
   /**
@@ -434,51 +237,12 @@ export class EventGraph {
       return this.cachedTopologicalOrder;
     }
 
-    const remainingParents = new Map<EventId, number>();
-    const ready: EventId[] = [];
-
-    for (const [id, event] of this.events) {
-      remainingParents.set(id, event.parentVersion.size);
-      if (event.parentVersion.size === 0) {
-        ready.push(id);
-      }
-    }
-    ready.sort(compareEventIds);
-
-    const result: GraphEvent[] = [];
-    while (ready.length > 0) {
-      const id = ready.shift()!;
-      const event = this.events.get(id);
-      if (!event) {
-        continue;
-      }
-      result.push(event);
-
-      const children = Array.from(this.childrenMap.get(id) ?? []).sort(
-        compareEventIds,
-      );
-      for (const childId of children) {
-        const remaining = (remainingParents.get(childId) ?? 0) - 1;
-        remainingParents.set(childId, remaining);
-        if (remaining === 0) {
-          // Insertion-sort into ready to keep deterministic order
-          // without re-sorting the whole queue.
-          let insertionIndex = ready.findIndex(
-            (pending) => compareEventIds(pending, childId) > 0,
-          );
-          if (insertionIndex === -1) {
-            insertionIndex = ready.length;
-          }
-          ready.splice(insertionIndex, 0, childId);
-        }
-      }
-    }
-
-    if (result.length !== this.events.size) {
-      throw new Error("Cycle detected in event graph");
-    }
-
-    this.cachedTopologicalOrder = Object.freeze(result);
+    this.cachedTopologicalOrder = Object.freeze(
+      computeTopologicalOrder({
+        events: this.events,
+        childrenMap: this.childrenMap,
+      }),
+    );
     return this.cachedTopologicalOrder;
   }
 
@@ -520,69 +284,12 @@ export class EventGraph {
       return this.cachedBranchPreservingOrder;
     }
 
-    const remainingParents = new Map<EventId, number>();
-    const roots: EventId[] = [];
-
-    for (const [id, event] of this.events) {
-      remainingParents.set(id, event.parentVersion.size);
-      if (event.parentVersion.size === 0) {
-        roots.push(id);
-      }
-    }
-    roots.sort(compareEventIds);
-
-    // The stack is the deferred set: events that became ready but are
-    // not the natural continuation of the branch we're currently
-    // walking. We push children in descending order so the smallest
-    // (by `compareEventIds`) is on top and is popped next, which keeps
-    // the traversal deterministic across input shapes.
-    const stack: EventId[] = [];
-    for (let i = roots.length - 1; i >= 0; i--) {
-      stack.push(roots[i]!);
-    }
-
-    const result: GraphEvent[] = [];
-    const visited = new Set<EventId>();
-
-    while (stack.length > 0) {
-      const id = stack.pop()!;
-      if (visited.has(id)) {
-        continue;
-      }
-      const event = this.events.get(id);
-      if (!event) {
-        continue;
-      }
-      visited.add(id);
-      result.push(event);
-
-      const children = this.childrenMap.get(id);
-      if (!children || children.size === 0) {
-        continue;
-      }
-
-      const newlyReady: EventId[] = [];
-      for (const childId of children) {
-        const remaining = (remainingParents.get(childId) ?? 0) - 1;
-        remainingParents.set(childId, remaining);
-        if (remaining === 0) {
-          newlyReady.push(childId);
-        }
-      }
-      if (newlyReady.length === 0) {
-        continue;
-      }
-      newlyReady.sort(compareEventIds);
-      for (let i = newlyReady.length - 1; i >= 0; i--) {
-        stack.push(newlyReady[i]!);
-      }
-    }
-
-    if (result.length !== this.events.size) {
-      throw new Error("Cycle detected in event graph");
-    }
-
-    this.cachedBranchPreservingOrder = Object.freeze(result);
+    this.cachedBranchPreservingOrder = Object.freeze(
+      computeBranchPreservingTopologicalOrder({
+        events: this.events,
+        childrenMap: this.childrenMap,
+      }),
+    );
     return this.cachedBranchPreservingOrder;
   }
 
@@ -607,17 +314,17 @@ export class EventGraph {
     if (ancestor === descendant) return false;
 
     const visited = new Set<EventId>();
-    const queue = [descendant];
+    const stack = [descendant];
 
-    while (queue.length > 0) {
-      const current = queue.shift()!;
+    while (stack.length > 0) {
+      const current = stack.pop()!;
       if (visited.has(current)) continue;
       visited.add(current);
 
       const parents = this.getParents(current);
       for (const parent of parents) {
         if (parent === ancestor) return true;
-        queue.push(parent);
+        stack.push(parent);
       }
     }
 
@@ -662,74 +369,6 @@ export class EventGraph {
    * Deserialize event graph from persistence (Kahn's algorithm; O(n)).
    */
   static deserialize(data: SerializedGraphInput): EventGraph {
-    const graph = new EventGraph();
-
-    if (data.metadata) {
-      graph.metadata = data.metadata;
-    }
-
-    const eventsById = new Map<EventId, GraphEvent>();
-    const remainingParents = new Map<EventId, number>();
-    const childrenIndex = new Map<EventId, EventId[]>();
-
-    for (const incoming of data.events) {
-      const event: GraphEvent = {
-        id: incoming.id,
-        operation: incoming.operation,
-        parentVersion: new Set(normalizeEventIds(incoming.parentVersion)),
-        timestamp: incoming.timestamp,
-      };
-      eventsById.set(event.id, event);
-      remainingParents.set(event.id, event.parentVersion.size);
-      for (const parentId of event.parentVersion) {
-        const list = childrenIndex.get(parentId) ?? [];
-        list.push(event.id);
-        childrenIndex.set(parentId, list);
-      }
-    }
-
-    const ready: EventId[] = [];
-    for (const [id, count] of remainingParents) {
-      if (count === 0) {
-        ready.push(id);
-      }
-    }
-
-    let added = 0;
-    while (ready.length > 0) {
-      const id = ready.pop()!;
-      const event = eventsById.get(id);
-      if (!event) {
-        continue;
-      }
-      graph.addEvent(event);
-      added++;
-
-      for (const childId of childrenIndex.get(id) ?? []) {
-        const remaining = (remainingParents.get(childId) ?? 0) - 1;
-        remainingParents.set(childId, remaining);
-        if (remaining === 0) {
-          ready.push(childId);
-        }
-      }
-    }
-
-    if (added !== eventsById.size) {
-      const missingParents = new Set<EventId>();
-      for (const event of eventsById.values()) {
-        for (const parentId of event.parentVersion) {
-          if (!eventsById.has(parentId)) {
-            missingParents.add(parentId);
-          }
-        }
-      }
-      throw new Error(
-        `Cannot deserialize event graph with missing parents: ${[
-          ...missingParents,
-        ].join(", ")}`,
-      );
-    }
-
-    return graph;
+    return deserializeEventGraph(data, () => new EventGraph());
   }
 }

--- a/packages/eg-walker/src/graph/internals/binary-io.ts
+++ b/packages/eg-walker/src/graph/internals/binary-io.ts
@@ -1,0 +1,170 @@
+export const BINARY_MAGIC = new Uint8Array([0x45, 0x47, 0x57, 0x33]); // EGW3
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export const encodeText = (value: string): Uint8Array =>
+  textEncoder.encode(value);
+
+export const decodeText = (bytes: Uint8Array): string =>
+  textDecoder.decode(bytes);
+
+export const toUint8Array = (
+  bytes: ReadonlyArray<number> | Uint8Array,
+): Uint8Array => (bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes));
+
+/**
+ * Zigzag encoding maps signed integers to non-negative integers:
+ * `0 -> 0, -1 -> 1, 1 -> 2, -2 -> 3, 2 -> 4, ...`. Uses safe-integer
+ * arithmetic rather than bitwise ops so values beyond +/-2^31 round-trip
+ * correctly.
+ */
+const zigzagEncode = (value: number): number =>
+  value >= 0 ? value * 2 : value * -2 - 1;
+
+const zigzagDecode = (value: number): number =>
+  value % 2 === 0 ? value / 2 : -((value + 1) / 2);
+
+export class BinaryWriter {
+  private buffer = new Uint8Array(256);
+  private size = 0;
+
+  writeVarint(value: number): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`Cannot encode invalid varint value ${value}`);
+    }
+
+    let remaining = value;
+    while (remaining >= 0x80) {
+      this.writeByte((remaining % 0x80) + 0x80);
+      remaining = Math.floor(remaining / 0x80);
+    }
+    this.writeByte(remaining);
+  }
+
+  writeVarintArray(values: ReadonlyArray<number>): void {
+    this.writeVarint(values.length);
+    for (const value of values) {
+      this.writeVarint(value);
+    }
+  }
+
+  writeZigZagVarint(value: number): void {
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`Cannot encode invalid zigzag varint value ${value}`);
+    }
+    this.writeVarint(zigzagEncode(value));
+  }
+
+  writeZigZagDeltaArray(values: ReadonlyArray<number>): void {
+    this.writeVarint(values.length);
+    let previous = 0;
+    for (const value of values) {
+      this.writeZigZagVarint(value - previous);
+      previous = value;
+    }
+  }
+
+  writeString(value: string): void {
+    this.writeBytes(encodeText(value));
+  }
+
+  writeStringArray(values: ReadonlyArray<string>): void {
+    this.writeVarint(values.length);
+    for (const value of values) {
+      this.writeString(value);
+    }
+  }
+
+  writeBytes(bytes: Uint8Array): void {
+    this.writeVarint(bytes.length);
+    this.ensureCapacity(this.size + bytes.length);
+    this.buffer.set(bytes, this.size);
+    this.size += bytes.length;
+  }
+
+  toUint8Array(): Uint8Array {
+    return this.buffer.slice(0, this.size);
+  }
+
+  private writeByte(byte: number): void {
+    this.ensureCapacity(this.size + 1);
+    this.buffer[this.size++] = byte;
+  }
+
+  private ensureCapacity(required: number): void {
+    if (required <= this.buffer.length) {
+      return;
+    }
+    let nextCapacity = this.buffer.length * 2;
+    while (nextCapacity < required) {
+      nextCapacity *= 2;
+    }
+    const next = new Uint8Array(nextCapacity);
+    next.set(this.buffer);
+    this.buffer = next;
+  }
+}
+
+export class BinaryReader {
+  private offset = 0;
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  readVarint(): number {
+    let value = 0;
+    let multiplier = 1;
+
+    while (true) {
+      const byte = this.bytes[this.offset++];
+      if (byte === undefined) {
+        throw new Error("Unexpected end of varint");
+      }
+
+      value += (byte & 0x7f) * multiplier;
+      if ((byte & 0x80) === 0) {
+        return value;
+      }
+      multiplier *= 0x80;
+    }
+  }
+
+  readVarintArray(): number[] {
+    const length = this.readVarint();
+    return Array.from({ length }, () => this.readVarint());
+  }
+
+  readZigZagVarint(): number {
+    return zigzagDecode(this.readVarint());
+  }
+
+  readZigZagDeltaArray(): number[] {
+    const length = this.readVarint();
+    const values: number[] = new Array<number>(length);
+    let previous = 0;
+    for (let i = 0; i < length; i++) {
+      const value = previous + this.readZigZagVarint();
+      values[i] = value;
+      previous = value;
+    }
+    return values;
+  }
+
+  readString(): string {
+    return decodeText(this.readBytes(this.readVarint()));
+  }
+
+  readStringArray(): string[] {
+    const length = this.readVarint();
+    return Array.from({ length }, () => this.readString());
+  }
+
+  readBytes(length: number): Uint8Array {
+    if (this.offset + length > this.bytes.length) {
+      throw new Error("Unexpected end of binary eg-walker graph");
+    }
+    const result = this.bytes.slice(this.offset, this.offset + length);
+    this.offset += length;
+    return result;
+  }
+}

--- a/packages/eg-walker/src/graph/internals/binary-io.ts
+++ b/packages/eg-walker/src/graph/internals/binary-io.ts
@@ -114,19 +114,34 @@ export class BinaryReader {
   readVarint(): number {
     let value = 0;
     let multiplier = 1;
+    // A safe-integer (53-bit) value encodes to at most 8 continuation bytes
+    // plus 1 terminating byte. Reject anything longer up front so a crafted
+    // payload can't loop the decoder over arbitrary input.
+    const MAX_BYTES = 9;
 
-    while (true) {
-      const byte = this.bytes[this.offset++];
-      if (byte === undefined) {
+    for (let bytesRead = 0; bytesRead < MAX_BYTES; bytesRead++) {
+      if (this.offset >= this.bytes.length) {
         throw new Error("Unexpected end of varint");
       }
+      const byte = this.bytes[this.offset++]!;
 
       value += (byte & 0x7f) * multiplier;
+      // Even within MAX_BYTES, a high-bit-set byte combined with a large
+      // multiplier can carry the partial result past Number.MAX_SAFE_INTEGER,
+      // where integer arithmetic silently loses precision. Fail loudly
+      // instead of returning a corrupted number.
+      if (value > Number.MAX_SAFE_INTEGER) {
+        throw new Error("Varint exceeds Number.MAX_SAFE_INTEGER");
+      }
       if ((byte & 0x80) === 0) {
         return value;
       }
       multiplier *= 0x80;
     }
+
+    throw new Error(
+      `Varint exceeds maximum encoded length of ${MAX_BYTES} bytes`,
+    );
   }
 
   readVarintArray(): number[] {

--- a/packages/eg-walker/src/graph/internals/binary-io.ts
+++ b/packages/eg-walker/src/graph/internals/binary-io.ts
@@ -114,10 +114,11 @@ export class BinaryReader {
   readVarint(): number {
     let value = 0;
     let multiplier = 1;
-    // A safe-integer (53-bit) value encodes to at most 8 continuation bytes
-    // plus 1 terminating byte. Reject anything longer up front so a crafted
-    // payload can't loop the decoder over arbitrary input.
-    const MAX_BYTES = 9;
+    // 8 bytes carry 56 bits (7 per byte), more than enough for any value
+    // <= Number.MAX_SAFE_INTEGER (53 bits). Reject longer payloads up front
+    // so a crafted overlong encoding can't loop the decoder over arbitrary
+    // input.
+    const MAX_BYTES = 8;
 
     for (let bytesRead = 0; bytesRead < MAX_BYTES; bytesRead++) {
       if (this.offset >= this.bytes.length) {
@@ -128,8 +129,10 @@ export class BinaryReader {
       value += (byte & 0x7f) * multiplier;
       // Even within MAX_BYTES, a high-bit-set byte combined with a large
       // multiplier can carry the partial result past Number.MAX_SAFE_INTEGER,
-      // where integer arithmetic silently loses precision. Fail loudly
-      // instead of returning a corrupted number.
+      // where the addition above silently loses low bits to double-precision
+      // rounding. The comparison itself is still reliable — any rounded
+      // result above the safe range stays above MAX_SAFE_INTEGER (2^53 - 1)
+      // — so we fail loudly here instead of returning a corrupted number.
       if (value > Number.MAX_SAFE_INTEGER) {
         throw new Error("Varint exceeds Number.MAX_SAFE_INTEGER");
       }

--- a/packages/eg-walker/src/graph/internals/diff-versions.ts
+++ b/packages/eg-walker/src/graph/internals/diff-versions.ts
@@ -1,0 +1,79 @@
+import type { EventId } from "../../types";
+import { MaxHeap } from "./max-heap";
+
+const DIFF_COLOR = {
+  LEFT: 1,
+  RIGHT: 2,
+  COMMON: 3,
+} as const;
+
+interface DiffVersionsView {
+  readonly getParents: (id: EventId) => ReadonlySet<EventId>;
+  readonly hasEvent: (id: EventId) => boolean;
+  readonly insertionRankOf: (id: EventId) => number | undefined;
+}
+
+export const diffVersions = (
+  left: ReadonlySet<EventId>,
+  right: ReadonlySet<EventId>,
+  view: DiffVersionsView,
+): {
+  readonly onlyInLeft: Set<EventId>;
+  readonly onlyInRight: Set<EventId>;
+} => {
+  const onlyInLeft = new Set<EventId>();
+  const onlyInRight = new Set<EventId>();
+
+  const color = new Map<EventId, number>();
+  const heap = new MaxHeap<EventId>(
+    (a, b) => (view.insertionRankOf(a) ?? -1) - (view.insertionRankOf(b) ?? -1),
+  );
+
+  let pendingDivergent = 0;
+
+  const paint = (id: EventId, addedColor: number): void => {
+    if (!view.hasEvent(id)) {
+      return;
+    }
+    const existing = color.get(id) ?? 0;
+    const merged = existing | addedColor;
+    if (merged === existing) {
+      return;
+    }
+    color.set(id, merged);
+    if (existing === 0) {
+      heap.push(id);
+      if (merged !== DIFF_COLOR.COMMON) {
+        pendingDivergent++;
+      }
+    } else if (existing !== DIFF_COLOR.COMMON && merged === DIFF_COLOR.COMMON) {
+      pendingDivergent--;
+    }
+  };
+
+  for (const id of left) {
+    paint(id, DIFF_COLOR.LEFT);
+  }
+  for (const id of right) {
+    paint(id, DIFF_COLOR.RIGHT);
+  }
+
+  while (heap.size > 0 && pendingDivergent > 0) {
+    const id = heap.pop()!;
+    const finalColor = color.get(id) ?? 0;
+
+    if (finalColor === DIFF_COLOR.LEFT) {
+      onlyInLeft.add(id);
+      pendingDivergent--;
+    } else if (finalColor === DIFF_COLOR.RIGHT) {
+      onlyInRight.add(id);
+      pendingDivergent--;
+    }
+
+    for (const parent of view.getParents(id)) {
+      paint(parent, finalColor);
+    }
+  }
+
+  return { onlyInLeft, onlyInRight };
+};

--- a/packages/eg-walker/src/graph/internals/diff-versions.ts
+++ b/packages/eg-walker/src/graph/internals/diff-versions.ts
@@ -1,6 +1,12 @@
 import type { EventId } from "../../types";
 import { MaxHeap } from "./max-heap";
 
+/**
+ * Bit flags used by `diffVersions` to colour events while running the
+ * priority-queue diff. `LEFT` means "reachable from the left frontier",
+ * `RIGHT` means "reachable from the right frontier", and
+ * `COMMON = LEFT | RIGHT` means the event is a shared ancestor.
+ */
 const DIFF_COLOR = {
   LEFT: 1,
   RIGHT: 2,
@@ -13,6 +19,24 @@ interface DiffVersionsView {
   readonly insertionRankOf: (id: EventId) => number | undefined;
 }
 
+/**
+ * Compute Appendix B's transitive version diff.
+ *
+ * Uses a local, merge-base style traversal instead of expanding both versions
+ * to their full causal sets. Events from both frontiers are coloured (`LEFT`,
+ * `RIGHT`, or `COMMON`) and walked toward their ancestors in descending
+ * topological order via a max-heap keyed by insertion rank. Each event has
+ * its colour merged with the colours of its visited descendants, so once an
+ * event is popped its final colour is known and it can be classified into
+ * `onlyInLeft`, `onlyInRight`, or discarded as common.
+ *
+ * Traversal terminates as soon as every event still in the heap has been
+ * resolved to `COMMON`, which means the divergent region has been fully
+ * enumerated and any remaining ancestors are guaranteed to be shared. For a
+ * deep linear history with a small divergent branch this avoids touching
+ * unrelated history, replacing a full-expansion O(|history|) walk with cost
+ * proportional to the diff region.
+ */
 export const diffVersions = (
   left: ReadonlySet<EventId>,
   right: ReadonlySet<EventId>,
@@ -29,6 +53,12 @@ export const diffVersions = (
     (a, b) => (view.insertionRankOf(a) ?? -1) - (view.insertionRankOf(b) ?? -1),
   );
 
+  /**
+   * Count of events currently in the heap whose colour is not yet `COMMON`.
+   * Once this drops to zero, every remaining heap entry is a common ancestor
+   * and its own ancestors must be common as well, so the traversal can
+   * terminate early.
+   */
   let pendingDivergent = 0;
 
   const paint = (id: EventId, addedColor: number): void => {
@@ -47,6 +77,10 @@ export const diffVersions = (
         pendingDivergent++;
       }
     } else if (existing !== DIFF_COLOR.COMMON && merged === DIFF_COLOR.COMMON) {
+      // The event was queued as divergent earlier but a second-frontier
+      // descendant has just revealed that it is in fact common. It is still
+      // in the heap, so adjust the divergent counter without pushing a
+      // duplicate entry.
       pendingDivergent--;
     }
   };
@@ -69,6 +103,9 @@ export const diffVersions = (
       onlyInRight.add(id);
       pendingDivergent--;
     }
+    // COMMON events fall through; their colour is still propagated to
+    // ancestors below so that ancestors reachable only through this path are
+    // also marked as common rather than being mis-classified as one-sided.
 
     for (const parent of view.getParents(id)) {
       paint(parent, finalColor);

--- a/packages/eg-walker/src/graph/internals/event-graph-serialization.ts
+++ b/packages/eg-walker/src/graph/internals/event-graph-serialization.ts
@@ -43,6 +43,14 @@ export const deserializeEventGraph = <TGraph extends MutableEventGraph>(
   const childrenIndex = new Map<EventId, EventId[]>();
 
   for (const incoming of data.events) {
+    // Reject duplicate ids up front. Silently overwriting would coalesce two
+    // distinct payloads under one id and double-count this id in
+    // `childrenIndex` from both edges, breaking the Kahn pass below.
+    if (eventsById.has(incoming.id)) {
+      throw new Error(
+        `Cannot deserialize event graph with duplicate event id: ${incoming.id}`,
+      );
+    }
     const event: GraphEvent = {
       id: incoming.id,
       operation: incoming.operation,
@@ -93,10 +101,19 @@ export const deserializeEventGraph = <TGraph extends MutableEventGraph>(
         }
       }
     }
+    if (missingParents.size > 0) {
+      throw new Error(
+        `Cannot deserialize event graph with missing parents: ${[
+          ...missingParents,
+        ].join(", ")}`,
+      );
+    }
+    // Every parent is present in the payload but the Kahn pass still
+    // couldn't drain it — only a cycle (or some other unresolvable
+    // dependency, e.g. a self-parent) can leave events with non-zero
+    // `remainingParents` in that state.
     throw new Error(
-      `Cannot deserialize event graph with missing parents: ${[
-        ...missingParents,
-      ].join(", ")}`,
+      "Cannot deserialize event graph: cycle or unresolvable ordering detected",
     );
   }
 

--- a/packages/eg-walker/src/graph/internals/event-graph-serialization.ts
+++ b/packages/eg-walker/src/graph/internals/event-graph-serialization.ts
@@ -1,0 +1,104 @@
+import type { EventId, GraphEvent, SerializedGraphInput } from "../../types";
+
+interface MutableEventGraph {
+  addEvent(event: GraphEvent): void;
+  setMetadata(metadata: Record<string, unknown>): void;
+}
+
+export const normalizeEventIds = (value: unknown): EventId[] => {
+  if (Array.isArray(value)) {
+    return value.filter((id): id is EventId => typeof id === "string");
+  }
+
+  if (value instanceof Set) {
+    return Array.from(value).filter(
+      (id): id is EventId => typeof id === "string",
+    );
+  }
+
+  if (value && typeof value === "object") {
+    const maybeIterable = value as { [Symbol.iterator]?: unknown };
+    if (typeof maybeIterable[Symbol.iterator] === "function") {
+      return Array.from(value as Iterable<unknown>).filter(
+        (id): id is EventId => typeof id === "string",
+      );
+    }
+  }
+
+  return [];
+};
+
+export const deserializeEventGraph = <TGraph extends MutableEventGraph>(
+  data: SerializedGraphInput,
+  createGraph: () => TGraph,
+): TGraph => {
+  const graph = createGraph();
+
+  if (data.metadata) {
+    graph.setMetadata(data.metadata);
+  }
+
+  const eventsById = new Map<EventId, GraphEvent>();
+  const remainingParents = new Map<EventId, number>();
+  const childrenIndex = new Map<EventId, EventId[]>();
+
+  for (const incoming of data.events) {
+    const event: GraphEvent = {
+      id: incoming.id,
+      operation: incoming.operation,
+      parentVersion: new Set(normalizeEventIds(incoming.parentVersion)),
+      timestamp: incoming.timestamp,
+    };
+    eventsById.set(event.id, event);
+    remainingParents.set(event.id, event.parentVersion.size);
+    for (const parentId of event.parentVersion) {
+      const list = childrenIndex.get(parentId) ?? [];
+      list.push(event.id);
+      childrenIndex.set(parentId, list);
+    }
+  }
+
+  const ready: EventId[] = [];
+  for (const [id, count] of remainingParents) {
+    if (count === 0) {
+      ready.push(id);
+    }
+  }
+
+  let added = 0;
+  while (ready.length > 0) {
+    const id = ready.pop()!;
+    const event = eventsById.get(id);
+    if (!event) {
+      continue;
+    }
+    graph.addEvent(event);
+    added++;
+
+    for (const childId of childrenIndex.get(id) ?? []) {
+      const remaining = (remainingParents.get(childId) ?? 0) - 1;
+      remainingParents.set(childId, remaining);
+      if (remaining === 0) {
+        ready.push(childId);
+      }
+    }
+  }
+
+  if (added !== eventsById.size) {
+    const missingParents = new Set<EventId>();
+    for (const event of eventsById.values()) {
+      for (const parentId of event.parentVersion) {
+        if (!eventsById.has(parentId)) {
+          missingParents.add(parentId);
+        }
+      }
+    }
+    throw new Error(
+      `Cannot deserialize event graph with missing parents: ${[
+        ...missingParents,
+      ].join(", ")}`,
+    );
+  }
+
+  return graph;
+};

--- a/packages/eg-walker/src/graph/internals/max-heap.ts
+++ b/packages/eg-walker/src/graph/internals/max-heap.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal binary max-heap. The eg-walker package does not depend on a
+ * priority-queue library, so internal graph traversals share this small
+ * implementation instead.
+ */
+export class MaxHeap<T> {
+  private readonly items: T[] = [];
+
+  constructor(private readonly compare: (left: T, right: T) => number) {}
+
+  get size(): number {
+    return this.items.length;
+  }
+
+  push(value: T): void {
+    this.items.push(value);
+    this.siftUp(this.items.length - 1);
+  }
+
+  pop(): T | undefined {
+    if (this.items.length === 0) {
+      return undefined;
+    }
+    const top = this.items[0]!;
+    const last = this.items.pop()!;
+    if (this.items.length > 0) {
+      this.items[0] = last;
+      this.siftDown(0);
+    }
+    return top;
+  }
+
+  private siftUp(index: number): void {
+    while (index > 0) {
+      const parent = (index - 1) >> 1;
+      if (this.compare(this.items[index]!, this.items[parent]!) <= 0) {
+        return;
+      }
+      const tmp = this.items[index]!;
+      this.items[index] = this.items[parent]!;
+      this.items[parent] = tmp;
+      index = parent;
+    }
+  }
+
+  private siftDown(index: number): void {
+    const length = this.items.length;
+    while (true) {
+      const left = 2 * index + 1;
+      const right = 2 * index + 2;
+      let largest = index;
+      if (
+        left < length &&
+        this.compare(this.items[left]!, this.items[largest]!) > 0
+      ) {
+        largest = left;
+      }
+      if (
+        right < length &&
+        this.compare(this.items[right]!, this.items[largest]!) > 0
+      ) {
+        largest = right;
+      }
+      if (largest === index) {
+        return;
+      }
+      const tmp = this.items[index]!;
+      this.items[index] = this.items[largest]!;
+      this.items[largest] = tmp;
+      index = largest;
+    }
+  }
+}

--- a/packages/eg-walker/src/graph/internals/topological-order.ts
+++ b/packages/eg-walker/src/graph/internals/topological-order.ts
@@ -1,0 +1,111 @@
+import type { EventId, GraphEvent } from "../../types";
+import { compareEventIds } from "../event-id";
+import { MaxHeap } from "./max-heap";
+
+interface TopologicalOrderView {
+  readonly events: ReadonlyMap<EventId, GraphEvent>;
+  readonly childrenMap: ReadonlyMap<EventId, ReadonlySet<EventId>>;
+}
+
+export const getTopologicalOrder = (
+  view: TopologicalOrderView,
+): GraphEvent[] => {
+  const remainingParents = new Map<EventId, number>();
+  const ready = new MaxHeap<EventId>((left, right) =>
+    compareEventIds(right, left),
+  );
+
+  for (const [id, event] of view.events) {
+    remainingParents.set(id, event.parentVersion.size);
+    if (event.parentVersion.size === 0) {
+      ready.push(id);
+    }
+  }
+
+  const result: GraphEvent[] = [];
+  while (ready.size > 0) {
+    const id = ready.pop()!;
+    const event = view.events.get(id);
+    if (!event) {
+      continue;
+    }
+    result.push(event);
+
+    for (const childId of view.childrenMap.get(id) ?? []) {
+      const remaining = (remainingParents.get(childId) ?? 0) - 1;
+      remainingParents.set(childId, remaining);
+      if (remaining === 0) {
+        ready.push(childId);
+      }
+    }
+  }
+
+  if (result.length !== view.events.size) {
+    throw new Error("Cycle detected in event graph");
+  }
+
+  return result;
+};
+
+export const getBranchPreservingTopologicalOrder = (
+  view: TopologicalOrderView,
+): GraphEvent[] => {
+  const remainingParents = new Map<EventId, number>();
+  const roots: EventId[] = [];
+
+  for (const [id, event] of view.events) {
+    remainingParents.set(id, event.parentVersion.size);
+    if (event.parentVersion.size === 0) {
+      roots.push(id);
+    }
+  }
+  roots.sort(compareEventIds);
+
+  const stack: EventId[] = [];
+  for (let i = roots.length - 1; i >= 0; i--) {
+    stack.push(roots[i]!);
+  }
+
+  const result: GraphEvent[] = [];
+  const visited = new Set<EventId>();
+
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (visited.has(id)) {
+      continue;
+    }
+    const event = view.events.get(id);
+    if (!event) {
+      continue;
+    }
+    visited.add(id);
+    result.push(event);
+
+    const children = view.childrenMap.get(id);
+    if (!children || children.size === 0) {
+      continue;
+    }
+
+    const newlyReady: EventId[] = [];
+    for (const childId of children) {
+      const remaining = (remainingParents.get(childId) ?? 0) - 1;
+      remainingParents.set(childId, remaining);
+      if (remaining === 0) {
+        newlyReady.push(childId);
+      }
+    }
+    if (newlyReady.length === 0) {
+      continue;
+    }
+    newlyReady.sort(compareEventIds);
+    for (let i = newlyReady.length - 1; i >= 0; i--) {
+      stack.push(newlyReady[i]!);
+    }
+  }
+
+  if (result.length !== view.events.size) {
+    throw new Error("Cycle detected in event graph");
+  }
+
+  return result;
+};

--- a/packages/eg-walker/src/graph/internals/topological-order.ts
+++ b/packages/eg-walker/src/graph/internals/topological-order.ts
@@ -7,6 +7,14 @@ interface TopologicalOrderView {
   readonly childrenMap: ReadonlyMap<EventId, ReadonlySet<EventId>>;
 }
 
+/**
+ * Kahn's algorithm with a heap-backed ready queue, breaking ties by
+ * numeric-aware event id via {@link compareEventIds}. The heap stays a
+ * max-heap with an inverted comparator so each `pop` returns the lex-smallest
+ * ready event, matching the previous shift+insertion-sort implementation
+ * byte-for-byte — important because the columnar codec's on-disk bytes are
+ * keyed off this ordering.
+ */
 export const getTopologicalOrder = (
   view: TopologicalOrderView,
 ): GraphEvent[] => {
@@ -47,6 +55,21 @@ export const getTopologicalOrder = (
   return result;
 };
 
+/**
+ * Branch-preserving topological order (Section 5.2 of the Eg-walker paper).
+ *
+ * Kahn's algorithm with a sorted ready queue interleaves concurrent branches
+ * whenever a child event lex-sorts after a deferred sibling root, which
+ * forces the replay engine to retreat and re-advance on every transition.
+ * This DFS variant walks one branch as far as possible before starting
+ * another, so two consecutive events in the output usually share a parent
+ * relationship and the engine's diff against the previous version collapses
+ * to an empty retreat/advance pair.
+ *
+ * Roots and sibling branches are ordered by numeric-aware event id via
+ * {@link compareEventIds} so the output is a deterministic function of the
+ * graph.
+ */
 export const getBranchPreservingTopologicalOrder = (
   view: TopologicalOrderView,
 ): GraphEvent[] => {
@@ -61,6 +84,11 @@ export const getBranchPreservingTopologicalOrder = (
   }
   roots.sort(compareEventIds);
 
+  // The stack is the deferred set: events that became ready but are not the
+  // natural continuation of the branch we're currently walking. We push
+  // children in descending order so the smallest (by `compareEventIds`) is
+  // on top and is popped next, which keeps the traversal deterministic
+  // across input shapes.
   const stack: EventId[] = [];
   for (let i = roots.length - 1; i >= 0; i--) {
     stack.push(roots[i]!);

--- a/packages/eg-walker/src/test/binary-io.test.ts
+++ b/packages/eg-walker/src/test/binary-io.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { BinaryReader, BinaryWriter } from "../graph/internals/binary-io";
+
+describe("BinaryReader.readVarint hardening", () => {
+  it("rejects an overlong varint (more bytes than a safe-integer needs)", () => {
+    // Nine continuation bytes — never legal: a Number.MAX_SAFE_INTEGER value
+    // fits in 8 bytes (7 continuation + 1 terminating). The decoder should
+    // bail before reading past the cap rather than spinning over the input.
+    const overlong = new Uint8Array(9).fill(0xff);
+    expect(() => new BinaryReader(overlong).readVarint()).toThrow(
+      /maximum encoded length|MAX_SAFE_INTEGER/,
+    );
+  });
+
+  it("rejects a varint whose decoded value exceeds Number.MAX_SAFE_INTEGER", () => {
+    // Seven 0xff bytes followed by a terminating byte that pushes the value
+    // past 2^53 - 1. Within MAX_BYTES, but the per-byte safe-integer guard
+    // should fire before the loop returns a corrupted double.
+    const overflowing = new Uint8Array([
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f,
+    ]);
+    expect(() => new BinaryReader(overflowing).readVarint()).toThrow(
+      /MAX_SAFE_INTEGER/,
+    );
+  });
+
+  it("rejects a varint that ends mid-stream", () => {
+    // Continuation bit set on the final byte means more bytes were expected
+    // but the buffer is exhausted; this is a distinct failure from overlong.
+    const truncated = new Uint8Array([0xff, 0xff]);
+    expect(() => new BinaryReader(truncated).readVarint()).toThrow(
+      /Unexpected end of varint/,
+    );
+  });
+
+  it("still round-trips the safe-integer ceiling", () => {
+    const writer = new BinaryWriter();
+    writer.writeVarint(Number.MAX_SAFE_INTEGER);
+    const bytes = writer.toUint8Array();
+    expect(new BinaryReader(bytes).readVarint()).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("round-trips small varints with no overhead", () => {
+    for (const value of [0, 1, 127, 128, 16383, 16384, 2 ** 32]) {
+      const writer = new BinaryWriter();
+      writer.writeVarint(value);
+      expect(new BinaryReader(writer.toUint8Array()).readVarint()).toBe(value);
+    }
+  });
+});

--- a/packages/eg-walker/src/test/binary-io.test.ts
+++ b/packages/eg-walker/src/test/binary-io.test.ts
@@ -3,13 +3,15 @@ import { describe, expect, it } from "vitest";
 import { BinaryReader, BinaryWriter } from "../graph/internals/binary-io";
 
 describe("BinaryReader.readVarint hardening", () => {
-  it("rejects an overlong varint (more bytes than a safe-integer needs)", () => {
-    // Nine continuation bytes — never legal: a Number.MAX_SAFE_INTEGER value
-    // fits in 8 bytes (7 continuation + 1 terminating). The decoder should
-    // bail before reading past the cap rather than spinning over the input.
-    const overlong = new Uint8Array(9).fill(0xff);
-    expect(() => new BinaryReader(overlong).readVarint()).toThrow(
-      /maximum encoded length|MAX_SAFE_INTEGER/,
+  it("rejects a payload longer than the MAX_BYTES cap", () => {
+    // Eight continuation-only bytes (0x80 = continuation set, zero data
+    // payload) keep the accumulated value at 0 through every iteration, so
+    // the per-byte `value > MAX_SAFE_INTEGER` guard never fires. The loop
+    // exits via its `bytesRead < MAX_BYTES` condition instead, exercising
+    // the length-cap throw distinctly from the value-overflow path below.
+    const lengthCapped = new Uint8Array(8).fill(0x80);
+    expect(() => new BinaryReader(lengthCapped).readVarint()).toThrow(
+      /maximum encoded length/,
     );
   });
 
@@ -41,11 +43,21 @@ describe("BinaryReader.readVarint hardening", () => {
     expect(new BinaryReader(bytes).readVarint()).toBe(Number.MAX_SAFE_INTEGER);
   });
 
-  it("round-trips small varints with no overhead", () => {
-    for (const value of [0, 1, 127, 128, 16383, 16384, 2 ** 32]) {
+  it("round-trips representative values at each encoding-length boundary", () => {
+    const cases: ReadonlyArray<{ label: string; value: number }> = [
+      { label: "zero", value: 0 },
+      { label: "single-byte max (127)", value: 127 },
+      { label: "two-byte min (128)", value: 128 },
+      { label: "two-byte max (16383)", value: 16383 },
+      { label: "three-byte min (16384)", value: 16384 },
+      { label: "five-byte (2^32)", value: 2 ** 32 },
+    ];
+    for (const { label, value } of cases) {
       const writer = new BinaryWriter();
       writer.writeVarint(value);
-      expect(new BinaryReader(writer.toUint8Array()).readVarint()).toBe(value);
+      expect(new BinaryReader(writer.toUint8Array()).readVarint(), label).toBe(
+        value,
+      );
     }
   });
 });

--- a/packages/eg-walker/src/test/eg-walker-engine.test.ts
+++ b/packages/eg-walker/src/test/eg-walker-engine.test.ts
@@ -203,10 +203,6 @@ describe("EgWalkerEngine", () => {
       retreat: ["c"],
       advance: ["a", "b"],
     });
-    // @ts-expect-error - Private method coverage for ID tie fallback.
-    expect(engine.compareByTopologicalOrder("b", "a")).toBeGreaterThan(0);
-    // @ts-expect-error - Private method coverage for locale-independent ID ordering.
-    expect(engine.compareByTopologicalOrder("Z:0", "a:0")).toBeLessThan(0);
   });
 
   it("round-trips persisted event graph state through the public API", () => {

--- a/packages/eg-walker/src/test/event-graph.test.ts
+++ b/packages/eg-walker/src/test/event-graph.test.ts
@@ -756,6 +756,40 @@ describe("EventGraph", () => {
       );
     });
 
+    it("should reject serialized graphs containing a multi-event cycle", () => {
+      // event-a → event-b → event-c → event-a, covering the path where a
+      // cycle spans more than two nodes (the A↔B test above is the minimal
+      // case).
+      expect(() =>
+        EventGraph.deserialize({
+          version: new Set<EventId>(),
+          events: [
+            {
+              id: "event-a",
+              timestamp: 1,
+              parentVersion: new Set<EventId>(["event-c"]),
+              operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
+            },
+            {
+              id: "event-b",
+              timestamp: 2,
+              parentVersion: new Set<EventId>(["event-a"]),
+              operation: { type: OPERATION_TYPE.INSERT, index: 1, text: "B" },
+            },
+            {
+              id: "event-c",
+              timestamp: 3,
+              parentVersion: new Set<EventId>(["event-b"]),
+              operation: { type: OPERATION_TYPE.INSERT, index: 2, text: "C" },
+            },
+          ],
+          metadata: {},
+        }),
+      ).toThrow(
+        "Cannot deserialize event graph: cycle or unresolvable ordering detected",
+      );
+    });
+
     it("should reject serialized graphs containing a self-parent (degenerate cycle)", () => {
       expect(() =>
         EventGraph.deserialize({

--- a/packages/eg-walker/src/test/event-graph.test.ts
+++ b/packages/eg-walker/src/test/event-graph.test.ts
@@ -708,6 +708,72 @@ describe("EventGraph", () => {
         "Cannot deserialize event graph with missing parents: missing-parent",
       );
     });
+
+    it("should reject serialized graphs with duplicate event ids", () => {
+      const event: GraphEvent = {
+        id: "event-1",
+        timestamp: 100,
+        parentVersion: new Set<EventId>(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
+      };
+
+      expect(() =>
+        EventGraph.deserialize({
+          version: new Set<EventId>(),
+          events: [event, event],
+          metadata: {},
+        }),
+      ).toThrow(
+        "Cannot deserialize event graph with duplicate event id: event-1",
+      );
+    });
+
+    it("should reject serialized graphs containing a parent cycle", () => {
+      // event-a parents on event-b, event-b parents on event-a — every parent
+      // referenced is present in the payload, so the failure mode is a cycle,
+      // not a missing parent.
+      expect(() =>
+        EventGraph.deserialize({
+          version: new Set<EventId>(),
+          events: [
+            {
+              id: "event-a",
+              timestamp: 1,
+              parentVersion: new Set<EventId>(["event-b"]),
+              operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
+            },
+            {
+              id: "event-b",
+              timestamp: 2,
+              parentVersion: new Set<EventId>(["event-a"]),
+              operation: { type: OPERATION_TYPE.INSERT, index: 1, text: "B" },
+            },
+          ],
+          metadata: {},
+        }),
+      ).toThrow(
+        "Cannot deserialize event graph: cycle or unresolvable ordering detected",
+      );
+    });
+
+    it("should reject serialized graphs containing a self-parent (degenerate cycle)", () => {
+      expect(() =>
+        EventGraph.deserialize({
+          version: new Set<EventId>(),
+          events: [
+            {
+              id: "self",
+              timestamp: 1,
+              parentVersion: new Set<EventId>(["self"]),
+              operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "X" },
+            },
+          ],
+          metadata: {},
+        }),
+      ).toThrow(
+        "Cannot deserialize event graph: cycle or unresolvable ordering detected",
+      );
+    });
   });
 
   describe("branch coverage improvements", () => {


### PR DESCRIPTION
## Summary

Split the five >500-LOC source files in `packages/eg-walker/src` into focused internal modules and take the low-risk perf wins surfaced along the way. No public surface change — `EgWalkerReplica`, `EventGraph`, `EgWalkerEngine`, `IndexedSequence`, `ColumnarEventGraphCodec`, `OPERATION_TYPE`, and the `types/*` exports are unchanged.

### Structural splits

| File | Before | After | Extracted to |
| --- | ---: | ---: | --- |
| `graph/event-graph.ts` | 735 | ~380 | `event-graph-errors.ts`, `internals/{max-heap,diff-versions,topological-order,event-graph-serialization}.ts` |
| `graph/columnar-codec.ts` | 750 | ~430 | `internals/binary-io.ts` (BinaryReader/Writer + zigzag helpers) |
| `engine/eg-walker-engine.ts` | 739 | ~460 | `internals/{insert-handler,delete-handler}.ts` |
| `engine/indexed-sequence.ts` | 712 | ~645 | `internals/indexed-sequence-node.ts` (B-tree node primitives) |
| `core/replica.ts` | 650 | ~470 | `internals/{critical-checkpoint-store,remote-event-buffer,persistence-metadata}.ts` |

### Performance cleanups

- `EventGraph.frontier` is now an incrementally maintained `Set` updated in `addEvent` / `clear`, so `getFrontier()` is O(parents) instead of O(N) per call (hot in `EgWalkerReplica.advanceWithEvent`).
- `EventGraph.getTopologicalOrder` swaps the O(n²) `shift()` + `findIndex` ready queue for a heap with inverted `compareEventIds` — byte-stable output preserved (covered by `columnar-codec-size.test.ts`).
- `EventGraph.isAncestor` BFS → stack so a long parent chain is no longer quadratic.
- `EgWalkerEngine.diffVersions` pre-materialises `eventOrder` ranks per id behind `sortByEventOrder`, dropping repeated map lookups in the sort comparator.
- `IndexedSequence` B-tree walkers replace `Array.prototype.find`-with-side-effects with explicit `for` loops on the three hot paths (`findLeafByRecordIndex`, `prefixSum`, `weightIndexToPositionAndOffset`).
- `EgWalkerEngine` now constructs `insertDeps` / `deleteDeps` once at construction time, so `processEvent` no longer allocates a dep object + arrow closures per applied event.

### Review-feedback fixes (last commit)

- Hoisted handler deps out of the per-event hot path (above).
- Simplified the `diffVersions` tied-rank tiebreak to call `compareEventIds` directly instead of round-tripping through `compareByTopologicalOrder`.
- Restored the paper-section, invariant, and regression-history comments that were stripped from `insert-handler`, `delete-handler`, `diff-versions`, `topological-order`, and `indexed-sequence-node` during the initial extraction.

## Validation

- `pnpm --filter @softmaple/eg-walker test -- --run` — 254/254 passing
- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker build`
- `pnpm --filter @softmaple/eg-walker lint`

## Test plan

- [x] All eg-walker unit, convergence, traversal-independence, and replay-benchmark suites green
- [x] `columnar-codec-size.test.ts` confirms on-disk bytes unchanged after the topo-order heap swap
- [x] `traversal-order-independence.test.ts` confirms branch-preserving order still matches Kahn output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal architecture to improve code maintainability: extracted specialized handlers for core operations, consolidated checkpoint management, refactored graph computation utilities into dedicated modules, and improved serialization infrastructure for better separation of concerns across the event graph system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->