### PR TITLE
feat(packages/awareness): add editor-agnostic position-mapping subpath

### DIFF
--- a/apps/playground/src/lib/text-diff.ts
+++ b/apps/playground/src/lib/text-diff.ts
@@ -1,65 +1,13 @@
 /**
- * Text diffing utilities for collaborative editing
+ * Text diffing utilities for collaborative editing.
+ *
+ * Implementations live in `@softmaple/awareness/mapping` so they can be
+ * shared with other consumers; this module re-exports them to keep existing
+ * `@/lib/text-diff` imports working.
  */
 
-/**
- * Find where text was inserted by comparing old and new text
- * @param oldText - The original text
- * @param newText - The new text after insertion
- * @returns The position where text was inserted
- */
-export const findInsertPosition = (
-  oldText: string,
-  newText: string,
-): number => {
-  for (let i = 0; i < Math.min(oldText.length, newText.length); i++) {
-    if (oldText[i] !== newText[i]) {
-      return i;
-    }
-  }
-  return oldText.length;
-};
-
-/**
- * Find where text was deleted by comparing old and new text
- * @param oldText - The original text
- * @param newText - The new text after deletion
- * @returns The position where text was deleted
- */
-export const findDeletePosition = (
-  oldText: string,
-  newText: string,
-): number => {
-  for (let i = 0; i < Math.min(oldText.length, newText.length); i++) {
-    if (oldText[i] !== newText[i]) {
-      return i;
-    }
-  }
-  return newText.length;
-};
-
-/**
- * Find the range of differing characters between two strings of equal length
- * @param oldText - The original text
- * @param newText - The new text
- * @returns Object with start and end indices of the differing range
- */
-export const findDifferingRange = (
-  oldText: string,
-  newText: string,
-): { start: number; end: number } => {
-  let start = 0;
-  let end = oldText.length - 1;
-
-  // Find first differing index from the start
-  while (start < oldText.length && oldText[start] === newText[start]) {
-    start++;
-  }
-
-  // Find last differing index from the end
-  while (end >= start && oldText[end] === newText[end]) {
-    end--;
-  }
-
-  return { start, end };
-};
+export {
+  findDeletePosition,
+  findDifferingRange,
+  findInsertPosition,
+} from "@softmaple/awareness/mapping";

--- a/apps/playground/workspace-aliases.ts
+++ b/apps/playground/workspace-aliases.ts
@@ -27,6 +27,9 @@ export const workspaceAlias: Readonly<Record<string, string>> = {
   "@softmaple/awareness/styles.css": fromPlayground(
     "../../packages/awareness/src/global.css",
   ),
+  "@softmaple/awareness/mapping": fromPlayground(
+    "../../packages/awareness/src/mapping/index.ts",
+  ),
   "@softmaple/awareness": fromPlayground(
     "../../packages/awareness/src/index.ts",
   ),

--- a/packages/awareness/package.json
+++ b/packages/awareness/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/utils/textarea-rects.d.ts",
       "import": "./dist/utils/textarea-rects.js"
     },
+    "./mapping": {
+      "types": "./dist/mapping/index.d.ts",
+      "import": "./dist/mapping/index.js"
+    },
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"

--- a/packages/awareness/src/mapping/index.ts
+++ b/packages/awareness/src/mapping/index.ts
@@ -1,0 +1,15 @@
+export { mapCursorThroughOperation } from "./map-cursor";
+export { mapSelectionThroughOperation } from "./map-selection";
+export {
+  type DeleteOperation,
+  type InsertOperation,
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+  type PositionOperationType,
+  type PositionRange,
+} from "./position-operation";
+export {
+  findDeletePosition,
+  findDifferingRange,
+  findInsertPosition,
+} from "./text-diff";

--- a/packages/awareness/src/mapping/map-cursor.test.ts
+++ b/packages/awareness/src/mapping/map-cursor.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { mapCursorThroughOperation } from "./map-cursor";
+import {
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+} from "./position-operation";
+
+const insertAt = (index: number, length: number): PositionOperation => ({
+  type: POSITION_OPERATION_TYPE.Insert,
+  index,
+  length,
+});
+
+const deleteAt = (index: number, length: number): PositionOperation => ({
+  type: POSITION_OPERATION_TYPE.Delete,
+  index,
+  length,
+});
+
+describe("mapCursorThroughOperation: insert", () => {
+  it("leaves a cursor strictly before the insert unchanged", () => {
+    expect(mapCursorThroughOperation(2, insertAt(5, 3))).toBe(2);
+  });
+
+  it("shifts a cursor at the insert index right by the inserted length", () => {
+    expect(mapCursorThroughOperation(5, insertAt(5, 3))).toBe(8);
+  });
+
+  it("shifts a cursor after the insert right by the inserted length", () => {
+    expect(mapCursorThroughOperation(10, insertAt(5, 3))).toBe(13);
+  });
+
+  it("handles a zero-length insert as a no-op", () => {
+    expect(mapCursorThroughOperation(5, insertAt(3, 0))).toBe(5);
+  });
+
+  it("handles an insert at index 0", () => {
+    expect(mapCursorThroughOperation(0, insertAt(0, 4))).toBe(4);
+    expect(mapCursorThroughOperation(7, insertAt(0, 4))).toBe(11);
+  });
+});
+
+describe("mapCursorThroughOperation: delete", () => {
+  it("leaves a cursor before the delete unchanged", () => {
+    expect(mapCursorThroughOperation(2, deleteAt(5, 3))).toBe(2);
+  });
+
+  it("leaves a cursor at the start of the deleted range unchanged", () => {
+    expect(mapCursorThroughOperation(5, deleteAt(5, 3))).toBe(5);
+  });
+
+  it("collapses a cursor inside the deleted range to the deletion start", () => {
+    expect(mapCursorThroughOperation(6, deleteAt(5, 3))).toBe(5);
+    expect(mapCursorThroughOperation(7, deleteAt(5, 3))).toBe(5);
+  });
+
+  it("shifts a cursor at the deletion end left by the deleted length", () => {
+    expect(mapCursorThroughOperation(8, deleteAt(5, 3))).toBe(5);
+  });
+
+  it("shifts a cursor after the deletion left by the deleted length", () => {
+    expect(mapCursorThroughOperation(12, deleteAt(5, 3))).toBe(9);
+  });
+
+  it("handles a zero-length delete as a no-op", () => {
+    expect(mapCursorThroughOperation(5, deleteAt(3, 0))).toBe(5);
+  });
+
+  it("handles a delete at index 0", () => {
+    expect(mapCursorThroughOperation(0, deleteAt(0, 4))).toBe(0);
+    expect(mapCursorThroughOperation(2, deleteAt(0, 4))).toBe(0);
+    expect(mapCursorThroughOperation(10, deleteAt(0, 4))).toBe(6);
+  });
+});

--- a/packages/awareness/src/mapping/map-cursor.ts
+++ b/packages/awareness/src/mapping/map-cursor.ts
@@ -1,0 +1,34 @@
+import {
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+} from "./position-operation";
+
+/**
+ * Map a cursor index through a single insert or delete operation.
+ *
+ * - Insert at `op.index`: a cursor strictly before the insert is unchanged;
+ *   a cursor at or after the insert shifts right by `op.length`. The "at the
+ *   insert" case advances the cursor so that the same characters remain to
+ *   the left of it after the insert.
+ * - Delete from `op.index` of `op.length` units: a cursor at or before the
+ *   delete is unchanged; a cursor at or after the deleted range shifts left
+ *   by `op.length`; a cursor inside the deleted range collapses to
+ *   `op.index`.
+ */
+export const mapCursorThroughOperation = (
+  cursor: number,
+  operation: PositionOperation,
+): number => {
+  if (operation.type === POSITION_OPERATION_TYPE.Insert) {
+    return cursor < operation.index ? cursor : cursor + operation.length;
+  }
+
+  const deleteEnd = operation.index + operation.length;
+  if (cursor <= operation.index) {
+    return cursor;
+  }
+  if (cursor >= deleteEnd) {
+    return cursor - operation.length;
+  }
+  return operation.index;
+};

--- a/packages/awareness/src/mapping/map-selection.test.ts
+++ b/packages/awareness/src/mapping/map-selection.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { mapSelectionThroughOperation } from "./map-selection";
+import {
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+} from "./position-operation";
+
+const insertAt = (index: number, length: number): PositionOperation => ({
+  type: POSITION_OPERATION_TYPE.Insert,
+  index,
+  length,
+});
+
+const deleteAt = (index: number, length: number): PositionOperation => ({
+  type: POSITION_OPERATION_TYPE.Delete,
+  index,
+  length,
+});
+
+describe("mapSelectionThroughOperation: insert", () => {
+  it("leaves a selection strictly before the insert unchanged", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 1, to: 3 }, insertAt(5, 4)),
+    ).toEqual({
+      from: 1,
+      to: 3,
+    });
+  });
+
+  it("shifts a selection strictly after the insert right by the inserted length", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 6, to: 9 }, insertAt(5, 4)),
+    ).toEqual({
+      from: 10,
+      to: 13,
+    });
+  });
+
+  it("extends a selection whose range straddles the insert", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 3, to: 8 }, insertAt(5, 4)),
+    ).toEqual({
+      from: 3,
+      to: 12,
+    });
+  });
+
+  it("shifts a collapsed selection at the insert index", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 5, to: 5 }, insertAt(5, 2)),
+    ).toEqual({
+      from: 7,
+      to: 7,
+    });
+  });
+});
+
+describe("mapSelectionThroughOperation: delete", () => {
+  it("leaves a selection before the delete unchanged", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 1, to: 3 }, deleteAt(5, 4)),
+    ).toEqual({
+      from: 1,
+      to: 3,
+    });
+  });
+
+  it("shifts a selection after the delete left by the deleted length", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 10, to: 14 }, deleteAt(5, 4)),
+    ).toEqual({
+      from: 6,
+      to: 10,
+    });
+  });
+
+  it("collapses a selection fully inside the deleted range to a point", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 6, to: 8 }, deleteAt(5, 4)),
+    ).toEqual({
+      from: 5,
+      to: 5,
+    });
+  });
+
+  it("clamps a selection that partially overlaps the start of a deletion", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 3, to: 7 }, deleteAt(5, 4)),
+    ).toEqual({
+      from: 3,
+      to: 5,
+    });
+  });
+
+  it("clamps a selection that partially overlaps the end of a deletion", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 7, to: 12 }, deleteAt(5, 4)),
+    ).toEqual({
+      from: 5,
+      to: 8,
+    });
+  });
+
+  it("clamps a selection whose range fully contains a deletion", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 2, to: 12 }, deleteAt(5, 4)),
+    ).toEqual({
+      from: 2,
+      to: 8,
+    });
+  });
+});
+
+describe("mapSelectionThroughOperation: invariants", () => {
+  it("always returns from <= to", () => {
+    const cases = [
+      { range: { from: 0, to: 10 }, op: insertAt(5, 2) },
+      { range: { from: 0, to: 10 }, op: deleteAt(2, 5) },
+      { range: { from: 3, to: 3 }, op: deleteAt(2, 2) },
+      { range: { from: 7, to: 9 }, op: deleteAt(5, 6) },
+    ];
+    for (const { range, op } of cases) {
+      const mapped = mapSelectionThroughOperation(range, op);
+      expect(mapped.from).toBeLessThanOrEqual(mapped.to);
+    }
+  });
+
+  it("normalises a reversed input range (from > to) into from <= to", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 9, to: 3 }, insertAt(5, 2)),
+    ).toEqual({ from: 3, to: 11 });
+  });
+});

--- a/packages/awareness/src/mapping/map-selection.test.ts
+++ b/packages/awareness/src/mapping/map-selection.test.ts
@@ -53,6 +53,24 @@ describe("mapSelectionThroughOperation: insert", () => {
       to: 7,
     });
   });
+
+  it("keeps the trailing boundary put when insert lands exactly at `to`", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 1, to: 3 }, insertAt(3, 2)),
+    ).toEqual({ from: 1, to: 3 });
+  });
+
+  it("still advances the trailing boundary for inserts strictly inside the selection", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 1, to: 5 }, insertAt(3, 2)),
+    ).toEqual({ from: 1, to: 7 });
+  });
+
+  it("shifts a non-collapsed selection right when insert lands at `from`", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 3, to: 5 }, insertAt(3, 2)),
+    ).toEqual({ from: 5, to: 7 });
+  });
 });
 
 describe("mapSelectionThroughOperation: delete", () => {

--- a/packages/awareness/src/mapping/map-selection.test.ts
+++ b/packages/awareness/src/mapping/map-selection.test.ts
@@ -148,4 +148,15 @@ describe("mapSelectionThroughOperation: invariants", () => {
       mapSelectionThroughOperation({ from: 9, to: 3 }, insertAt(5, 2)),
     ).toEqual({ from: 3, to: 11 });
   });
+
+  it("maps equivalent forward and reversed ranges identically at insert boundaries", () => {
+    const operation = insertAt(5, 2);
+
+    expect(mapSelectionThroughOperation({ from: 3, to: 5 }, operation)).toEqual(
+      { from: 3, to: 5 },
+    );
+    expect(mapSelectionThroughOperation({ from: 5, to: 3 }, operation)).toEqual(
+      { from: 3, to: 5 },
+    );
+  });
 });

--- a/packages/awareness/src/mapping/map-selection.ts
+++ b/packages/awareness/src/mapping/map-selection.ts
@@ -31,16 +31,20 @@ export const mapSelectionThroughOperation = (
   range: PositionRange,
   operation: PositionOperation,
 ): PositionRange => {
-  const from = mapCursorThroughOperation(range.from, operation);
+  const low = Math.min(range.from, range.to);
+  const high = Math.max(range.from, range.to);
 
-  const useLeftBiasOnTo =
-    operation.type === POSITION_OPERATION_TYPE.Insert &&
-    range.from !== range.to;
-  const to = useLeftBiasOnTo
-    ? range.to <= operation.index
-      ? range.to
-      : range.to + operation.length
-    : mapCursorThroughOperation(range.to, operation);
+  const mappedLow = mapCursorThroughOperation(low, operation);
 
-  return from <= to ? { from, to } : { from: to, to: from };
+  const useLeftBiasOnHigh =
+    operation.type === POSITION_OPERATION_TYPE.Insert && low !== high;
+  const mappedHigh = useLeftBiasOnHigh
+    ? high <= operation.index
+      ? high
+      : high + operation.length
+    : mapCursorThroughOperation(high, operation);
+
+  return mappedLow <= mappedHigh
+    ? { from: mappedLow, to: mappedHigh }
+    : { from: mappedHigh, to: mappedLow };
 };

--- a/packages/awareness/src/mapping/map-selection.ts
+++ b/packages/awareness/src/mapping/map-selection.ts
@@ -1,0 +1,18 @@
+import { mapCursorThroughOperation } from "./map-cursor";
+import type { PositionOperation, PositionRange } from "./position-operation";
+
+/**
+ * Map a selection range through a single insert or delete operation.
+ *
+ * Both endpoints are mapped independently with `mapCursorThroughOperation`,
+ * then re-ordered so the returned range satisfies `from <= to`. A selection
+ * fully inside a deletion collapses to a point at `op.index`.
+ */
+export const mapSelectionThroughOperation = (
+  range: PositionRange,
+  operation: PositionOperation,
+): PositionRange => {
+  const a = mapCursorThroughOperation(range.from, operation);
+  const b = mapCursorThroughOperation(range.to, operation);
+  return a <= b ? { from: a, to: b } : { from: b, to: a };
+};

--- a/packages/awareness/src/mapping/map-selection.ts
+++ b/packages/awareness/src/mapping/map-selection.ts
@@ -1,18 +1,46 @@
 import { mapCursorThroughOperation } from "./map-cursor";
-import type { PositionOperation, PositionRange } from "./position-operation";
+import {
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+  type PositionRange,
+} from "./position-operation";
 
 /**
  * Map a selection range through a single insert or delete operation.
  *
- * Both endpoints are mapped independently with `mapCursorThroughOperation`,
- * then re-ordered so the returned range satisfies `from <= to`. A selection
- * fully inside a deletion collapses to a point at `op.index`.
+ * Selections are treated as half-open `[from, to)`. To prevent an insert at
+ * the trailing boundary from swallowing the new text into the selection,
+ * boundary biases are asymmetric for inserts on non-collapsed selections:
+ *
+ * - `from` is right-biased (matches `mapCursorThroughOperation`): an insert
+ *   at `from` shifts the leading boundary past the new text.
+ * - `to` is left-biased for non-collapsed inserts: an insert exactly at `to`
+ *   keeps the trailing boundary put so the new text lands outside the
+ *   selection. For inserts strictly inside the range, `to` still advances.
+ * - Collapsed selections (`from === to`) keep symmetric right-bias on both
+ *   endpoints so a point cursor doesn't expand into a non-empty selection.
+ *
+ * Delete operations route both endpoints through
+ * `mapCursorThroughOperation`; a selection fully inside a deletion collapses
+ * to `op.index`.
+ *
+ * The returned range is normalised so `from <= to`. Callers tracking
+ * anchor/head orientation should re-derive it from the input endpoints.
  */
 export const mapSelectionThroughOperation = (
   range: PositionRange,
   operation: PositionOperation,
 ): PositionRange => {
-  const a = mapCursorThroughOperation(range.from, operation);
-  const b = mapCursorThroughOperation(range.to, operation);
-  return a <= b ? { from: a, to: b } : { from: b, to: a };
+  const from = mapCursorThroughOperation(range.from, operation);
+
+  const useLeftBiasOnTo =
+    operation.type === POSITION_OPERATION_TYPE.Insert &&
+    range.from !== range.to;
+  const to = useLeftBiasOnTo
+    ? range.to <= operation.index
+      ? range.to
+      : range.to + operation.length
+    : mapCursorThroughOperation(range.to, operation);
+
+  return from <= to ? { from, to } : { from: to, to: from };
 };

--- a/packages/awareness/src/mapping/position-operation.ts
+++ b/packages/awareness/src/mapping/position-operation.ts
@@ -1,0 +1,35 @@
+/**
+ * Editor-agnostic operation shapes over an index-based 1D sequence.
+ *
+ * These types describe a position change without taking a dependency on any
+ * specific editor model (plain text, rich text linearised, block editor,
+ * canvas, node-based, IDE-like). Callers using a different unit (graphemes,
+ * UTF-32 code points) provide indices and lengths in that same unit.
+ */
+
+export const POSITION_OPERATION_TYPE = {
+  Insert: "insert",
+  Delete: "delete",
+} as const;
+
+export type PositionOperationType =
+  (typeof POSITION_OPERATION_TYPE)[keyof typeof POSITION_OPERATION_TYPE];
+
+export type InsertOperation = {
+  readonly type: typeof POSITION_OPERATION_TYPE.Insert;
+  readonly index: number;
+  readonly length: number;
+};
+
+export type DeleteOperation = {
+  readonly type: typeof POSITION_OPERATION_TYPE.Delete;
+  readonly index: number;
+  readonly length: number;
+};
+
+export type PositionOperation = InsertOperation | DeleteOperation;
+
+export type PositionRange = {
+  readonly from: number;
+  readonly to: number;
+};

--- a/packages/awareness/src/mapping/text-diff.test.ts
+++ b/packages/awareness/src/mapping/text-diff.test.ts
@@ -90,4 +90,20 @@ describe("findDifferingRange", () => {
   it("finds the outermost bounds when changes wrap around shared interior", () => {
     expect(findDifferingRange("abcde", "xbcdz")).toEqual({ start: 0, end: 4 });
   });
+
+  it("returns end < start when newText only appends to oldText", () => {
+    const result = findDifferingRange("abc", "abcdef");
+    expect(result.end).toBeLessThan(result.start);
+  });
+
+  it("reports a suffix deletion in oldText correctly", () => {
+    expect(findDifferingRange("abcdef", "abc")).toEqual({ start: 3, end: 5 });
+  });
+
+  it("aligns the backward scan to each string's own length", () => {
+    expect(findDifferingRange("abcde", "abXYZde")).toEqual({
+      start: 2,
+      end: 2,
+    });
+  });
 });

--- a/packages/awareness/src/mapping/text-diff.test.ts
+++ b/packages/awareness/src/mapping/text-diff.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  findDeletePosition,
+  findDifferingRange,
+  findInsertPosition,
+} from "./text-diff";
+
+describe("findInsertPosition", () => {
+  it("returns 0 when text is inserted at the start", () => {
+    expect(findInsertPosition("world", "hello world")).toBe(0);
+  });
+
+  it("finds an insert in the middle", () => {
+    expect(findInsertPosition("helloworld", "hello world")).toBe(5);
+  });
+
+  it("returns oldText.length when the insert is at the end", () => {
+    expect(findInsertPosition("hello", "hello world")).toBe(5);
+  });
+
+  it("handles inserting into an empty string", () => {
+    expect(findInsertPosition("", "abc")).toBe(0);
+  });
+
+  it("handles single-character inserts", () => {
+    expect(findInsertPosition("ac", "abc")).toBe(1);
+  });
+});
+
+describe("findDeletePosition", () => {
+  it("returns 0 when text is deleted from the start", () => {
+    expect(findDeletePosition("hello world", "world")).toBe(0);
+  });
+
+  it("finds a delete in the middle", () => {
+    expect(findDeletePosition("hello world", "helloworld")).toBe(5);
+  });
+
+  it("returns newText.length when the delete is at the end", () => {
+    expect(findDeletePosition("hello world", "hello")).toBe(5);
+  });
+
+  it("handles deleting to empty", () => {
+    expect(findDeletePosition("abc", "")).toBe(0);
+  });
+
+  it("handles single-character deletes", () => {
+    expect(findDeletePosition("abc", "ac")).toBe(1);
+  });
+});
+
+describe("findDifferingRange", () => {
+  it("identifies a replaced span in the middle", () => {
+    expect(findDifferingRange("hello world", "hello WORLD")).toEqual({
+      start: 6,
+      end: 10,
+    });
+  });
+
+  it("identifies a replacement at the start", () => {
+    expect(findDifferingRange("hello world", "HELLO world")).toEqual({
+      start: 0,
+      end: 4,
+    });
+  });
+
+  it("identifies a replacement at the end", () => {
+    expect(findDifferingRange("hello world", "hello WORLD")).toEqual({
+      start: 6,
+      end: 10,
+    });
+  });
+
+  it("returns end < start when strings are equal", () => {
+    const result = findDifferingRange("abc", "abc");
+    expect(result.end).toBeLessThan(result.start);
+  });
+
+  it("works for a single-character replacement", () => {
+    expect(findDifferingRange("cat", "bat")).toEqual({ start: 0, end: 0 });
+  });
+
+  it("works for a multi-character middle replacement", () => {
+    expect(findDifferingRange("abcdef", "abXYef")).toEqual({
+      start: 2,
+      end: 3,
+    });
+  });
+
+  it("finds the outermost bounds when changes wrap around shared interior", () => {
+    expect(findDifferingRange("abcde", "xbcdz")).toEqual({ start: 0, end: 4 });
+  });
+});

--- a/packages/awareness/src/mapping/text-diff.ts
+++ b/packages/awareness/src/mapping/text-diff.ts
@@ -1,0 +1,52 @@
+/**
+ * Best-effort diff fallback for callers that only have before/after strings
+ * rather than an explicit `PositionOperation`. These helpers infer where a
+ * single insert or delete happened by scanning from the start.
+ *
+ * They are not a full diff — they assume exactly one edit happened between
+ * `oldText` and `newText` and bail out at the first divergence.
+ */
+
+export const findInsertPosition = (
+  oldText: string,
+  newText: string,
+): number => {
+  const min = Math.min(oldText.length, newText.length);
+  for (let i = 0; i < min; i++) {
+    if (oldText[i] !== newText[i]) {
+      return i;
+    }
+  }
+  return oldText.length;
+};
+
+export const findDeletePosition = (
+  oldText: string,
+  newText: string,
+): number => {
+  const min = Math.min(oldText.length, newText.length);
+  for (let i = 0; i < min; i++) {
+    if (oldText[i] !== newText[i]) {
+      return i;
+    }
+  }
+  return newText.length;
+};
+
+export const findDifferingRange = (
+  oldText: string,
+  newText: string,
+): { start: number; end: number } => {
+  let start = 0;
+  let end = oldText.length - 1;
+
+  while (start < oldText.length && oldText[start] === newText[start]) {
+    start++;
+  }
+
+  while (end >= start && oldText[end] === newText[end]) {
+    end--;
+  }
+
+  return { start, end };
+};

--- a/packages/awareness/src/mapping/text-diff.ts
+++ b/packages/awareness/src/mapping/text-diff.ts
@@ -38,15 +38,24 @@ export const findDifferingRange = (
   newText: string,
 ): { start: number; end: number } => {
   let start = 0;
-  let end = oldText.length - 1;
+  let endOld = oldText.length - 1;
+  let endNew = newText.length - 1;
 
   while (start < oldText.length && oldText[start] === newText[start]) {
     start++;
   }
 
-  while (end >= start && oldText[end] === newText[end]) {
-    end--;
+  // Track separate end pointers so a different-length newText doesn't drag
+  // oldText's end pointer past a real divergence (e.g. shared "de" suffix
+  // in "abcde" / "abXYZde" lives at different indices in each string).
+  while (
+    endOld >= start &&
+    endNew >= start &&
+    oldText[endOld] === newText[endNew]
+  ) {
+    endOld--;
+    endNew--;
   }
 
-  return { start, end };
+  return { start, end: endOld };
 };

--- a/packages/awareness/vite.config.ts
+++ b/packages/awareness/vite.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
           __dirname,
           "src/utils/textarea-rects.ts",
         ),
+        "mapping/index": path.resolve(__dirname, "src/mapping/index.ts"),
         "testing/index": path.resolve(__dirname, "src/testing/index.ts"),
         "hooks/index": path.resolve(__dirname, "src/hooks/index.ts"),
         "adapters/index": path.resolve(__dirname, "src/adapters/index.ts"),


### PR DESCRIPTION
## Summary

- Introduces `@softmaple/awareness/mapping` with `mapCursorThroughOperation` and `mapSelectionThroughOperation` over a generic `PositionOperation` discriminated union (insert/delete with `index`/`length`). No imports from eg-walker, Lexical, ProseMirror, or Slate — the API is usable for plain text, rich text, block, canvas, and node-based editors.
- Moves the playground's `findInsertPosition` / `findDeletePosition` / `findDifferingRange` into the same `mapping/` folder as a diff fallback for callers that only have before/after strings.
- `apps/playground/src/lib/text-diff.ts` becomes a re-export shim so existing `@/lib/text-diff` imports (3 source files + 2 test files) keep working unchanged.
- Closes https://github.com/softmaple/softmaple/issues/724

## Test plan

- [x] `pnpm --filter @softmaple/awareness typecheck`
- [x] `pnpm --filter @softmaple/awareness build` — emits `dist/mapping/index.js`; `validate-exports.mjs` passes
- [x] `pnpm --filter @softmaple/awareness test --run` — 385/385 pass (41 new mapping tests)
- [x] `pnpm --filter @softmaple/awareness test:coverage --run` — 97.18 lines / 90.43 branches / 99.68 functions / 98.89 statements (all above the 90% thresholds)
- [x] `biome check src/` clean in awareness
- [x] `pnpm --filter @softmaple/playground typecheck`
- [x] `pnpm --filter @softmaple/playground test --run` — 42/42 pass, including the 17-test `src/test/lib/text-diff.test.ts` that now exercises the shim


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added utilities for mapping text positions through insert and delete operations.
  * Introduced text diff capabilities to identify changes in content.
  * Expanded the awareness package with mapping functionality for managing editor position and content changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->