### PR TITLE
test(packages/eg-walker): add fast-check property-test suite

### DIFF
--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: javascript-testing-expert
+description: Expert-level JavaScript testing skill focused on writing high-quality tests that find bugs, serve as documentation, and prevent regressions. Advocates for property-based testing with fast-check and protects against indeterministic code in tests. Does not cover black-box e2e testing.
+---
+
+> **⚠️ Scope:** Testing functions and components, not black-box e2e.
+
+**🏅 Main objectives:** use tests as a way to...
+
+1. uncover hard to detect bugs
+2. document how to use the code
+3. avoid regressions
+4. challenge the code
+
+**🔧 Recommended tooling:** `vitest`, `fast-check`, `@fast-check/vitest`, `@testing-library/*`, `@vitest/browser-playwright`, `msw` installed as devDependencies.  
+**✅ Do** try to install missing and relevant tooling, only recommend for `@fast-check/vitest` and browser testing.  
+**✅ Do** highly recommend user to install missing and relevant tooling.  
+**✅ Do** adapt yourself to missing tools.
+
+## File and code layout
+
+**✅ Do** mimic the existing test structure of the project when adding new tests
+
+**✅ Do** use one test file per code file
+
+**👍 Prefer** using `.spec.ts` extension (e.g., `fileName.ts` → `fileName.spec.ts`) and colocated with the source file if no existing test structure is present
+
+**✅ Do** put `it` within `describe`, when using `it`
+
+**👍 Prefer** `it` over `test`
+
+**✅ Do** name the `describe` with the name of the function being tested
+
+**✅ Do** use a dedicated `describe` for each function being tested
+
+**✅ Do** start naming `it` with "should" and considers that the name should be clear, as consise as possible and could be read as a sentence implicitly prefixed by "it"
+
+**✅ Do** start with simple and documenting tests
+
+**✅ Do** continue with advanced tests looking for edge-cases
+
+**❌ Don't** delimitate explicitely simple from advanced tests, just but them in the right order
+
+**✅ Do** put helper functions specific to the file after all the `describe`s just below a comment `// Helpers` stating the beginning of the helpers tailored for this file
+
+## Core guidelines
+
+**✅ Do** follow the AAA pattern and make it visible in the test
+
+```ts
+it('should...', () => {
+  // Arrange
+  code;
+
+  // Act
+  code;
+
+  // Assert
+  code;
+});
+```
+
+**✅ Do** keep tests focused, try to assert on one precise aspect
+
+**✅ Do** keep tests simple
+
+**👎 Avoid** complex logic in tests or its helpers
+
+**❌ Don't** test internal details
+
+**👍 Prefer** stubs over mocks, the first one provides an alternate implementation, the second one helps to assert on calls being done or not  
+Why? Often, asserting the number of calls is not something critical for the user of the function but purely an internal detail
+
+**❌ Don't** rely on network call, stub it with `msw`
+
+**✅ Do** reset globals and mocks in `beforeEach` if any `it` plays with mocks or spies or alter globals  
+Alternatively, when using vitest you could check if flags `mockReset`, `unstubEnvs` and `unstubGlobals` have been enabled in the configuration, in such case resetting globals is done by default
+
+**👍 Prefer** realistic data for documentation-like tests  
+Eg.: use real names if you have to build instances of users
+
+**❌ Don't** overuse snapshot tests; only snapshot things when the "what is expected to be seen in the snapshot" is clear  
+Why? Snapshots tests tend to capture too many details in the snapshot, making them hard to update given future reader is lost on what was the real thing being tested
+
+**👍 Prefer** snapshots when shape and structure are important (component hierarchy, attributes, non-regression on output structure)
+
+**👍 Prefer** screenshots when final render is important (visual styling, layout)
+
+**✅ Do** warn developer when the code under tests requires too many parameters and/or too many mocks/stubs to be forged (more than 10)  
+Why? Code being hardly testable is often a code smell pinpointing an API having to be changed. Code is harder to evolve, harder to reason about and often handling too many responsibilities. Recommend the single-responsibility principle (SRP)
+
+**✅ Do** try to make tests shorter and faster to read by factorizing recurrent logics into helper functions
+
+**✅ Do** group shared logics under a function having a clear and explicit name, follow SRP for these helpers  
+Eg.: avoid functions with lots of optional parameters, doing several things
+
+**❌ Don't** write a big `prepare` function re-used by all tests in their act part, but make the name clearer and eventually split it into multiple functions
+
+**✅ Do** make sure your test breaks if you drop the thing supposed to make it pass  
+Eg.: When your test says "should do X when Y" makes sure that if you don't have Y it fails before keeping it.
+
+**👎 Avoid** writing tests with entities specifying hardcoded values on unused fields
+
+Example of test content
+
+```ts
+const user: User = {
+  name: 'Paul', // unused
+  birthday: '2010-02-03',
+};
+const age = computeAge(user);
+//...
+```
+
+**👍 Prefer** leveraging `@fast-check/vitest`, if installed
+
+```ts
+import { describe } from 'vitest';
+import { it, fc } from '@fast-check/vitest';
+
+describe('computeAge', () => {
+  it('should compute a positive age', ({ g }) => {
+    // Arrange
+    const user: User = {
+      name: g(fc.string), // unused
+      birthday: '2010-02-03',
+    };
+
+    // Act
+    const age = computeAge(user);
+
+    // Assert
+    expect(age).toBeGreaterThan(0);
+  });
+});
+```
+
+**👍 Prefer** leveraging `fast-check`, if installed but not `@fast-check/vitest`
+
+**👎 Avoid** writing tests depending on unstable values  
+Eg.: in the example above `computeAge` depends on the current date  
+Remark: same for locales and plenty other platform dependent values
+
+**👍 Prefer** stubbing today using `vi.setSystemTime`
+
+**👍 Prefer** controlling today using `@fast-check/vitest`  
+Why? Contrary to `vi.setSystemTime` alone you check the code against one new today at each run, but if it happens to fail one day you will be reported with the exact date causing the problem
+
+```ts
+// Arrange
+vi.setSystemTime(g(fc.date, { min: new Date('2010-02-04'), noInvalidDate: true }));
+const user: User = {
+  name: g(fc.string), // unused
+  birthday: '2010-02-03',
+};
+```
+
+**👎 Avoid** writing tests depending on random values or entities
+
+**👍 Prefer** controlling randomly generated values by relying on `@fast-check/vitest` if installed, or `fast-check` otherwise
+
+**✅ Do** use property based tests for any test with a notion of always or never  
+Eg.: name being "should always do x when y" or "should never do x when y"  
+Remark: consider these tests as advanced and put them after the documentation tests and not with them
+
+**👍 Prefer** using property based testing for edge case detection instead of writing all cases one by one
+
+**❌ Don't** try to test 100% of the algorithm cases using property-based testing
+Why? Property-based testing and example-based testing are complementary. Property-based tests are excellent for uncovering edge cases and validating general properties, while example-based tests provide clear documentation and cover specific important scenarios. Use both approaches together for comprehensive test coverage.
+
+```ts
+// for all a, b, c strings
+// b is a substring of a + b + c
+it.prop([fc.string(), fc.string(), fc.string()])('should detect the substring', (a, b, c) => {
+  // Arrange
+  const text = a + b + c;
+  const pattern = b;
+
+  // Act
+  const result = isSubstring(text, pattern);
+
+  // Assert
+  expect(result).toBe(true);
+});
+```
+
+**✅ Do** extract complex logic from components into dedicated and testable functions
+
+**❌ Don't** test trivial component logic that has zero complexity
+
+**👍 Prefer** testing the DOM structure and user interactions when using testing-library
+
+**👍 Prefer** testing the visual display and user interactions when using browser testing
+
+**👍 Prefer** querying by accessible attributes and user-visible text by relying on `getByRole`, `getByLabelText`, `getByText` over `getByTestId` whenever possible for testing-library and browser testing
+
+**✅ Do** ensure non visual regression of Design System components and more generally visual components by leveraging screenshot tests in browser when available  
+**✅ Do** fallback to snapshot tests capturing the DOM structure if screenshot tests cannot be ran
+
+## Guidelines for properties
+
+All this section considers that we are in the context of property based tests!
+
+**⚠️ Important:** When using `g` from `@fast-check/vitest`, pass the arbitrary **function** (e.g., `fc.string`, `fc.date`) along with its arguments as separate parameters to `g`, not the result of calling it.  
+Correct: `g(fc.string)`, `g(fc.date, { min: new Date('2010-01-01') })`  
+Incorrect: `g(fc.string())`, `g(fc.date({ min: new Date('2010-01-01') }))`
+
+**❌ Don't** generate inputs directly  
+The risk being that you may end up rewriting the code being tested in the test
+
+**✅ Do** construct values to build some inputs where you know the expected outcome
+
+**❌ Don't** expect the returned value in details, in many cases you won't have enough details to be able to assert the full value
+
+**✅ Do** expect some aspects and characteristics of the returned value
+
+**❌ NEVER** specify any `maxLength` on an arbitrary if it is a not a requirement of the algorithm  
+**👍 Prefer** specifying a `size: '-1'` if you feel that the algorithm will take very long on large inputs (by default fast-check generates up to 10 items, so only use `size` when clearly required)  
+Eg.: No `fc.string({maxLength: 5})` or `fc.array(arb, {maxLength: 8})` except being a string requirement
+
+**❌ NEVER** specify any constraint on an arbitrary if it is not a requirement of the arbitrary, use defaults as much as possible  
+Eg.: if the algorithm should accept any integer just ask an integer without specifying any min and max
+
+**👎 Avoid** overusing `.filter` and `fc.pre`  
+Why? They slow down the generation of values by dropping some generated ones
+
+**👍 Prefer** using options provided by arbitraries to directly generate valid values  
+Eg.: use `fc.string({ minLength: 2 })` instead of `fc.string().filter(s => s.length >= 2)`  
+Eg.: use `fc.integer({ min: 1 })` instead of `fc.integer().filter(n => n >= 1)`, or use `fc.nat()` instead of `fc.integer().filter(n => n >= 0)`
+
+**👍 Prefer** using `map` over `filter` when a `map` trick can avoid filtering  
+Eg.: use `fc.nat().map(n => n * 2)` for even numbers  
+Eg.: use `fc.tuple(fc.string(), fc.string()).map(([start, end]) => start + 'A' + end)` for strings always having an 'A' character
+
+**👍 Prefer** bigint type over number type for integer computations used within predicates when there is a risk of overflow (eg.: when running pow, multiply.. on generated values)
+
+Some classical properties:
+
+1. Characteristics independent of the inputs. _Eg.: for any floating point number d, Math.floor(d) is an integer. for any integer n, Math.abs(n) ≥ 0_
+2. Characteristics derived from the inputs. _Eg.: for any a and b integers, the average of a and b is between a and b. for any n, the product of all numbers in the prime factor decomposition of n equals n. for any array of data, sorted(data) and data contains the same elements. for any n1, n2 integers such that n1 != n2, romanString(n1) != romanString(n2). for any floating point number d, Math.floor(d) is an integer such as d-1 ≤ Math.floor(d) ≤ d_
+3. Restricted set of inputs with useful characteristics. _Eg.: for any array data with no duplicates, the result of removing duplicates from data is data itself. for any a, b and c strings, the concatenation of a, b and c always contains b. for any prime number p, its decomposition into prime factors is itself_
+4. Characteristics on combination of functions. _Eg.: zipping then unzipping a file should result in the original file. lcm(a,b) times gcd(a,b) must be equal to a times b_
+5. Comparison with a simpler implementation. _Eg.: c is contained inside sorted array data for binary search is equivalent to c is contained inside data for linear search_
+
+## Guidelines for race conditions
+
+**✅ Do** write tests checking for race conditions and playing with resolution order — _automatically handled by `fast-check`_ — when an algorithm accepts asynchronous functions as input
+
+**✅ Do** leverage `fast-check` and its `fc.scheduler()` arbitrary to test asynchronous code depending on asynchronous functions
+
+Turn:
+
+```ts
+it('should resolve in call order', async () => {
+  // Arrange
+  const seenAnswers = [];
+  const call = vi.fn().mockImplementation((v) => Promise.resolve(v));
+
+  // Act
+  const queued = queue(call);
+  await Promise.all([queued(1).then((v) => seenAnswers.push(v)), queued(2).then((v) => seenAnswers.push(v))]);
+
+  // Assert
+  expect(seenAnswers).toEqual([1, 2]);
+});
+```
+
+Into:
+
+```ts
+it('should resolve in call order', async () => {
+  await fc.assert(
+    fc.asyncProperty(fc.scheduler(), async (s) => {
+      // Arrange
+      const seenAnswers = [];
+      const call = vi.fn().mockImplementation((v) => Promise.resolve(v));
+
+      // Act
+      const queued = queue(s.scheduleFunction(call));
+      await s.waitFor(
+        Promise.all([queued(1).then((v) => seenAnswers.push(v)), queued(2).then((v) => seenAnswers.push(v))]),
+      );
+
+      // Assert
+      expect(seenAnswers).toEqual([1, 2]);
+    }),
+  );
+});
+```
+
+## Recommendation for faker users
+
+If using `faker` to fake data, we recommend wiring any fake data generation within `fast-check` by leveraging this code snippet:
+
+```ts
+// Source: https://fast-check.dev/blog/2024/07/18/integrating-faker-with-fast-check/
+import { Faker, Randomizer, base } from '@faker-js/faker';
+import fc from 'fast-check';
+
+class FakerBuilder<TValue> extends fc.Arbitrary<TValue> {
+  constructor(private readonly generator: (faker: Faker) => TValue) {
+    super();
+  }
+  generate(mrng: fc.Random, biasFactor: number | undefined): fc.Value<TValue> {
+    const randomizer: Randomizer = {
+      next: (): number => mrng.nextDouble(),
+      seed: () => {}, // no-op, no support for updates of the seed, could even throw
+    };
+    const customFaker = new Faker({ locale: base, randomizer });
+    return new fc.Value(this.generator(customFaker), undefined);
+  }
+  canShrinkWithoutContext(value: unknown): value is TValue {
+    return false;
+  }
+  shrink(value: TValue, context: unknown): fc.Stream<fc.Value<TValue>> {
+    return fc.Stream.nil();
+  }
+}
+
+function fakerToArb<TValue>(generator: (faker: Faker) => TValue): fc.Arbitrary<TValue> {
+  return new FakerBuilder(generator);
+}
+```
+
+Example of usage
+
+```ts
+fc.assert(
+  fc.property(
+    fakerToArb((faker) => faker.person.firstName),
+    fakerToArb((faker) => faker.person.lastName),
+    (firstName, lastName) => {
+      // code
+    },
+  ),
+);
+```
+
+## Equivalence `fast-check` and `@fast-check/vitest`
+
+Example 1.
+
+```ts
+// with @fast-check/vitest
+import { it, fc } from '@fast-check/vitest';
+it('...', ({ g }) => {
+  //...
+});
+
+// with fast-check
+import { it } from 'vitest';
+import fc from 'fast-check';
+it('...', () => {
+  fc.assert(
+    fc.property(fc.gen(), (g) => {
+      //...
+    }),
+  );
+});
+```
+
+Example 2.
+
+```ts
+// with @fast-check/vitest
+import { it, fc } from '@fast-check/vitest';
+it.prop([...arbitraries])('...', (...values) => {
+  //...
+});
+
+// with fast-check
+import { it } from 'vitest';
+import fc from 'fast-check';
+it('...', () => {
+  fc.assert(
+    fc.property(...arbitraries, (...values) => {
+      //...
+    }),
+  );
+});
+```
+
+Example 3. If the predicate of `it` or `it.prop` is asynchronous, when using only `fast-check` the property has to be instantiated via `asyncProperty` and `assert` has to be awaited.
+
+```ts
+// with @fast-check/vitest
+import { it, fc } from '@fast-check/vitest';
+it.prop([...arbitraries])('...', async (...values) => {
+  //...
+});
+
+// with fast-check
+import { it } from 'vitest';
+import fc from 'fast-check';
+it('...', async () => {
+  await fc.assert(
+    fc.asyncProperty(...arbitraries, async (...values) => {
+      //...
+    }),
+  );
+});
+```

--- a/.claude/skills/javascript-testing-expert
+++ b/.claude/skills/javascript-testing-expert
@@ -1,0 +1,1 @@
+../../.agents/skills/javascript-testing-expert

--- a/packages/eg-walker/package.json
+++ b/packages/eg-walker/package.json
@@ -37,10 +37,12 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@fast-check/vitest": "^0.4.1",
     "@softmaple/eslint-config": "workspace:*",
     "@softmaple/typescript-config": "workspace:*",
     "@types/node": "^24.10.4",
     "@vitest/coverage-v8": "^4.0.16",
+    "fast-check": "^4.8.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.16"

--- a/packages/eg-walker/src/test/property/README.md
+++ b/packages/eg-walker/src/test/property/README.md
@@ -1,0 +1,68 @@
+# eg-walker property tests
+
+`fast-check`-driven property tests for `@softmaple/eg-walker`. Each file
+in this directory pins one invariant of the engine and exercises it
+against shrunk inputs, so a failing case reduces to a minimal
+script + delivery permutation instead of an opaque seed.
+
+## Run count
+
+Every property uses a shared run-count knob defined in
+[`run-config.ts`](./run-config.ts). The default is **100 runs per
+property** (the acceptance criterion on softmaple/softmaple issue
+#722). Override it from the shell:
+
+```bash
+# Default — 100 runs per property.
+pnpm --filter @softmaple/eg-walker test
+
+# Cheap smoke run — 10 runs per property. Useful when iterating.
+EG_WALKER_PROPERTY_RUNS=10 pnpm --filter @softmaple/eg-walker test -- --run src/test/property
+
+# Recommended pre-release sweep — 500 runs per property.
+EG_WALKER_PROPERTY_RUNS=500 pnpm --filter @softmaple/eg-walker test
+```
+
+The variable is declared on the turbo `test` task in `turbo.json`, so
+`turbo/no-undeclared-env-vars` is satisfied and the cache key picks it
+up automatically.
+
+## Layout
+
+| File | Property |
+| --- | --- |
+| [`convergence.property.test.ts`](./convergence.property.test.ts) | Every shuffled delivery order of a trace matches the canonical replay text. |
+| [`delivery-order-invariance.property.test.ts`](./delivery-order-invariance.property.test.ts) | For a *fixed* event set, every permutation lands on the canonical text. |
+| [`duplicate-event-idempotency.property.test.ts`](./duplicate-event-idempotency.property.test.ts) | Re-applying every event leaves replica state unchanged. |
+| [`missing-parent-buffering.property.test.ts`](./missing-parent-buffering.property.test.ts) | Events delivered before their parents are buffered and flushed to the canonical text. |
+| [`serialize-roundtrip.property.test.ts`](./serialize-roundtrip.property.test.ts) | JSON `serialize`/`deserialize` and columnar `encodeBinary`/`decodeBinary` preserve text and frontier. |
+| [`unicode-surrogate.property.test.ts`](./unicode-surrogate.property.test.ts) | Surrogate-biased traces stay well-formed UTF-16 and converge under random delivery. |
+
+## Shared helpers
+
+| File | Purpose |
+| --- | --- |
+| [`arbitraries.ts`](./arbitraries.ts) | Shared `fast-check` arbitraries (replica ids, BMP/surrogate-biased text, edit instructions, multi-replica `TraceParams`, explicit DAGs). |
+| [`trace-runner.ts`](./trace-runner.ts) | Drives a fleet of `EgWalkerReplica` instances through a `TraceParams` script, returns the deduplicated event list, canonical replay text, per-replica final text, and the applied-edit count. |
+| [`run-config.ts`](./run-config.ts) | Centralises the `numRuns` knob and the `EG_WALKER_PROPERTY_RUNS` override. |
+| [`utf16.ts`](./utf16.ts) | UTF-16 well-formedness predicate for the surrogate test. |
+
+## Adding a new property test
+
+1. Add a new `*.property.test.ts` file in this directory — one property
+   per file so a failing run is easy to attribute. The filename should
+   describe the invariant (e.g. `causal-consistency.property.test.ts`).
+2. Compose existing arbitraries from `arbitraries.ts` where possible.
+   New shared generators (used by ≥ 2 properties) belong there too;
+   one-off generators can stay in the test file.
+3. Call `runTrace(params)` from `trace-runner.ts` whenever you need a
+   realistic multi-replica event set. The runner is deterministic in
+   its inputs, so a shrunk `TraceParams` is enough to reproduce a
+   failure outside fast-check.
+4. Pass `fcParams()` (from `run-config.ts`) as the second argument to
+   `fc.assert` so your test respects the
+   `EG_WALKER_PROPERTY_RUNS` override.
+5. Guard against trivially empty traces with
+   `fc.pre(trace.appliedEdits > 0)` rather than `if (...) return;` so
+   skipped iterations don't silently inflate the reported `numRuns`
+   and so fast-check's shrinker stays honest.

--- a/packages/eg-walker/src/test/property/README.md
+++ b/packages/eg-walker/src/test/property/README.md
@@ -10,14 +10,14 @@ script + delivery permutation instead of an opaque seed.
 Every property uses a shared run-count knob defined in
 [`run-config.ts`](./run-config.ts). The default is **100 runs per
 property** (the acceptance criterion on softmaple/softmaple issue
-#722). Override it from the shell:
+`#722`). Override it from the shell:
 
 ```bash
 # Default — 100 runs per property.
 pnpm --filter @softmaple/eg-walker test
 
 # Cheap smoke run — 10 runs per property. Useful when iterating.
-EG_WALKER_PROPERTY_RUNS=10 pnpm --filter @softmaple/eg-walker test -- --run src/test/property
+EG_WALKER_PROPERTY_RUNS=10 pnpm --filter @softmaple/eg-walker test --run src/test/property
 
 # Recommended pre-release sweep — 500 runs per property.
 EG_WALKER_PROPERTY_RUNS=500 pnpm --filter @softmaple/eg-walker test

--- a/packages/eg-walker/src/test/property/arbitraries.ts
+++ b/packages/eg-walker/src/test/property/arbitraries.ts
@@ -202,11 +202,15 @@ export const traceParamsArb = (opts: {
  * Explicit small DAG of `GraphEvent`s, used by tests that need to
  * control delivery order independently of replica-driven scripts.
  *
- * Construction: pick a `size` between `minSize` and `maxSize`; for each
- * index `i`, generate 0–2 parents drawn from indices `< i`. Index 0 is
- * always a root (no parents). Every event is an insert at index 0 with
- * a short BMP string, which keeps the generator simple and the prepare
- * state non-empty for downstream events.
+ * Construction: pick a `size` between `minSize` and `maxSize`. Index 0
+ * is the single root (no parents); every non-root index `i` gets 1–2
+ * parents drawn uniquely from `[0, i - 1]`. The ≥1 lower bound is what
+ * lets `missing-parent-buffering.property.test.ts` assert that a
+ * reverse-order delivery actually exercises the `RemoteEventBuffer`
+ * flushing path — a disconnected DAG would let every event apply
+ * cleanly without ever buffering. Every event is an insert at index 0
+ * with a short BMP string, which keeps the generator simple and the
+ * prepare state non-empty for downstream events.
  */
 export const eventDagArb = (opts: {
   readonly minSize?: number;

--- a/packages/eg-walker/src/test/property/arbitraries.ts
+++ b/packages/eg-walker/src/test/property/arbitraries.ts
@@ -1,0 +1,255 @@
+/**
+ * Shared `fast-check` arbitraries for the property-test suite.
+ *
+ * Layout:
+ *
+ *   - `replicaIdArb`       — small pool so traces have realistic concurrent
+ *                            branching across a handful of authors.
+ *   - `bmpTextArb`         — ASCII-biased insert text. Avoids surrogate
+ *                            edge cases so unrelated properties are not
+ *                            tripped by Unicode well-formedness checks.
+ *   - `surrogateBiasedTextArb` — emits paired surrogates frequently for
+ *                            the unicode-surrogate property test.
+ *   - `localEditScriptArb` — sequence of insert/delete *instructions*
+ *                            parameterised by offset/length seeds. The
+ *                            trace runner resolves seeds against the
+ *                            replica's live text length so generated
+ *                            scripts always stay in bounds.
+ *   - `traceParamsArb`     — the inputs to the trace runner. Keeping the
+ *                            arbitrary as plain data (not as a generated
+ *                            `GraphEvent[]`) means fast-check shrinks
+ *                            scripts directly instead of opaque events.
+ *   - `eventDagArb`        — explicit small DAGs of `GraphEvent`s for
+ *                            the missing-parent-buffering test.
+ */
+
+import fc from "fast-check";
+
+import { OPERATION_TYPE } from "../../constants/operation-types";
+import type { EventId, GraphEvent } from "../../types";
+
+export const REPLICA_IDS: ReadonlyArray<string> = [
+  "alice",
+  "bob",
+  "carol",
+  "dave",
+];
+
+export const replicaIdArb: fc.Arbitrary<string> = fc.constantFrom(
+  ...REPLICA_IDS,
+);
+
+const SAFE_BMP_CODE_POINT = fc.oneof(
+  { weight: 8, arbitrary: fc.integer({ min: 0x20, max: 0x7e }) },
+  { weight: 1, arbitrary: fc.integer({ min: 0xa1, max: 0xd7ff }) },
+  { weight: 1, arbitrary: fc.integer({ min: 0xe000, max: 0xfffd }) },
+);
+
+const SURROGATE_BIASED_CODE_POINT = fc.oneof(
+  { weight: 3, arbitrary: fc.integer({ min: 0x20, max: 0x7e }) },
+  { weight: 1, arbitrary: fc.integer({ min: 0xa1, max: 0xd7ff }) },
+  { weight: 1, arbitrary: fc.integer({ min: 0xe000, max: 0xfffd }) },
+  // Drives the engine through paired-surrogate inserts/deletes.
+  { weight: 4, arbitrary: fc.integer({ min: 0x10000, max: 0x10ffff }) },
+);
+
+const codePointsToString = (codePoints: ReadonlyArray<number>): string =>
+  codePoints.map((cp) => String.fromCodePoint(cp)).join("");
+
+export const bmpTextArb = (
+  opts: { readonly minLength?: number; readonly maxLength?: number } = {},
+): fc.Arbitrary<string> =>
+  fc
+    .array(SAFE_BMP_CODE_POINT, {
+      minLength: opts.minLength ?? 1,
+      maxLength: opts.maxLength ?? 4,
+    })
+    .map(codePointsToString);
+
+export const surrogateBiasedTextArb = (
+  opts: { readonly minLength?: number; readonly maxLength?: number } = {},
+): fc.Arbitrary<string> =>
+  fc
+    .array(SURROGATE_BIASED_CODE_POINT, {
+      minLength: opts.minLength ?? 1,
+      maxLength: opts.maxLength ?? 3,
+    })
+    .map(codePointsToString);
+
+export const SEED_TEXTS: ReadonlyArray<string> = [
+  "",
+  "the quick brown fox",
+  "Hello, world!",
+  "𝐀𝐁𝐂", // mathematical bold A/B/C — every char is a surrogate pair
+];
+
+/**
+ * One local edit before its position seeds are resolved.
+ *
+ * `offsetSeed` and `lengthSeed` are normalised to `[0, 1)` so they can be
+ * shrunk independently of the document length they will eventually be
+ * mapped onto. The trace runner multiplies them by the replica's live
+ * text length to pick an in-bounds index.
+ */
+export type EditInstruction =
+  | {
+      readonly kind: "insert";
+      readonly offsetSeed: number;
+      readonly text: string;
+    }
+  | {
+      readonly kind: "delete";
+      readonly offsetSeed: number;
+      readonly lengthSeed: number;
+    };
+
+const editInstructionArb = (
+  textArb: fc.Arbitrary<string>,
+  deleteWeight: number,
+): fc.Arbitrary<EditInstruction> =>
+  fc.oneof(
+    {
+      weight: 10 - deleteWeight,
+      arbitrary: fc.record({
+        kind: fc.constant("insert" as const),
+        offsetSeed: fc.double({ min: 0, max: 1, noNaN: true }),
+        text: textArb,
+      }),
+    },
+    {
+      weight: deleteWeight,
+      arbitrary: fc.record({
+        kind: fc.constant("delete" as const),
+        offsetSeed: fc.double({ min: 0, max: 1, noNaN: true }),
+        lengthSeed: fc.double({ min: 0, max: 1, noNaN: true }),
+      }),
+    },
+  );
+
+export const localEditScriptArb = (opts: {
+  readonly minSteps: number;
+  readonly maxSteps: number;
+  readonly textArb: fc.Arbitrary<string>;
+  /** Weight in `[0, 10]` for delete vs insert. Higher = more deletes. */
+  readonly deleteWeight?: number;
+}): fc.Arbitrary<ReadonlyArray<EditInstruction>> =>
+  fc.array(editInstructionArb(opts.textArb, opts.deleteWeight ?? 3), {
+    minLength: opts.minSteps,
+    maxLength: opts.maxSteps,
+  });
+
+/**
+ * Parameters for the multi-replica trace runner. The runner is the
+ * separate `./trace-runner.ts` module so the property body can call it
+ * with deterministic inputs.
+ */
+export interface TraceParams {
+  readonly initialText: string;
+  readonly scripts: ReadonlyArray<{
+    readonly replicaId: string;
+    readonly edits: ReadonlyArray<EditInstruction>;
+  }>;
+  readonly syncEveryN: number;
+}
+
+export const traceParamsArb = (opts: {
+  readonly minReplicas?: number;
+  readonly maxReplicas?: number;
+  readonly minStepsPerReplica?: number;
+  readonly maxStepsPerReplica?: number;
+  readonly textArb?: fc.Arbitrary<string>;
+  readonly seedTextArb?: fc.Arbitrary<string>;
+  readonly syncEveryNArb?: fc.Arbitrary<number>;
+  readonly deleteWeight?: number;
+}): fc.Arbitrary<TraceParams> => {
+  const textArb = opts.textArb ?? bmpTextArb();
+  const seedTextArb = opts.seedTextArb ?? fc.constantFrom(...SEED_TEXTS);
+  const syncEveryNArb = opts.syncEveryNArb ?? fc.integer({ min: 1, max: 7 });
+  const minReplicas = opts.minReplicas ?? 2;
+  const maxReplicas = opts.maxReplicas ?? 4;
+  const minSteps = opts.minStepsPerReplica ?? 2;
+  const maxSteps = opts.maxStepsPerReplica ?? 8;
+  return fc
+    .tuple(
+      fc.uniqueArray(replicaIdArb, {
+        minLength: minReplicas,
+        maxLength: maxReplicas,
+      }),
+      seedTextArb,
+      syncEveryNArb,
+    )
+    .chain(([replicaIds, initialText, syncEveryN]) =>
+      fc
+        .tuple(
+          ...replicaIds.map((replicaId) =>
+            localEditScriptArb({
+              minSteps,
+              maxSteps,
+              textArb,
+              deleteWeight: opts.deleteWeight,
+            }).map((edits) => ({ replicaId, edits })),
+          ),
+        )
+        .map((scripts) => ({
+          initialText,
+          scripts,
+          syncEveryN,
+        })),
+    );
+};
+
+/**
+ * Explicit small DAG of `GraphEvent`s, used by tests that need to
+ * control delivery order independently of replica-driven scripts.
+ *
+ * Construction: pick a `size` between `minSize` and `maxSize`; for each
+ * index `i`, generate 0–2 parents drawn from indices `< i`. Index 0 is
+ * always a root (no parents). Every event is an insert at index 0 with
+ * a short BMP string, which keeps the generator simple and the prepare
+ * state non-empty for downstream events.
+ */
+export const eventDagArb = (opts: {
+  readonly minSize?: number;
+  readonly maxSize?: number;
+}): fc.Arbitrary<ReadonlyArray<GraphEvent>> => {
+  const minSize = opts.minSize ?? 3;
+  const maxSize = opts.maxSize ?? 10;
+  return fc.integer({ min: minSize, max: maxSize }).chain((size) =>
+    fc
+      .tuple(
+        ...Array.from({ length: size }, (_unused, i) =>
+          fc.record({
+            text: bmpTextArb({ minLength: 1, maxLength: 3 }),
+            timestamp: fc.integer({ min: 0, max: 1_000_000 }),
+            parentPicks:
+              i === 0
+                ? fc.constant<ReadonlyArray<number>>([])
+                : fc.uniqueArray(fc.integer({ min: 0, max: i - 1 }), {
+                    minLength: 1,
+                    maxLength: Math.min(2, i),
+                  }),
+          }),
+        ),
+      )
+      .map((entries) => {
+        const events: GraphEvent[] = [];
+        for (let i = 0; i < entries.length; i++) {
+          const entry = entries[i]!;
+          const parentVersion = new Set<EventId>(
+            entry.parentPicks.map((idx) => events[idx]!.id),
+          );
+          events.push({
+            id: `dag${i}:0`,
+            parentVersion,
+            operation: {
+              type: OPERATION_TYPE.INSERT,
+              index: 0,
+              text: entry.text,
+            },
+            timestamp: entry.timestamp,
+          });
+        }
+        return events;
+      }),
+  );
+};

--- a/packages/eg-walker/src/test/property/convergence.property.test.ts
+++ b/packages/eg-walker/src/test/property/convergence.property.test.ts
@@ -17,6 +17,7 @@ import { EgWalkerReplica } from "../../core/replica";
 import { cloneEvent } from "../test-helpers";
 import { traceParamsArb } from "./arbitraries";
 import { fcParams } from "./run-config";
+import { shuffleWithSeed } from "./shuffle";
 import { runTrace } from "./trace-runner";
 
 describe("property: convergence under randomized delivery", () => {
@@ -65,26 +66,3 @@ describe("property: convergence under randomized delivery", () => {
     );
   });
 });
-
-/**
- * Fisher–Yates shuffle keyed on a 32-bit seed via the same LCG used in
- * `test-helpers.ts`. We do not reuse `createPrng` directly because the
- * inputs here come from fast-check's shrinkable integers, and binding
- * the helper inline keeps the shuffle reproducible from the shrunk
- * inputs alone.
- */
-const shuffleWithSeed = <T>(items: ReadonlyArray<T>, seed: number): T[] => {
-  let state = seed >>> 0;
-  const next = (): number => {
-    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
-    return state / 0x1_0000_0000;
-  };
-  const result = items.slice();
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(next() * (i + 1));
-    const tmp = result[i]!;
-    result[i] = result[j]!;
-    result[j] = tmp;
-  }
-  return result;
-};

--- a/packages/eg-walker/src/test/property/convergence.property.test.ts
+++ b/packages/eg-walker/src/test/property/convergence.property.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Property: for any randomly generated multi-replica trace, every
+ * replica that observes the full event set converges to the same text
+ * as the canonical (topological) replay — regardless of the order in
+ * which the events arrive over the wire.
+ *
+ * Complements the seed-based `convergence-property.test.ts` with
+ * fast-check shrinking: a failing case reduces to a minimal trace plus
+ * a minimal delivery permutation, rather than landing as an opaque
+ * seed.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { EgWalkerReplica } from "../../core/replica";
+import { cloneEvent } from "../test-helpers";
+import { traceParamsArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+import { runTrace } from "./trace-runner";
+
+describe("property: convergence under randomized delivery", () => {
+  it("every shuffled delivery order matches the canonical replay text", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 4,
+          minStepsPerReplica: 2,
+          maxStepsPerReplica: 6,
+        }),
+        // Three independent permutations per generated trace so the
+        // outer fast-check loop is not the only source of delivery
+        // diversity.
+        fc.array(fc.integer({ min: 0, max: 0x7fff_ffff }), {
+          minLength: 3,
+          maxLength: 3,
+        }),
+        (params, permutationSeeds) => {
+          const trace = runTrace(params);
+          // Every live replica must already agree with the canonical
+          // text — this is the multi-replica convergence claim.
+          for (const finalText of trace.finalTextPerReplica.values()) {
+            expect(finalText).toBe(trace.canonicalText);
+          }
+
+          // Now replay the *same* event set into fresh replicas in
+          // distinct random orders. Every replay must converge.
+          for (let trial = 0; trial < permutationSeeds.length; trial++) {
+            const seed = permutationSeeds[trial]!;
+            const shuffled = shuffleWithSeed(trace.events, seed);
+            const replica = new EgWalkerReplica(
+              `verify-${trial}`,
+              params.initialText,
+            );
+            for (const event of shuffled) {
+              replica.applyRemoteEvent(cloneEvent(event));
+            }
+            expect(replica.getPendingRemoteCount()).toBe(0);
+            expect(replica.getText()).toBe(trace.canonicalText);
+          }
+        },
+      ),
+      fcParams(),
+    );
+  });
+});
+
+/**
+ * Fisher–Yates shuffle keyed on a 32-bit seed via the same LCG used in
+ * `test-helpers.ts`. We do not reuse `createPrng` directly because the
+ * inputs here come from fast-check's shrinkable integers, and binding
+ * the helper inline keeps the shuffle reproducible from the shrunk
+ * inputs alone.
+ */
+const shuffleWithSeed = <T>(items: ReadonlyArray<T>, seed: number): T[] => {
+  let state = seed >>> 0;
+  const next = (): number => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+  const result = items.slice();
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(next() * (i + 1));
+    const tmp = result[i]!;
+    result[i] = result[j]!;
+    result[j] = tmp;
+  }
+  return result;
+};

--- a/packages/eg-walker/src/test/property/delivery-order-invariance.property.test.ts
+++ b/packages/eg-walker/src/test/property/delivery-order-invariance.property.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Property: for a *fixed* event set, the final replica text is
+ * invariant under every shuffled delivery permutation. Pins the trace
+ * and varies only the delivery permutation, exercising the
+ * `RemoteEventBuffer` flushing path in isolation from trace generation.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { EgWalkerReplica } from "../../core/replica";
+import type { GraphEvent } from "../../types";
+import { cloneEvent } from "../test-helpers";
+import { traceParamsArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+import { runTrace } from "./trace-runner";
+
+const eventPermutationArb = (
+  events: ReadonlyArray<GraphEvent>,
+): fc.Arbitrary<ReadonlyArray<number>> =>
+  fc
+    .uniqueArray(fc.integer({ min: 0, max: events.length - 1 }), {
+      minLength: events.length,
+      maxLength: events.length,
+    })
+    .filter((indices) => indices.length === events.length);
+
+describe("property: delivery-order invariance for a fixed event set", () => {
+  it("every permutation of the same event set yields the same final text", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 3,
+          minStepsPerReplica: 2,
+          maxStepsPerReplica: 5,
+        }),
+        (params) => {
+          const trace = runTrace(params);
+          if (trace.events.length === 0) {
+            return;
+          }
+          // Inner property: across N permutations, every delivered
+          // replica must end at the canonical text. Using an inner
+          // `fc.assert` lets fast-check shrink the permutation
+          // independently of the trace.
+          fc.assert(
+            fc.property(eventPermutationArb(trace.events), (perm) => {
+              const replica = new EgWalkerReplica("perm", params.initialText);
+              for (const idx of perm) {
+                replica.applyRemoteEvent(cloneEvent(trace.events[idx]!));
+              }
+              expect(replica.getPendingRemoteCount()).toBe(0);
+              expect(replica.getText()).toBe(trace.canonicalText);
+            }),
+            // Inner runs are cheap — every permutation just feeds the
+            // existing event list through a fresh replica. Cap at 8
+            // so the outer fast-check budget is not spent here.
+            { numRuns: 8 },
+          );
+        },
+      ),
+      fcParams(),
+    );
+  });
+});

--- a/packages/eg-walker/src/test/property/delivery-order-invariance.property.test.ts
+++ b/packages/eg-walker/src/test/property/delivery-order-invariance.property.test.ts
@@ -9,55 +9,57 @@ import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
 import { EgWalkerReplica } from "../../core/replica";
-import type { GraphEvent } from "../../types";
 import { cloneEvent } from "../test-helpers";
 import { traceParamsArb } from "./arbitraries";
 import { fcParams } from "./run-config";
 import { runTrace } from "./trace-runner";
 
-const eventPermutationArb = (
-  events: ReadonlyArray<GraphEvent>,
-): fc.Arbitrary<ReadonlyArray<number>> =>
-  fc
-    .uniqueArray(fc.integer({ min: 0, max: events.length - 1 }), {
-      minLength: events.length,
-      maxLength: events.length,
-    })
-    .filter((indices) => indices.length === events.length);
+/**
+ * Fisher–Yates shuffle keyed on a 32-bit seed via the same LCG used in
+ * `test-helpers.ts`. Kept local so the shrunk inputs (trace params +
+ * permutation seed) are sufficient to reproduce a failing case without
+ * pulling in additional helpers.
+ */
+const shuffleWithSeed = <T>(items: ReadonlyArray<T>, seed: number): T[] => {
+  let state = seed >>> 0;
+  const next = (): number => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+  const result = items.slice();
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(next() * (i + 1));
+    const tmp = result[i]!;
+    result[i] = result[j]!;
+    result[j] = tmp;
+  }
+  return result;
+};
 
 describe("property: delivery-order invariance for a fixed event set", () => {
   it("every permutation of the same event set yields the same final text", () => {
     fc.assert(
       fc.property(
-        traceParamsArb({
-          minReplicas: 2,
-          maxReplicas: 3,
-          minStepsPerReplica: 2,
-          maxStepsPerReplica: 5,
-        }),
-        (params) => {
+        fc.tuple(
+          traceParamsArb({
+            minReplicas: 2,
+            maxReplicas: 3,
+            minStepsPerReplica: 2,
+            maxStepsPerReplica: 5,
+          }),
+          fc.integer({ min: 0, max: 0x7fff_ffff }),
+        ),
+        ([params, permutationSeed]) => {
           const trace = runTrace(params);
-          if (trace.events.length === 0) {
-            return;
+          fc.pre(trace.appliedEdits > 0);
+
+          const shuffled = shuffleWithSeed(trace.events, permutationSeed);
+          const replica = new EgWalkerReplica("perm", params.initialText);
+          for (const event of shuffled) {
+            replica.applyRemoteEvent(cloneEvent(event));
           }
-          // Inner property: across N permutations, every delivered
-          // replica must end at the canonical text. Using an inner
-          // `fc.assert` lets fast-check shrink the permutation
-          // independently of the trace.
-          fc.assert(
-            fc.property(eventPermutationArb(trace.events), (perm) => {
-              const replica = new EgWalkerReplica("perm", params.initialText);
-              for (const idx of perm) {
-                replica.applyRemoteEvent(cloneEvent(trace.events[idx]!));
-              }
-              expect(replica.getPendingRemoteCount()).toBe(0);
-              expect(replica.getText()).toBe(trace.canonicalText);
-            }),
-            // Inner runs are cheap — every permutation just feeds the
-            // existing event list through a fresh replica. Cap at 8
-            // so the outer fast-check budget is not spent here.
-            { numRuns: 8 },
-          );
+          expect(replica.getPendingRemoteCount()).toBe(0);
+          expect(replica.getText()).toBe(trace.canonicalText);
         },
       ),
       fcParams(),

--- a/packages/eg-walker/src/test/property/delivery-order-invariance.property.test.ts
+++ b/packages/eg-walker/src/test/property/delivery-order-invariance.property.test.ts
@@ -12,29 +12,8 @@ import { EgWalkerReplica } from "../../core/replica";
 import { cloneEvent } from "../test-helpers";
 import { traceParamsArb } from "./arbitraries";
 import { fcParams } from "./run-config";
+import { shuffleWithSeed } from "./shuffle";
 import { runTrace } from "./trace-runner";
-
-/**
- * Fisher–Yates shuffle keyed on a 32-bit seed via the same LCG used in
- * `test-helpers.ts`. Kept local so the shrunk inputs (trace params +
- * permutation seed) are sufficient to reproduce a failing case without
- * pulling in additional helpers.
- */
-const shuffleWithSeed = <T>(items: ReadonlyArray<T>, seed: number): T[] => {
-  let state = seed >>> 0;
-  const next = (): number => {
-    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
-    return state / 0x1_0000_0000;
-  };
-  const result = items.slice();
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(next() * (i + 1));
-    const tmp = result[i]!;
-    result[i] = result[j]!;
-    result[j] = tmp;
-  }
-  return result;
-};
 
 describe("property: delivery-order invariance for a fixed event set", () => {
   it("every permutation of the same event set yields the same final text", () => {

--- a/packages/eg-walker/src/test/property/duplicate-event-idempotency.property.test.ts
+++ b/packages/eg-walker/src/test/property/duplicate-event-idempotency.property.test.ts
@@ -34,9 +34,7 @@ describe("property: duplicate event delivery is idempotent", () => {
         fc.integer({ min: 0, max: 0x7fff_ffff }),
         (params, baselineSeed, duplicateSeed) => {
           const trace = runTrace(params);
-          if (trace.events.length === 0) {
-            return;
-          }
+          fc.pre(trace.appliedEdits > 0);
 
           const baseline = new EgWalkerReplica("baseline", params.initialText);
           for (const event of shuffleWithSeed(trace.events, baselineSeed)) {

--- a/packages/eg-walker/src/test/property/duplicate-event-idempotency.property.test.ts
+++ b/packages/eg-walker/src/test/property/duplicate-event-idempotency.property.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Property: applying every event to a replica twice is a no-op. The
+ * second application must not throw, must not corrupt state, and the
+ * final text must match the single-delivery replica.
+ *
+ * Verifies the `EventAlreadyExistsError` swallow in
+ * `RemoteEventBuffer.tryAccept` and the project's "graceful duplicate
+ * handling" pattern documented in `.claude/CLAUDE.md`.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { EgWalkerReplica } from "../../core/replica";
+import { cloneEvent } from "../test-helpers";
+import { traceParamsArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+import { runTrace } from "./trace-runner";
+
+describe("property: duplicate event delivery is idempotent", () => {
+  it("re-applying every event leaves the replica state unchanged", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 3,
+          minStepsPerReplica: 2,
+          maxStepsPerReplica: 5,
+        }),
+        // Two integer seeds: one picks the duplicate ordering, the
+        // other picks the single-delivery baseline ordering. Using
+        // fast-check integers keeps the permutations shrinkable.
+        fc.integer({ min: 0, max: 0x7fff_ffff }),
+        fc.integer({ min: 0, max: 0x7fff_ffff }),
+        (params, baselineSeed, duplicateSeed) => {
+          const trace = runTrace(params);
+          if (trace.events.length === 0) {
+            return;
+          }
+
+          const baseline = new EgWalkerReplica("baseline", params.initialText);
+          for (const event of shuffleWithSeed(trace.events, baselineSeed)) {
+            baseline.applyRemoteEvent(cloneEvent(event));
+          }
+          expect(baseline.getPendingRemoteCount()).toBe(0);
+          expect(baseline.getText()).toBe(trace.canonicalText);
+
+          // Now build a duplicate-laden delivery: every event appears
+          // twice, interleaved by the duplicate seed.
+          const doubled = [...trace.events, ...trace.events];
+          const dupReplica = new EgWalkerReplica(
+            "duplicates",
+            params.initialText,
+          );
+          for (const event of shuffleWithSeed(doubled, duplicateSeed)) {
+            // Must not throw, even for the second arrival.
+            dupReplica.applyRemoteEvent(cloneEvent(event));
+          }
+
+          expect(dupReplica.getPendingRemoteCount()).toBe(0);
+          expect(dupReplica.getText()).toBe(trace.canonicalText);
+
+          // The graph must still contain exactly one record per event
+          // id.
+          const dupIds = new Set(
+            dupReplica.exportEventGraph().map((event) => event.id),
+          );
+          expect(dupIds.size).toBe(trace.events.length);
+
+          // Sanity: duplicate deliveries should not have inflated the
+          // event graph relative to the baseline.
+          expect(dupReplica.exportEventGraph().length).toBe(
+            baseline.exportEventGraph().length,
+          );
+        },
+      ),
+      fcParams(),
+    );
+  });
+});
+
+const shuffleWithSeed = <T>(items: ReadonlyArray<T>, seed: number): T[] => {
+  let state = seed >>> 0;
+  const next = (): number => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+  const result = items.slice();
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(next() * (i + 1));
+    const tmp = result[i]!;
+    result[i] = result[j]!;
+    result[j] = tmp;
+  }
+  return result;
+};

--- a/packages/eg-walker/src/test/property/duplicate-event-idempotency.property.test.ts
+++ b/packages/eg-walker/src/test/property/duplicate-event-idempotency.property.test.ts
@@ -15,6 +15,7 @@ import { EgWalkerReplica } from "../../core/replica";
 import { cloneEvent } from "../test-helpers";
 import { traceParamsArb } from "./arbitraries";
 import { fcParams } from "./run-config";
+import { shuffleWithSeed } from "./shuffle";
 import { runTrace } from "./trace-runner";
 
 describe("property: duplicate event delivery is idempotent", () => {
@@ -76,19 +77,3 @@ describe("property: duplicate event delivery is idempotent", () => {
     );
   });
 });
-
-const shuffleWithSeed = <T>(items: ReadonlyArray<T>, seed: number): T[] => {
-  let state = seed >>> 0;
-  const next = (): number => {
-    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
-    return state / 0x1_0000_0000;
-  };
-  const result = items.slice();
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(next() * (i + 1));
-    const tmp = result[i]!;
-    result[i] = result[j]!;
-    result[j] = tmp;
-  }
-  return result;
-};

--- a/packages/eg-walker/src/test/property/missing-parent-buffering.property.test.ts
+++ b/packages/eg-walker/src/test/property/missing-parent-buffering.property.test.ts
@@ -12,10 +12,10 @@ import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
 import { EgWalkerReplica } from "../../core/replica";
-import type { GraphEvent } from "../../types";
 import { cloneEvent } from "../test-helpers";
 import { eventDagArb } from "./arbitraries";
 import { fcParams } from "./run-config";
+import { shuffleWithSeed } from "./shuffle";
 import { canonicalReplay } from "./trace-runner";
 
 describe("property: missing-parent buffering", () => {
@@ -69,22 +69,3 @@ describe("property: missing-parent buffering", () => {
     );
   });
 });
-
-const shuffleWithSeed = (
-  items: ReadonlyArray<GraphEvent>,
-  seed: number,
-): GraphEvent[] => {
-  let state = seed >>> 0;
-  const next = (): number => {
-    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
-    return state / 0x1_0000_0000;
-  };
-  const result = items.slice();
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(next() * (i + 1));
-    const tmp = result[i]!;
-    result[i] = result[j]!;
-    result[j] = tmp;
-  }
-  return result;
-};

--- a/packages/eg-walker/src/test/property/missing-parent-buffering.property.test.ts
+++ b/packages/eg-walker/src/test/property/missing-parent-buffering.property.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Property: events delivered before their causal parents are held in
+ * the `RemoteEventBuffer` and flushed exactly once their parents
+ * arrive. The terminal state must match the canonical replay over the
+ * same event set.
+ *
+ * Uses `eventDagArb` so we control both the parent topology and the
+ * delivery order, decoupled from the multi-replica trace runner.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { EgWalkerReplica } from "../../core/replica";
+import type { GraphEvent } from "../../types";
+import { cloneEvent } from "../test-helpers";
+import { eventDagArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+import { canonicalReplay } from "./trace-runner";
+
+describe("property: missing-parent buffering", () => {
+  it("reverse-order delivery is buffered, then flushed to canonical text", () => {
+    fc.assert(
+      fc.property(eventDagArb({ minSize: 3, maxSize: 12 }), (events) => {
+        const expected = canonicalReplay(events);
+
+        // Reverse-topological delivery: every non-root event lands
+        // before its parents and must be buffered.
+        const replica = new EgWalkerReplica("reverse");
+        let sawBuffering = false;
+        for (let i = events.length - 1; i >= 0; i--) {
+          replica.applyRemoteEvent(cloneEvent(events[i]!));
+          if (replica.getPendingRemoteCount() > 0) {
+            sawBuffering = true;
+          }
+        }
+        expect(replica.getPendingRemoteCount()).toBe(0);
+        expect(replica.getText()).toBe(expected);
+
+        // We expect buffering to be exercised for any DAG with at
+        // least one non-root event (i.e. every DAG of size ≥ 2,
+        // because index 0 is a root and index 1 has it as a
+        // parent). The single-event case has no parents to wait on.
+        if (events.length >= 2) {
+          expect(sawBuffering).toBe(true);
+        }
+      }),
+      fcParams(),
+    );
+  });
+
+  it("arbitrary delivery permutations flush completely", () => {
+    fc.assert(
+      fc.property(
+        eventDagArb({ minSize: 2, maxSize: 10 }),
+        fc.integer({ min: 0, max: 0x7fff_ffff }),
+        (events, seed) => {
+          const expected = canonicalReplay(events);
+          const delivery = shuffleWithSeed(events, seed);
+          const replica = new EgWalkerReplica("shuffled");
+          for (const event of delivery) {
+            replica.applyRemoteEvent(cloneEvent(event));
+          }
+          expect(replica.getPendingRemoteCount()).toBe(0);
+          expect(replica.getText()).toBe(expected);
+        },
+      ),
+      fcParams(),
+    );
+  });
+});
+
+const shuffleWithSeed = (
+  items: ReadonlyArray<GraphEvent>,
+  seed: number,
+): GraphEvent[] => {
+  let state = seed >>> 0;
+  const next = (): number => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+  const result = items.slice();
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(next() * (i + 1));
+    const tmp = result[i]!;
+    result[i] = result[j]!;
+    result[j] = tmp;
+  }
+  return result;
+};

--- a/packages/eg-walker/src/test/property/run-config.ts
+++ b/packages/eg-walker/src/test/property/run-config.ts
@@ -12,7 +12,7 @@ import type fc from "fast-check";
 
 const parsed = Number(process.env.EG_WALKER_PROPERTY_RUNS);
 export const PROPERTY_RUNS: number =
-  Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 100;
+  Number.isFinite(parsed) && parsed > 0 ? Math.max(1, Math.floor(parsed)) : 100;
 
 export const fcParams = (
   overrides?: fc.Parameters<unknown>,

--- a/packages/eg-walker/src/test/property/run-config.ts
+++ b/packages/eg-walker/src/test/property/run-config.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared fast-check configuration for the property-test suite.
+ *
+ * Default run count is 100 (the acceptance criterion on
+ * softmaple/softmaple issue 722). Override via the
+ * `EG_WALKER_PROPERTY_RUNS` env var, e.g.:
+ *
+ *   EG_WALKER_PROPERTY_RUNS=500 pnpm --filter @softmaple/eg-walker test
+ */
+
+import type fc from "fast-check";
+
+const parsed = Number(process.env.EG_WALKER_PROPERTY_RUNS);
+export const PROPERTY_RUNS: number =
+  Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 100;
+
+export const fcParams = (
+  overrides?: fc.Parameters<unknown>,
+): fc.Parameters<unknown> => ({
+  numRuns: PROPERTY_RUNS,
+  ...overrides,
+});

--- a/packages/eg-walker/src/test/property/serialize-roundtrip.property.test.ts
+++ b/packages/eg-walker/src/test/property/serialize-roundtrip.property.test.ts
@@ -113,9 +113,7 @@ describe("property: columnar codec round-trip", () => {
         }),
         (params) => {
           const trace = runTrace(params);
-          if (trace.events.length === 0) {
-            return;
-          }
+          fc.pre(trace.appliedEdits > 0);
 
           const sourceGraph = new EventGraph();
           for (const event of trace.events.map(cloneEvent)) {

--- a/packages/eg-walker/src/test/property/serialize-roundtrip.property.test.ts
+++ b/packages/eg-walker/src/test/property/serialize-roundtrip.property.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Property: `EgWalkerReplica.serialize()` → `deserialize()` and the
+ * columnar codec's `encodeBinary` → `decodeBinary` are both
+ * round-trips that preserve text and frontier.
+ *
+ * Replay-stat counters (`fullReplays`, `incrementalApplies`,
+ * `sequenceRecordCount`) are intentionally not asserted: they reflect
+ * which replay path produced the engine state. The original replica
+ * was built via incremental applies, the restored replica via a cold
+ * full replay over the deserialized graph, so the two will legitimately
+ * land on different internal record layouts even though the public
+ * document state matches.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { EgWalkerReplica } from "../../core/replica";
+import { EventGraph } from "../../graph/event-graph";
+import { ColumnarEventGraphCodec } from "../../graph/columnar-codec";
+import type { EventId, GraphEvent } from "../../types";
+import { cloneEvent } from "../test-helpers";
+import { traceParamsArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+import { runTrace } from "./trace-runner";
+
+const frontierSet = (replica: EgWalkerReplica): Set<EventId> => {
+  const events = replica.exportEventGraph();
+  const childOf = new Map<EventId, Set<EventId>>();
+  const allIds = new Set<EventId>();
+  for (const event of events) {
+    allIds.add(event.id);
+    for (const parent of event.parentVersion) {
+      if (!childOf.has(parent)) {
+        childOf.set(parent, new Set());
+      }
+      childOf.get(parent)!.add(event.id);
+    }
+  }
+  const frontier = new Set<EventId>();
+  for (const id of allIds) {
+    if (!childOf.has(id) || childOf.get(id)!.size === 0) {
+      frontier.add(id);
+    }
+  }
+  return frontier;
+};
+
+const setEquals = <T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean => {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const item of a) {
+    if (!b.has(item)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+describe("property: JSON serialize/deserialize round-trip", () => {
+  it("preserves text, frontier, and sequence-record count", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 3,
+          minStepsPerReplica: 2,
+          maxStepsPerReplica: 5,
+        }),
+        (params) => {
+          const trace = runTrace(params);
+          const original = new EgWalkerReplica("origin", params.initialText);
+          for (const event of trace.events) {
+            original.applyRemoteEvent(cloneEvent(event));
+          }
+          expect(original.getText()).toBe(trace.canonicalText);
+
+          const serialized = original.serialize();
+          // JSON round-trip — proves the on-wire payload is JSON-safe.
+          const wire = JSON.parse(
+            JSON.stringify(serialized),
+          ) as typeof serialized;
+          const restored = EgWalkerReplica.deserialize(wire, "restored");
+
+          expect(restored.getText()).toBe(original.getText());
+          expect(setEquals(frontierSet(restored), frontierSet(original))).toBe(
+            true,
+          );
+
+          // The restored replica must carry the full event history,
+          // so it can continue to accept new events without losing
+          // causal context.
+          expect(restored.exportEventGraph().length).toBe(
+            original.exportEventGraph().length,
+          );
+        },
+      ),
+      fcParams(),
+    );
+  });
+});
+
+describe("property: columnar codec round-trip", () => {
+  it("encodeBinary → decodeBinary preserves replay text", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 3,
+          minStepsPerReplica: 2,
+          maxStepsPerReplica: 5,
+        }),
+        (params) => {
+          const trace = runTrace(params);
+          if (trace.events.length === 0) {
+            return;
+          }
+
+          const sourceGraph = new EventGraph();
+          for (const event of trace.events.map(cloneEvent)) {
+            sourceGraph.addEvent(event);
+          }
+
+          const codec = new ColumnarEventGraphCodec();
+          const bytes = codec.encodeBinary(sourceGraph);
+          const decoded = codec.decodeBinary(bytes);
+
+          // Decoded graph must replay to the same text.
+          const replayed = replayGraph(decoded, params.initialText);
+          expect(replayed).toBe(trace.canonicalText);
+
+          // And the in-memory `encode/decode` path round-trips too.
+          const decoded2 = codec.decode(codec.encode(sourceGraph));
+          expect(replayGraph(decoded2, params.initialText)).toBe(
+            trace.canonicalText,
+          );
+        },
+      ),
+      fcParams(),
+    );
+  });
+});
+
+const replayGraph = (graph: EventGraph, initialText: string): string => {
+  const replica = new EgWalkerReplica("replay", initialText);
+  for (const event of graph.getTopologicalOrder()) {
+    const clone: GraphEvent = {
+      id: event.id,
+      operation: { ...event.operation },
+      parentVersion: new Set(event.parentVersion),
+      timestamp: event.timestamp,
+    };
+    replica.applyRemoteEvent(clone);
+  }
+  return replica.getText();
+};

--- a/packages/eg-walker/src/test/property/shuffle.ts
+++ b/packages/eg-walker/src/test/property/shuffle.ts
@@ -1,0 +1,35 @@
+/**
+ * Fisher–Yates shuffle keyed on a 32-bit seed.
+ *
+ * Used by the property tests to derive a reproducible delivery
+ * permutation from a fast-check-shrunk `seed: number`. The shrunk seed
+ * plus the upstream trace arbitrary are sufficient to reproduce any
+ * failing case without pulling in additional state.
+ *
+ * Constants `MULTIPLIER` and `INCREMENT` are Numerical Recipes' LCG
+ * parameters (same pair used by `createPrng` in `../test-helpers.ts`).
+ * Combined with the `>>> 0` mask and the `/ 2^32` normalisation, the
+ * generator produces a uniform `[0, 1)` stream with full 32-bit
+ * resolution.
+ */
+const MULTIPLIER = 1_664_525;
+const INCREMENT = 1_013_904_223;
+
+export const shuffleWithSeed = <T>(
+  items: ReadonlyArray<T>,
+  seed: number,
+): T[] => {
+  let state = seed >>> 0;
+  const next = (): number => {
+    state = (state * MULTIPLIER + INCREMENT) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+  const result = items.slice();
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(next() * (i + 1));
+    const tmp = result[i]!;
+    result[i] = result[j]!;
+    result[j] = tmp;
+  }
+  return result;
+};

--- a/packages/eg-walker/src/test/property/trace-runner.ts
+++ b/packages/eg-walker/src/test/property/trace-runner.ts
@@ -1,0 +1,164 @@
+/**
+ * Trace runner for the property-test suite.
+ *
+ * Takes the plain-data {@link TraceParams} produced by `traceParamsArb`,
+ * drives a fleet of {@link EgWalkerReplica} instances through the
+ * scripts with periodic broadcasts, and returns the deduplicated event
+ * list plus the canonical replay text for that event set.
+ *
+ * The runner deliberately does not call into `fast-check` itself — it
+ * operates on plain inputs so a failing property can be reproduced by
+ * calling it directly with the shrunk inputs.
+ */
+
+import { EgWalkerReplica } from "../../core/replica";
+import { EventGraph } from "../../graph/event-graph";
+import type { EventId, GraphEvent } from "../../types";
+import { cloneEvent } from "../test-helpers";
+import type { EditInstruction, TraceParams } from "./arbitraries";
+
+export interface TraceResult {
+  readonly events: ReadonlyArray<GraphEvent>;
+  readonly canonicalText: string;
+  readonly finalTextPerReplica: ReadonlyMap<string, string>;
+}
+
+const snapPastSurrogate = (text: string, index: number): number => {
+  if (index <= 0 || index >= text.length) {
+    return Math.max(0, Math.min(index, text.length));
+  }
+  const high = text.charCodeAt(index - 1);
+  if (high < 0xd800 || high > 0xdbff) {
+    return index;
+  }
+  const low = text.charCodeAt(index);
+  if (low >= 0xdc00 && low <= 0xdfff) {
+    return Math.min(index + 1, text.length);
+  }
+  return index;
+};
+
+const applyEdit = (replica: EgWalkerReplica, edit: EditInstruction): void => {
+  const text = replica.getText();
+  if (edit.kind === "insert") {
+    if (edit.text.length === 0) {
+      return;
+    }
+    const rawIndex = Math.floor(edit.offsetSeed * (text.length + 1));
+    const index = snapPastSurrogate(text, rawIndex);
+    replica.insert(index, edit.text);
+    return;
+  }
+  if (text.length === 0) {
+    return;
+  }
+  const rawStart = Math.floor(edit.offsetSeed * text.length);
+  const start = snapPastSurrogate(text, Math.min(rawStart, text.length - 1));
+  if (start >= text.length) {
+    return;
+  }
+  const remaining = text.length - start;
+  const rawLen = Math.max(1, Math.floor(edit.lengthSeed * remaining));
+  const rawEnd = snapPastSurrogate(text, start + rawLen);
+  const length = Math.min(rawEnd - start, remaining);
+  if (length <= 0) {
+    return;
+  }
+  replica.delete(start, length);
+};
+
+const broadcast = (params: {
+  readonly replicas: ReadonlyArray<{
+    readonly id: string;
+    readonly replica: EgWalkerReplica;
+  }>;
+  readonly seenIds: Set<EventId>;
+  readonly aggregateEvents: GraphEvent[];
+}): void => {
+  const { replicas, seenIds, aggregateEvents } = params;
+  const fresh: GraphEvent[] = [];
+  for (const { replica } of replicas) {
+    for (const event of replica.exportEventGraph()) {
+      if (seenIds.has(event.id)) {
+        continue;
+      }
+      seenIds.add(event.id);
+      aggregateEvents.push(cloneEvent(event));
+      fresh.push(cloneEvent(event));
+    }
+  }
+  if (fresh.length === 0) {
+    return;
+  }
+  for (const { id, replica } of replicas) {
+    const prefix = `${id}:`;
+    for (const event of fresh) {
+      if (event.id.startsWith(prefix)) {
+        continue;
+      }
+      replica.applyRemoteEvent(cloneEvent(event));
+    }
+  }
+};
+
+export const canonicalReplay = (
+  events: ReadonlyArray<GraphEvent>,
+  initialText: string = "",
+): string => {
+  const graph = new EventGraph();
+  for (const event of events.map(cloneEvent)) {
+    graph.addEvent(event);
+  }
+  const replica = new EgWalkerReplica("canonical", initialText);
+  for (const event of graph.getTopologicalOrder()) {
+    replica.applyRemoteEvent(cloneEvent(event));
+  }
+  return replica.getText();
+};
+
+export const runTrace = (params: TraceParams): TraceResult => {
+  const { initialText, scripts, syncEveryN } = params;
+  const sims = scripts.map(({ replicaId }) => ({
+    id: replicaId,
+    replica: new EgWalkerReplica(replicaId, initialText),
+  }));
+
+  const seenIds = new Set<EventId>();
+  const aggregateEvents: GraphEvent[] = [];
+  const sync = (): void =>
+    broadcast({ replicas: sims, seenIds, aggregateEvents });
+
+  // Interleave the per-replica scripts step-by-step so concurrent
+  // edits actually overlap rather than each replica completing all
+  // its edits before the next gets a turn.
+  const maxSteps = scripts.reduce(
+    (max, { edits }) => Math.max(max, edits.length),
+    0,
+  );
+  let stepCounter = 0;
+  for (let step = 0; step < maxSteps; step++) {
+    for (let r = 0; r < sims.length; r++) {
+      const edits = scripts[r]!.edits;
+      if (step >= edits.length) {
+        continue;
+      }
+      applyEdit(sims[r]!.replica, edits[step]!);
+      stepCounter++;
+      if (stepCounter % syncEveryN === 0) {
+        sync();
+      }
+    }
+  }
+  sync();
+
+  const finalTextPerReplica = new Map<string, string>();
+  for (const { id, replica } of sims) {
+    finalTextPerReplica.set(id, replica.getText());
+  }
+  const canonicalText = canonicalReplay(aggregateEvents, initialText);
+  return {
+    events: aggregateEvents,
+    canonicalText,
+    finalTextPerReplica,
+  };
+};

--- a/packages/eg-walker/src/test/property/trace-runner.ts
+++ b/packages/eg-walker/src/test/property/trace-runner.ts
@@ -21,6 +21,15 @@ export interface TraceResult {
   readonly events: ReadonlyArray<GraphEvent>;
   readonly canonicalText: string;
   readonly finalTextPerReplica: ReadonlyMap<string, string>;
+  /**
+   * Count of edit instructions in `params.scripts` that actually produced
+   * a `GraphEvent`. Lower than the total instruction count when the
+   * runner skipped no-ops (empty insert, delete on empty text, zero-length
+   * delete). Property tests use this with `fc.pre` to reject iterations
+   * whose generated script collapsed to nothing, instead of silently
+   * passing on an empty trace.
+   */
+  readonly appliedEdits: number;
 }
 
 const snapPastSurrogate = (text: string, index: number): number => {
@@ -38,33 +47,43 @@ const snapPastSurrogate = (text: string, index: number): number => {
   return index;
 };
 
-const applyEdit = (replica: EgWalkerReplica, edit: EditInstruction): void => {
+/**
+ * Apply one edit instruction. Returns `true` if the edit actually
+ * produced a `GraphEvent` on the replica, `false` if it was a no-op
+ * (empty insert, delete on empty text, zero-length delete). The caller
+ * uses this to maintain {@link TraceResult.appliedEdits}.
+ */
+const applyEdit = (
+  replica: EgWalkerReplica,
+  edit: EditInstruction,
+): boolean => {
   const text = replica.getText();
   if (edit.kind === "insert") {
     if (edit.text.length === 0) {
-      return;
+      return false;
     }
     const rawIndex = Math.floor(edit.offsetSeed * (text.length + 1));
     const index = snapPastSurrogate(text, rawIndex);
     replica.insert(index, edit.text);
-    return;
+    return true;
   }
   if (text.length === 0) {
-    return;
+    return false;
   }
   const rawStart = Math.floor(edit.offsetSeed * text.length);
   const start = snapPastSurrogate(text, Math.min(rawStart, text.length - 1));
   if (start >= text.length) {
-    return;
+    return false;
   }
   const remaining = text.length - start;
   const rawLen = Math.max(1, Math.floor(edit.lengthSeed * remaining));
   const rawEnd = snapPastSurrogate(text, start + rawLen);
   const length = Math.min(rawEnd - start, remaining);
   if (length <= 0) {
-    return;
+    return false;
   }
   replica.delete(start, length);
+  return true;
 };
 
 const broadcast = (params: {
@@ -136,13 +155,16 @@ export const runTrace = (params: TraceParams): TraceResult => {
     0,
   );
   let stepCounter = 0;
+  let appliedEdits = 0;
   for (let step = 0; step < maxSteps; step++) {
     for (let r = 0; r < sims.length; r++) {
       const edits = scripts[r]!.edits;
       if (step >= edits.length) {
         continue;
       }
-      applyEdit(sims[r]!.replica, edits[step]!);
+      if (applyEdit(sims[r]!.replica, edits[step]!)) {
+        appliedEdits++;
+      }
       stepCounter++;
       if (stepCounter % syncEveryN === 0) {
         sync();
@@ -160,5 +182,6 @@ export const runTrace = (params: TraceParams): TraceResult => {
     events: aggregateEvents,
     canonicalText,
     finalTextPerReplica,
+    appliedEdits,
   };
 };

--- a/packages/eg-walker/src/test/property/unicode-surrogate.property.test.ts
+++ b/packages/eg-walker/src/test/property/unicode-surrogate.property.test.ts
@@ -16,6 +16,7 @@ import { EgWalkerReplica } from "../../core/replica";
 import { cloneEvent } from "../test-helpers";
 import { surrogateBiasedTextArb, traceParamsArb } from "./arbitraries";
 import { fcParams } from "./run-config";
+import { shuffleWithSeed } from "./shuffle";
 import { runTrace } from "./trace-runner";
 import { wellFormedUtf16 } from "./utf16";
 
@@ -59,19 +60,3 @@ describe("property: UTF-16 surrogate well-formedness", () => {
     );
   });
 });
-
-const shuffleWithSeed = <T>(items: ReadonlyArray<T>, seed: number): T[] => {
-  let state = seed >>> 0;
-  const next = (): number => {
-    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
-    return state / 0x1_0000_0000;
-  };
-  const result = items.slice();
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(next() * (i + 1));
-    const tmp = result[i]!;
-    result[i] = result[j]!;
-    result[j] = tmp;
-  }
-  return result;
-};

--- a/packages/eg-walker/src/test/property/unicode-surrogate.property.test.ts
+++ b/packages/eg-walker/src/test/property/unicode-surrogate.property.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Property: inserts and deletes that span UTF-16 surrogate pairs
+ * respect the invariants enforced by `core/invariants.ts` —
+ * specifically `assertWellFormedUtf16`. Every replica's text must
+ * remain well-formed UTF-16, and every delivery permutation must
+ * converge.
+ *
+ * The trace generator biases insert payloads toward non-BMP code
+ * points so paired surrogates are exercised frequently.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { EgWalkerReplica } from "../../core/replica";
+import { cloneEvent } from "../test-helpers";
+import { surrogateBiasedTextArb, traceParamsArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+import { runTrace } from "./trace-runner";
+import { wellFormedUtf16 } from "./utf16";
+
+describe("property: UTF-16 surrogate well-formedness", () => {
+  it("surrogate-biased traces stay well-formed across replicas", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 3,
+          minStepsPerReplica: 2,
+          maxStepsPerReplica: 5,
+          textArb: surrogateBiasedTextArb(),
+          // Empty seed only: a surrogate-pair seed is exercised by
+          // the dedicated `convergence-property.test.ts` cases.
+          seedTextArb: fc.constant(""),
+        }),
+        fc.integer({ min: 0, max: 0x7fff_ffff }),
+        (params, permutationSeed) => {
+          const trace = runTrace(params);
+          expect(wellFormedUtf16(trace.canonicalText)).toBe(true);
+          for (const text of trace.finalTextPerReplica.values()) {
+            expect(wellFormedUtf16(text)).toBe(true);
+            expect(text).toBe(trace.canonicalText);
+          }
+
+          // Replay under a random delivery permutation — UTF-16
+          // well-formedness must be preserved regardless of the order
+          // events arrive.
+          const shuffled = shuffleWithSeed(trace.events, permutationSeed);
+          const replica = new EgWalkerReplica("surrogate");
+          for (const event of shuffled) {
+            replica.applyRemoteEvent(cloneEvent(event));
+          }
+          expect(replica.getPendingRemoteCount()).toBe(0);
+          expect(replica.getText()).toBe(trace.canonicalText);
+          expect(wellFormedUtf16(replica.getText())).toBe(true);
+        },
+      ),
+      fcParams(),
+    );
+  });
+});
+
+const shuffleWithSeed = <T>(items: ReadonlyArray<T>, seed: number): T[] => {
+  let state = seed >>> 0;
+  const next = (): number => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+  const result = items.slice();
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(next() * (i + 1));
+    const tmp = result[i]!;
+    result[i] = result[j]!;
+    result[j] = tmp;
+  }
+  return result;
+};

--- a/packages/eg-walker/src/test/property/utf16.ts
+++ b/packages/eg-walker/src/test/property/utf16.ts
@@ -1,0 +1,20 @@
+/**
+ * Well-formed UTF-16 predicate, duplicated from
+ * `convergence-property.test.ts` to avoid cross-importing between test
+ * files.
+ */
+export const wellFormedUtf16 = (text: string): boolean => {
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = i + 1 < text.length ? text.charCodeAt(i + 1) : 0;
+      if (next < 0xdc00 || next > 0xdfff) {
+        return false;
+      }
+      i++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
     devDependencies:
+      '@fast-check/vitest':
+        specifier: ^0.4.1
+        version: 0.4.1(vitest@4.0.16)
       '@softmaple/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -548,6 +551,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.0.16(@vitest/browser@4.0.16(vite@7.3.2(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.0.16))(vitest@4.0.16)
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@24.10.4))(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
@@ -1470,6 +1476,11 @@ packages:
     peerDependenciesMeta:
       '@exodus/crypto':
         optional: true
+
+  '@fast-check/vitest@0.4.1':
+    resolution: {integrity: sha512-OX6TecB+ZzRfPc49jcPChcV1cf5aDu77CdDU8liecWVam7eD7mPvJNP50b9bBSTxVoGN5wzxrX9PIcCnqgC8bg==}
+    peerDependencies:
+      vitest: ^4.1.0
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -5206,6 +5217,10 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -6365,6 +6380,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -8004,6 +8022,11 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.7.0': {}
+
+  '@fast-check/vitest@0.4.1(vitest@4.0.16)':
+    dependencies:
+      fast-check: 3.23.2
+      vitest: 4.0.16(@types/node@24.10.4)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@27.4.0(postcss@8.5.14))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -12061,6 +12084,10 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -13181,6 +13208,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  pure-rand@8.4.0: {}
 
   quansync@0.2.11: {}
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,6 +13,12 @@
       "skillPath": "skills/frontend-design/SKILL.md",
       "computedHash": "063a0e6448123cd359ad0044cc46b0e490cc7964d45ef4bb9fd842bd2ffbca67"
     },
+    "javascript-testing-expert": {
+      "source": "dubzzz/fast-check",
+      "sourceType": "github",
+      "skillPath": "skills/javascript-testing-expert/SKILL.md",
+      "computedHash": "a01dcd9b4e74a629253b340e9a15e3ee647af1c785f32637e7006d9a26d43150"
+    },
     "turborepo": {
       "source": "vercel/turborepo",
       "sourceType": "github",

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,9 @@
       "cache": false,
       "outputLogs": "full"
     },
+    "test": {
+      "env": ["EG_WALKER_PROPERTY_RUNS"]
+    },
     "dev": {
       "dependsOn": ["^db:generate"],
       "cache": false,


### PR DESCRIPTION
Closes #722 (A2 in the collaboration-audit plan).

## Summary

- New `packages/eg-walker/src/test/property/` directory with six shrinking property tests built on `fast-check`:
  - `convergence` — every shuffled delivery order matches the canonical replay text.
  - `delivery-order-invariance` — fixed event set, varying permutations all land on the canonical text.
  - `duplicate-event-idempotency` — every event delivered twice is a no-op, replica still converges.
  - `missing-parent-buffering` — reverse-order delivery is buffered then flushed, matches canonical.
  - `serialize-roundtrip` — JSON `serialize()`/`deserialize()` and columnar `encodeBinary`/`decodeBinary` preserve text and frontier.
  - `unicode-surrogate` — surrogate-biased traces stay well-formed UTF-16 and converge under random delivery.
- Shared helpers (`run-config.ts`, `arbitraries.ts`, `trace-runner.ts`, `utf16.ts`, `shuffle.ts`) so failing properties shrink to minimal scripts instead of opaque seeds. `shuffle.ts` consolidates the Fisher–Yates + LCG into a single module reused by all five property files.
- `delivery-order-invariance` uses a flat `fc.tuple(traceParamsArb, permutationSeed)` so the trace and the permutation shrink together.
- `trace-runner` returns an `appliedEdits` counter; three properties use `fc.pre(trace.appliedEdits > 0)` so rejected iterations no longer silently inflate `numRuns` and fast-check's shrinker stays honest.
- Defaults to **100 runs** per property; override via `EG_WALKER_PROPERTY_RUNS` (declared on the turbo `test` task so `turbo/no-undeclared-env-vars` stays satisfied).
- `README.md` documents the env-var override, the recommended pre-release sweep, the per-file invariants, and the contract for adding new property files.
- Existing `src/test/convergence-property.test.ts` is left untouched, as required by the issue.

## Notes / deviations from the original plan

- The plan suggested asserting `sequenceRecordCount` parity in `serialize-roundtrip`, but fast-check found cases (e.g. 3 consecutive inserts at index 0 from one replica + a delete from another) where the *original* replica (incremental applies) and the *restored* replica (cold full replay over the deserialized graph) legitimately land on different internal record layouts even though text and frontier match. That parity assertion was dropped; the tests still assert text equality, frontier equality, and event-graph size, which is the real round-trip contract.
- Same reasoning for the `sequenceRecordCount` assertion previously planned in `duplicate-event-idempotency`.

## Test plan

- [x] `pnpm --filter @softmaple/eg-walker test -- --run` — 276/276 passing at default 100 runs.
- [x] `pnpm --filter @softmaple/eg-walker typecheck` — clean.
- [x] `pnpm --filter @softmaple/eg-walker lint` — clean.
- [x] `pnpm --filter @softmaple/eg-walker test:coverage` — 96.4 / 86.43 / 100 / 96.37 vs floors 93.8 / 82.9 / 97 / 93.8.
- [x] `EG_WALKER_PROPERTY_RUNS=10 pnpm --filter @softmaple/eg-walker test -- --run src/test/property` — env-var override honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Tests**
  * Added comprehensive property-based tests validating multi-replica convergence, delivery-order invariance, duplicate-event idempotency, missing-parent buffering, serialization round-trips, UTF-16 surrogate safety, and deterministic shuffling.

* **Chores**
  * Introduced property-test infrastructure, shared helpers, deterministic run configuration, and test utilities plus a test dependency for property-based testing.

* **Documentation**
  * Added an expert-level JavaScript testing guide and a README describing the property-test suite and run configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->