### PR TITLE
feat(packages/eg-walker): surface benchmark-relevant metrics through replay stats

### DIFF
--- a/packages/eg-walker/CLAUDE.md
+++ b/packages/eg-walker/CLAUDE.md
@@ -109,8 +109,12 @@ diagnostic fields aimed at benches:
 - `sequenceRecordCount` — live records in the ranked B-tree; a memory
   proxy.
 - `peakSequenceRecordCount` — high-water mark of `sequenceRecordCount`
-  across the engine's lifetime. Survives later deletes/coalescing, so a
-  transient spike during a concurrent merge stays visible.
+  across the **replica's** lifetime. The replica folds the outgoing
+  engine's peak into a monotonic counter before each partial/full
+  replay engine swap, so the value survives later
+  deletes/coalescing *and* engine rebuilds: a transient spike during a
+  concurrent merge stays visible even if the next event triggers a
+  partial replay that creates a fresh engine.
 - `criticalCheckpointHits` / `criticalCheckpointMisses` — how often
   `CriticalCheckpointStore.pickFor` produced a usable starting point
   vs. forced a full replay. A miss means no retained critical version

--- a/packages/eg-walker/CLAUDE.md
+++ b/packages/eg-walker/CLAUDE.md
@@ -98,6 +98,33 @@ fields come from `EgWalkerReplica.getReplayStats()` and the engine's
 `engineRetreats`, or `sequenceRecordCount` is visible alongside the
 wall-clock numbers.
 
+`getReplayStats()` surfaces both steady-state counters and a few
+diagnostic fields aimed at benches:
+
+- `fullReplays` / `partialReplays` / `incrementalApplies` — counts of
+  which replay path handled each event.
+- `engineRetreats` / `engineAdvances` — cumulative engine churn.
+- `checkpointCount` — retained critical-version checkpoints in
+  `CriticalCheckpointStore` (capped at 32 via LRU).
+- `sequenceRecordCount` — live records in the ranked B-tree; a memory
+  proxy.
+- `peakSequenceRecordCount` — high-water mark of `sequenceRecordCount`
+  across the engine's lifetime. Survives later deletes/coalescing, so a
+  transient spike during a concurrent merge stays visible.
+- `criticalCheckpointHits` / `criticalCheckpointMisses` — how often
+  `CriticalCheckpointStore.pickFor` produced a usable starting point
+  vs. forced a full replay. A miss means no retained critical version
+  dominated the divergent suffix.
+- `lastReplaySource` — `"incremental" | "partial" | "full" | null`
+  (const object `REPLAY_SOURCE` in `constants/replay-source.ts`),
+  indicating which path handled the most recent event. `null` only on
+  a replica that has not yet processed an event.
+
+The `checkpoint-effectiveness` bench asserts
+`criticalCheckpointHits > 0` in its `afterAll`, so a regression that
+quietly stops using the checkpoint store fails the bench instead of
+just changing the wall-clock number.
+
 Scenarios:
 
 - `long-linear-history` — single-author append-only chain; exercises

--- a/packages/eg-walker/src/bench/checkpoint-effectiveness.bench.ts
+++ b/packages/eg-walker/src/bench/checkpoint-effectiveness.bench.ts
@@ -67,14 +67,21 @@ describe("checkpoint-effectiveness", () => {
 
 afterAll(() => {
   if (lastIncremental) {
-    console.info(
-      formatStatsLine(
-        summariseReplica(
-          "checkpoint-effectiveness",
-          events.length,
-          lastIncremental,
-        ),
-      ),
+    const summary = summariseReplica(
+      "checkpoint-effectiveness",
+      events.length,
+      lastIncremental,
     );
+    console.info(formatStatsLine(summary));
+    // The whole point of this bench is to exercise the partial-replay path
+    // via `CriticalCheckpointStore.pickFor`. A regression that quietly
+    // skipped the checkpoint store (or never produced a usable checkpoint)
+    // would still report sensible wall-clock times, so guard the diagnostic
+    // here: the trace must produce strictly positive checkpoint hits.
+    if (summary.criticalCheckpointHits <= 0) {
+      throw new Error(
+        `checkpoint-effectiveness bench expected criticalCheckpointHits > 0, got ${summary.criticalCheckpointHits}`,
+      );
+    }
   }
 });

--- a/packages/eg-walker/src/bench/traces.ts
+++ b/packages/eg-walker/src/bench/traces.ts
@@ -9,6 +9,7 @@
  */
 
 import { OPERATION_TYPE } from "../constants/operation-types";
+import type { ReplaySource } from "../constants/replay-source";
 import type { EgWalkerReplica } from "../core/replica";
 import type { EventId, GraphEvent } from "../types";
 
@@ -244,6 +245,10 @@ export interface BenchStatsSummary {
   readonly engineAdvances: number;
   readonly checkpointCount: number;
   readonly sequenceRecordCount: number;
+  readonly peakSequenceRecordCount: number;
+  readonly criticalCheckpointHits: number;
+  readonly criticalCheckpointMisses: number;
+  readonly lastReplaySource: ReplaySource | null;
 }
 
 /**
@@ -274,6 +279,10 @@ export const summariseReplica = (
     engineAdvances: stats.engineAdvances,
     checkpointCount: stats.checkpointCount,
     sequenceRecordCount: stats.sequenceRecordCount,
+    peakSequenceRecordCount: stats.peakSequenceRecordCount,
+    criticalCheckpointHits: stats.criticalCheckpointHits,
+    criticalCheckpointMisses: stats.criticalCheckpointMisses,
+    lastReplaySource: stats.lastReplaySource,
   };
 };
 
@@ -287,4 +296,8 @@ export const formatStatsLine = (summary: BenchStatsSummary): string =>
   ` retreats=${summary.engineRetreats}` +
   ` advances=${summary.engineAdvances}` +
   ` checkpoints=${summary.checkpointCount}` +
-  ` sequenceRecords=${summary.sequenceRecordCount}`;
+  ` sequenceRecords=${summary.sequenceRecordCount}` +
+  ` peakSequenceRecords=${summary.peakSequenceRecordCount}` +
+  ` checkpointHits=${summary.criticalCheckpointHits}` +
+  ` checkpointMisses=${summary.criticalCheckpointMisses}` +
+  ` lastReplaySource=${summary.lastReplaySource ?? "none"}`;

--- a/packages/eg-walker/src/constants/replay-source.ts
+++ b/packages/eg-walker/src/constants/replay-source.ts
@@ -1,0 +1,24 @@
+/**
+ * Source of the most recent replay performed by {@link EgWalkerReplica}.
+ *
+ * Const object with `as const` assertion (no TS enum) so callers see a
+ * narrow string-literal union and the value contributes nothing to bundle
+ * size beyond the string itself. Exposed via {@link EgWalkerReplica.getReplayStats}
+ * so benches and tests can correlate wall-clock measurements with the
+ * path that actually handled the last event.
+ *
+ * - `incremental` — engine state was a causal ancestor of the event's
+ *   parent, so only an advance was needed.
+ * - `partial` — divergent suffix was rebuilt from a critical-version
+ *   checkpoint (Section 3.5/3.6 of the paper).
+ * - `full` — no usable checkpoint dominated the divergence, so the entire
+ *   event graph was replayed from scratch (also the cold-start path on the
+ *   very first event).
+ */
+export const REPLAY_SOURCE = {
+  INCREMENTAL: "incremental",
+  PARTIAL: "partial",
+  FULL: "full",
+} as const;
+
+export type ReplaySource = (typeof REPLAY_SOURCE)[keyof typeof REPLAY_SOURCE];

--- a/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
+++ b/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
@@ -9,11 +9,32 @@ export type CriticalCheckpoint = ReplayCheckpoint;
 
 export class CriticalCheckpointStore {
   private checkpoints: ReadonlyArray<CriticalCheckpoint> = [];
+  private hitCount = 0;
+  private missCount = 0;
 
   constructor(private readonly analyzer: CriticalVersionAnalyzer) {}
 
   get count(): number {
     return this.checkpoints.length;
+  }
+
+  /**
+   * Cumulative count of {@link pickFor} calls that returned a usable
+   * checkpoint (i.e. a previously-recorded critical version dominated the
+   * graph's current frontier). Paired with {@link misses} to give benches
+   * a direct signal for partial-replay coverage on a given trace.
+   */
+  get hits(): number {
+    return this.hitCount;
+  }
+
+  /**
+   * Cumulative count of {@link pickFor} calls that returned `null`,
+   * forcing the caller (today: `EgWalkerReplica.advanceWithEvent`) into a
+   * full replay because no retained checkpoint dominated the divergence.
+   */
+  get misses(): number {
+    return this.missCount;
   }
 
   maybeAdvance(graph: EventGraph, document: string): void {
@@ -41,9 +62,11 @@ export class CriticalCheckpointStore {
         continue;
       }
       if (this.analyzer.isCritical(graph, candidate.version)) {
+        this.hitCount++;
         return candidate;
       }
     }
+    this.missCount++;
     return null;
   }
 

--- a/packages/eg-walker/src/core/replay-walker.ts
+++ b/packages/eg-walker/src/core/replay-walker.ts
@@ -23,6 +23,13 @@ export interface WalkResult {
    * to the full prepare/effect replay path.
    */
   readonly fullReplayCount: number;
+  /**
+   * High-water mark of the engine's live record count over the walk.
+   * Same semantics as {@link EngineStats.peakSequenceRecordCount} — the
+   * one-shot walker uses a single engine for its lifetime, so the engine
+   * peak and the walk peak coincide.
+   */
+  readonly peakSequenceRecordCount: number;
 }
 
 /**
@@ -59,6 +66,7 @@ export class ReplayWalker {
       advanceCount: generated.stats.advanceCount,
       nonConflictingRunCount: generated.stats.nonConflictingRunCount,
       fullReplayCount: generated.stats.fullReplayCount,
+      peakSequenceRecordCount: generated.stats.peakSequenceRecordCount,
     };
   }
 

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -8,6 +8,7 @@
  */
 
 import { OPERATION_TYPE } from "../constants/operation-types";
+import { REPLAY_SOURCE, type ReplaySource } from "../constants/replay-source";
 import type {
   ExternalOperation,
   DocumentState,
@@ -51,6 +52,7 @@ export class EgWalkerReplica {
   private fullReplayCount = 0;
   private partialReplayCount = 0;
   private incrementalApplyCount = 0;
+  private lastReplaySource: ReplaySource | null = null;
   private readonly criticalAnalyzer = new CriticalVersionAnalyzer();
   private readonly criticalCheckpoints = new CriticalCheckpointStore(
     this.criticalAnalyzer,
@@ -231,6 +233,10 @@ export class EgWalkerReplica {
     readonly engineAdvances: number;
     readonly checkpointCount: number;
     readonly sequenceRecordCount: number;
+    readonly peakSequenceRecordCount: number;
+    readonly criticalCheckpointHits: number;
+    readonly criticalCheckpointMisses: number;
+    readonly lastReplaySource: ReplaySource | null;
   } {
     const engineStats = this.engine?.getStats();
     return {
@@ -241,6 +247,10 @@ export class EgWalkerReplica {
       engineAdvances: engineStats?.advanceCount ?? 0,
       checkpointCount: this.criticalCheckpoints.count,
       sequenceRecordCount: engineStats?.sequenceRecordCount ?? 0,
+      peakSequenceRecordCount: engineStats?.peakSequenceRecordCount ?? 0,
+      criticalCheckpointHits: this.criticalCheckpoints.hits,
+      criticalCheckpointMisses: this.criticalCheckpoints.misses,
+      lastReplaySource: this.lastReplaySource,
     };
   }
 
@@ -356,6 +366,7 @@ export class EgWalkerReplica {
     this.currentVersion = this.eventGraph.getFrontier();
     this.engine = engine;
     this.fullReplayCount++;
+    this.lastReplaySource = REPLAY_SOURCE.FULL;
   }
 
   /**
@@ -385,6 +396,7 @@ export class EgWalkerReplica {
       this.document = this.engine.getText();
       this.currentVersion = this.eventGraph.getFrontier();
       this.incrementalApplyCount++;
+      this.lastReplaySource = REPLAY_SOURCE.INCREMENTAL;
       this.maybeAdvanceCheckpoint();
       return;
     }
@@ -435,6 +447,7 @@ export class EgWalkerReplica {
     this.document = result.text;
     this.currentVersion = frontier;
     this.partialReplayCount++;
+    this.lastReplaySource = REPLAY_SOURCE.PARTIAL;
   }
 
   private inferNextSequenceNumber(): number {

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -53,6 +53,15 @@ export class EgWalkerReplica {
   private partialReplayCount = 0;
   private incrementalApplyCount = 0;
   private lastReplaySource: ReplaySource | null = null;
+  /**
+   * Replica-lifetime high-water mark for the engine's
+   * `sequenceRecordCount`. The engine's own peak is engine-scoped and
+   * resets whenever a partial or full replay swaps in a fresh engine; we
+   * fold the outgoing engine's peak into this field before each swap so
+   * the value surfaced through {@link getReplayStats} stays monotonic
+   * across the replica's lifetime.
+   */
+  private replicaPeakSequenceRecordCount = 0;
   private readonly criticalAnalyzer = new CriticalVersionAnalyzer();
   private readonly criticalCheckpoints = new CriticalCheckpointStore(
     this.criticalAnalyzer,
@@ -224,6 +233,10 @@ export class EgWalkerReplica {
    *   top of existing engine state via retreat/advance.
    * - `engineRetreats` / `engineAdvances` are the cumulative engine counters,
    *   useful for proving replay work stays bounded to the divergent suffix.
+   * - `peakSequenceRecordCount` is monotonic across the replica's lifetime:
+   *   the engine's own peak resets on every partial/full replay engine swap,
+   *   so we max in {@link replicaPeakSequenceRecordCount} (the peak captured
+   *   from prior engines) here.
    */
   getReplayStats(): {
     readonly fullReplays: number;
@@ -247,7 +260,10 @@ export class EgWalkerReplica {
       engineAdvances: engineStats?.advanceCount ?? 0,
       checkpointCount: this.criticalCheckpoints.count,
       sequenceRecordCount: engineStats?.sequenceRecordCount ?? 0,
-      peakSequenceRecordCount: engineStats?.peakSequenceRecordCount ?? 0,
+      peakSequenceRecordCount: Math.max(
+        this.replicaPeakSequenceRecordCount,
+        engineStats?.peakSequenceRecordCount ?? 0,
+      ),
       criticalCheckpointHits: this.criticalCheckpoints.hits,
       criticalCheckpointMisses: this.criticalCheckpoints.misses,
       lastReplaySource: this.lastReplaySource,
@@ -357,6 +373,7 @@ export class EgWalkerReplica {
     // retreat/advance round-trip across an interleaved Kahn order. The
     // columnar codec keeps using {@link EventGraph.getTopologicalOrder}
     // (Kahn) so persisted on-disk bytes stay stable.
+    this.captureEnginePeakBeforeSwap();
     const sortedEvents = this.eventGraph.getBranchPreservingTopologicalOrder();
     const engine = new EgWalkerEngine();
     const generated = engine.generate(sortedEvents, this.initialText, {
@@ -367,6 +384,24 @@ export class EgWalkerReplica {
     this.engine = engine;
     this.fullReplayCount++;
     this.lastReplaySource = REPLAY_SOURCE.FULL;
+  }
+
+  /**
+   * Fold the outgoing engine's `peakSequenceRecordCount` into the
+   * replica-lifetime peak. Must be called before any code path that
+   * replaces {@link engine} with a fresh instance (see {@link fullReplay}
+   * and {@link partialReplayFromCheckpoint}); otherwise the transient
+   * pressure observed during a heavy concurrent merge would silently
+   * disappear from {@link getReplayStats} after the rebuild.
+   */
+  private captureEnginePeakBeforeSwap(): void {
+    if (!this.engine) {
+      return;
+    }
+    const enginePeak = this.engine.getStats().peakSequenceRecordCount;
+    if (enginePeak > this.replicaPeakSequenceRecordCount) {
+      this.replicaPeakSequenceRecordCount = enginePeak;
+    }
   }
 
   /**
@@ -437,6 +472,7 @@ export class EgWalkerReplica {
   }
 
   private partialReplayFromCheckpoint(checkpoint: CriticalCheckpoint): void {
+    this.captureEnginePeakBeforeSwap();
     const frontier = this.eventGraph.getFrontier();
     const result = this.partialReplayer.replayFromCheckpoint(
       this.eventGraph,

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -67,6 +67,7 @@ export class EgWalkerEngine {
   private advanceCount = 0;
   private nonConflictingRunCount = 0;
   private fullReplayCount = 0;
+  private peakSequenceRecordCount = 0;
   private placeholderCounter = 0;
 
   generate(
@@ -100,6 +101,7 @@ export class EgWalkerEngine {
         nonConflictingRunCount: this.nonConflictingRunCount,
         fullReplayCount: this.fullReplayCount,
         sequenceRecordCount: this.itemsById.size,
+        peakSequenceRecordCount: this.peakSequenceRecordCount,
       },
     };
   }
@@ -154,6 +156,7 @@ export class EgWalkerEngine {
       nonConflictingRunCount: this.nonConflictingRunCount,
       fullReplayCount: this.fullReplayCount,
       sequenceRecordCount: this.itemsById.size,
+      peakSequenceRecordCount: this.peakSequenceRecordCount,
     };
   }
 
@@ -175,6 +178,7 @@ export class EgWalkerEngine {
       const transformed = this.apply(event);
       this.currentVersion = new Set([event.id]);
       this.nonConflictingRunCount++;
+      this.samplePeakSequenceRecordCount();
       return transformed;
     }
 
@@ -193,7 +197,22 @@ export class EgWalkerEngine {
     const transformed = this.apply(event);
     this.currentVersion = new Set([event.id]);
     this.fullReplayCount++;
+    this.samplePeakSequenceRecordCount();
     return transformed;
+  }
+
+  /**
+   * Update the high-water mark for {@link sequenceRecordCount}. Sampling
+   * after each `apply` (and after the initial-text placeholder seed in
+   * `reset`) is sufficient: every record creation goes through `apply` or
+   * the placeholder seed path, and the post-apply sample captures any
+   * mid-apply growth that splits/inserts produced.
+   */
+  private samplePeakSequenceRecordCount(): void {
+    const live = this.itemsById.size;
+    if (live > this.peakSequenceRecordCount) {
+      this.peakSequenceRecordCount = live;
+    }
   }
 
   /**
@@ -240,6 +259,7 @@ export class EgWalkerEngine {
     this.advanceCount = 0;
     this.nonConflictingRunCount = 0;
     this.fullReplayCount = 0;
+    this.peakSequenceRecordCount = 0;
     this.placeholderCounter = 0;
 
     const graphEvents = options.eventGraph?.getTopologicalOrder() ?? events;
@@ -282,6 +302,7 @@ export class EgWalkerEngine {
     };
     this.sequence.push(placeholder);
     this.itemsById.set(placeholder.id, placeholder);
+    this.samplePeakSequenceRecordCount();
   }
 
   private nextPlaceholderId(): EventId {

--- a/packages/eg-walker/src/engine/internals/engine-types.ts
+++ b/packages/eg-walker/src/engine/internals/engine-types.ts
@@ -85,6 +85,15 @@ export interface EngineStats {
    * a slowdown.
    */
   readonly sequenceRecordCount: number;
+  /**
+   * High-water mark of {@link sequenceRecordCount} across the engine's
+   * lifetime. Sampled after each `apply` (and after the initial-text
+   * placeholder is seeded in `reset`). Useful for benchmarks because the
+   * steady-state `sequenceRecordCount` can hide transient pressure during a
+   * heavy concurrent merge — the peak surfaces that pressure even when
+   * later deletes/coalescing have shrunk the live record set.
+   */
+  readonly peakSequenceRecordCount: number;
 }
 
 export interface GenerateOptions {

--- a/packages/eg-walker/src/engine/internals/engine-types.ts
+++ b/packages/eg-walker/src/engine/internals/engine-types.ts
@@ -86,12 +86,18 @@ export interface EngineStats {
    */
   readonly sequenceRecordCount: number;
   /**
-   * High-water mark of {@link sequenceRecordCount} across the engine's
-   * lifetime. Sampled after each `apply` (and after the initial-text
-   * placeholder is seeded in `reset`). Useful for benchmarks because the
-   * steady-state `sequenceRecordCount` can hide transient pressure during a
-   * heavy concurrent merge — the peak surfaces that pressure even when
-   * later deletes/coalescing have shrunk the live record set.
+   * High-water mark of {@link sequenceRecordCount} across **this engine
+   * instance's** lifetime. Sampled after each `apply` (and after the
+   * initial-text placeholder is seeded in `reset`). Useful for benchmarks
+   * because the steady-state `sequenceRecordCount` can hide transient
+   * pressure during a heavy concurrent merge — the peak surfaces that
+   * pressure even when later deletes/coalescing have shrunk the live
+   * record set.
+   *
+   * Note: this peak resets on `reset`, so any caller that swaps engines
+   * (e.g. {@link EgWalkerReplica} during partial/full replay) must fold
+   * the outgoing engine's peak into its own monotonic counter before the
+   * swap if it wants a lifetime-of-replica figure.
    */
   readonly peakSequenceRecordCount: number;
 }

--- a/packages/eg-walker/src/index.ts
+++ b/packages/eg-walker/src/index.ts
@@ -12,5 +12,7 @@ export { ReplayWalker } from "./core/replay-walker";
 export type { WalkerConfig, WalkResult } from "./core/replay-walker";
 export { EventGraph } from "./graph/event-graph";
 export { OPERATION_TYPE } from "./constants/operation-types";
+export { REPLAY_SOURCE } from "./constants/replay-source";
+export type { ReplaySource } from "./constants/replay-source";
 
 export * from "./types";

--- a/packages/eg-walker/src/test/eg-walker-engine.test.ts
+++ b/packages/eg-walker/src/test/eg-walker-engine.test.ts
@@ -283,6 +283,10 @@ describe("ReplayWalker", () => {
       advanceCount: 0,
       nonConflictingRunCount: 0,
       fullReplayCount: 0,
+      // The engine seeds the initial-text placeholder during `reset` and
+      // samples the peak right after, so even an empty event list reports
+      // 1 live record.
+      peakSequenceRecordCount: 1,
     });
     expect(walker.getPrepareVersion()).toEqual(new Set());
     expect(walker.getEffectVersion()).toEqual(new Set());

--- a/packages/eg-walker/src/test/replay-stats.test.ts
+++ b/packages/eg-walker/src/test/replay-stats.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { OPERATION_TYPE } from "../constants/operation-types";
 import { REPLAY_SOURCE } from "../constants/replay-source";
 import { EgWalkerReplica } from "../core/replica";
+import { EventGraph } from "../graph/event-graph";
 import type { GraphEvent } from "../types";
 
 const buildLinearHistory = (count: number): GraphEvent[] => {
@@ -188,6 +189,21 @@ describe("EgWalkerReplica replay stats — new diagnostic fields", () => {
         timestamp: 1,
       });
       expect(api.getReplayStats().lastReplaySource).toBe(REPLAY_SOURCE.FULL);
+    });
+
+    it("is 'full' when the constructor adopts a prebuilt graph with events", () => {
+      // The constructor calls `fullReplay()` directly when handed an event
+      // graph that already has events, bypassing `advanceWithEvent`. That
+      // path is distinct from the cold-start `applyRemoteEvent` route and
+      // needs its own guard so a future refactor doesn't leave
+      // `lastReplaySource` null after a deserialize round-trip.
+      const prebuilt = new EventGraph();
+      for (const event of buildLinearHistory(3)) {
+        prebuilt.addEvent(event);
+      }
+      const api = new EgWalkerReplica("r1", "", prebuilt);
+      expect(api.getReplayStats().lastReplaySource).toBe(REPLAY_SOURCE.FULL);
+      expect(api.getReplayStats().fullReplays).toBe(1);
     });
 
     it("transitions through full → incremental → partial → full across a known sequence", () => {

--- a/packages/eg-walker/src/test/replay-stats.test.ts
+++ b/packages/eg-walker/src/test/replay-stats.test.ts
@@ -250,11 +250,13 @@ describe("EgWalkerReplica replay stats — new diagnostic fields", () => {
 
     it("only contains the documented string-literal values", () => {
       // Cheap structural check guarding against accidental enum-shape drift.
-      expect(Object.values(REPLAY_SOURCE)).toEqual([
-        "incremental",
-        "partial",
-        "full",
-      ]);
+      // Use `arrayContaining` + length so re-ordering the const object
+      // doesn't break the test for reasons unrelated to the contract.
+      const values = Object.values(REPLAY_SOURCE);
+      expect(values).toHaveLength(3);
+      expect(values).toEqual(
+        expect.arrayContaining(["incremental", "partial", "full"]),
+      );
     });
   });
 });

--- a/packages/eg-walker/src/test/replay-stats.test.ts
+++ b/packages/eg-walker/src/test/replay-stats.test.ts
@@ -65,6 +65,41 @@ describe("EgWalkerReplica replay stats — new diagnostic fields", () => {
         peakAfterSplit,
       );
     });
+
+    it("persists across partial-replay engine swaps", () => {
+      // `partialReplayFromCheckpoint` swaps in a fresh engine whose
+      // engine-local peak starts at zero. The replica must fold the
+      // outgoing engine's peak into its own monotonic counter, otherwise
+      // the value surfaced here would silently regress after the rebuild.
+      const api = new EgWalkerReplica("r1", "a".repeat(200));
+      // Spike the engine peak by splitting the seeded placeholder with a
+      // concurrent insert.
+      api.applyRemoteEvent({
+        id: "alice:0",
+        parentVersion: new Set(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 100, text: "Z" },
+        timestamp: 1,
+      });
+      const peakBefore = api.getReplayStats().peakSequenceRecordCount;
+      expect(peakBefore).toBeGreaterThan(0);
+
+      // Local edit advances the engine past alice:0 so the next remote
+      // event is concurrent with engine state, forcing a retreat.
+      api.insert(api.getText().length, "L");
+
+      // Concurrent remote rooted at alice:0 (parallel to the local L)
+      // routes through `partialReplayFromCheckpoint`, swapping engines.
+      api.applyRemoteEvent({
+        id: "bob:0",
+        parentVersion: new Set(["alice:0"]),
+        operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "!" },
+        timestamp: 2,
+      });
+
+      const after = api.getReplayStats();
+      expect(after.lastReplaySource).toBe(REPLAY_SOURCE.PARTIAL);
+      expect(after.peakSequenceRecordCount).toBeGreaterThanOrEqual(peakBefore);
+    });
   });
 
   describe("criticalCheckpointHits / criticalCheckpointMisses", () => {

--- a/packages/eg-walker/src/test/replay-stats.test.ts
+++ b/packages/eg-walker/src/test/replay-stats.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+import { OPERATION_TYPE } from "../constants/operation-types";
+import { REPLAY_SOURCE } from "../constants/replay-source";
+import { EgWalkerReplica } from "../core/replica";
+import type { GraphEvent } from "../types";
+
+const buildLinearHistory = (count: number): GraphEvent[] => {
+  const events: GraphEvent[] = [];
+  let parent: ReadonlySet<string> = new Set();
+  for (let i = 0; i < count; i++) {
+    const event: GraphEvent = {
+      id: `alice:${i}`,
+      parentVersion: parent,
+      operation: { type: OPERATION_TYPE.INSERT, index: i, text: "x" },
+      timestamp: i,
+    };
+    events.push(event);
+    parent = new Set([event.id]);
+  }
+  return events;
+};
+
+describe("EgWalkerReplica replay stats — new diagnostic fields", () => {
+  describe("peakSequenceRecordCount", () => {
+    it("starts at zero before any event is applied", () => {
+      const api = new EgWalkerReplica("r1");
+      expect(api.getReplayStats().peakSequenceRecordCount).toBe(0);
+    });
+
+    it("is at least as large as the live sequenceRecordCount", () => {
+      const api = new EgWalkerReplica("r1", "seed text");
+      for (const event of buildLinearHistory(20)) {
+        api.applyRemoteEvent(event);
+      }
+      const stats = api.getReplayStats();
+      expect(stats.peakSequenceRecordCount).toBeGreaterThanOrEqual(
+        stats.sequenceRecordCount,
+      );
+    });
+
+    it("retains the high-water mark after deletes shrink the live record set", () => {
+      // Force a concurrent insert into a long seeded placeholder so the
+      // placeholder splits (live records spike), then delete-heavy work
+      // collapses the visible text without the engine resetting. The peak
+      // must remember the spike even after the live count comes back down.
+      const api = new EgWalkerReplica("r1", "a".repeat(200));
+      api.applyRemoteEvent({
+        id: "bob:0",
+        parentVersion: new Set(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 100, text: "Z" },
+        timestamp: 1,
+      });
+      const afterSplit = api.getReplayStats();
+      expect(afterSplit.peakSequenceRecordCount).toBeGreaterThanOrEqual(
+        afterSplit.sequenceRecordCount,
+      );
+      const peakAfterSplit = afterSplit.peakSequenceRecordCount;
+
+      // A local single-character append shouldn't push the peak down even
+      // though the engine carries on.
+      api.insert(api.getText().length, "!");
+      const afterAppend = api.getReplayStats();
+      expect(afterAppend.peakSequenceRecordCount).toBeGreaterThanOrEqual(
+        peakAfterSplit,
+      );
+    });
+  });
+
+  describe("criticalCheckpointHits / criticalCheckpointMisses", () => {
+    it("are both zero before any divergent event triggers pickFor", () => {
+      const api = new EgWalkerReplica("r1");
+      for (const event of buildLinearHistory(10)) {
+        api.applyRemoteEvent(event);
+      }
+      // A purely linear history runs through `canIncrementallyAdvance`
+      // and never asks the checkpoint store for a starting point.
+      const stats = api.getReplayStats();
+      expect(stats.criticalCheckpointHits).toBe(0);
+      expect(stats.criticalCheckpointMisses).toBe(0);
+    });
+
+    it("increments hits when a checkpoint dominates the divergent suffix", () => {
+      const api = new EgWalkerReplica("r1");
+      const linear = buildLinearHistory(20);
+      for (const event of linear) {
+        api.applyRemoteEvent(event);
+      }
+      const tail = linear[linear.length - 1]!;
+
+      // Local edit on the tail, then a concurrent remote rooted at the
+      // same tail — forces `partialReplayFromCheckpoint`, which goes
+      // through `pickFor` and resolves to the tail checkpoint.
+      api.insert(api.getText().length, "L");
+      const before = api.getReplayStats();
+      api.applyRemoteEvent({
+        id: "bob:0",
+        parentVersion: new Set([tail.id]),
+        operation: {
+          type: OPERATION_TYPE.INSERT,
+          index: linear.length,
+          text: "R",
+        },
+        timestamp: linear.length + 1,
+      });
+      const after = api.getReplayStats();
+      expect(after.criticalCheckpointHits).toBe(
+        before.criticalCheckpointHits + 1,
+      );
+      expect(after.criticalCheckpointMisses).toBe(
+        before.criticalCheckpointMisses,
+      );
+    });
+
+    it("increments misses when the merge has no dominating critical version", () => {
+      const api = new EgWalkerReplica("r1");
+      api.applyRemoteEvent({
+        id: "alice:0",
+        parentVersion: new Set(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
+        timestamp: 1,
+      });
+      const before = api.getReplayStats();
+      // Concurrent root insert: no shared critical ancestor exists, so
+      // pickFor returns null and the replica falls back to full replay.
+      api.applyRemoteEvent({
+        id: "bob:0",
+        parentVersion: new Set(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "B" },
+        timestamp: 2,
+      });
+      const after = api.getReplayStats();
+      expect(after.criticalCheckpointMisses).toBe(
+        before.criticalCheckpointMisses + 1,
+      );
+      expect(after.criticalCheckpointHits).toBe(before.criticalCheckpointHits);
+      expect(after.fullReplays).toBe(before.fullReplays + 1);
+    });
+  });
+
+  describe("lastReplaySource", () => {
+    it("is null on a fresh replica with no events", () => {
+      const api = new EgWalkerReplica("r1");
+      expect(api.getReplayStats().lastReplaySource).toBeNull();
+    });
+
+    it("is 'full' immediately after the cold-start replay", () => {
+      const api = new EgWalkerReplica("r1");
+      api.applyRemoteEvent({
+        id: "alice:0",
+        parentVersion: new Set(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
+        timestamp: 1,
+      });
+      expect(api.getReplayStats().lastReplaySource).toBe(REPLAY_SOURCE.FULL);
+    });
+
+    it("transitions through full → incremental → partial → full across a known sequence", () => {
+      const api = new EgWalkerReplica("r1");
+      const linear = buildLinearHistory(5);
+      api.applyRemoteEvent(linear[0]!);
+      expect(api.getReplayStats().lastReplaySource).toBe(REPLAY_SOURCE.FULL);
+
+      for (let i = 1; i < linear.length; i++) {
+        api.applyRemoteEvent(linear[i]!);
+      }
+      // Linear extension keeps `canIncrementallyAdvance` true, so the
+      // most recent source is incremental.
+      expect(api.getReplayStats().lastReplaySource).toBe(
+        REPLAY_SOURCE.INCREMENTAL,
+      );
+
+      // Force partial replay by injecting a concurrent sibling off the
+      // shared tail after a local edit advances the engine past it.
+      const tail = linear[linear.length - 1]!;
+      api.insert(api.getText().length, "L");
+      api.applyRemoteEvent({
+        id: "bob:0",
+        parentVersion: new Set([tail.id]),
+        operation: {
+          type: OPERATION_TYPE.INSERT,
+          index: linear.length,
+          text: "R",
+        },
+        timestamp: linear.length + 1,
+      });
+      expect(api.getReplayStats().lastReplaySource).toBe(REPLAY_SOURCE.PARTIAL);
+
+      // Force full replay by introducing a concurrent root with no
+      // critical-version ancestor.
+      api.applyRemoteEvent({
+        id: "carol:0",
+        parentVersion: new Set(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "C" },
+        timestamp: 999,
+      });
+      expect(api.getReplayStats().lastReplaySource).toBe(REPLAY_SOURCE.FULL);
+    });
+
+    it("only contains the documented string-literal values", () => {
+      // Cheap structural check guarding against accidental enum-shape drift.
+      expect(Object.values(REPLAY_SOURCE)).toEqual([
+        "incremental",
+        "partial",
+        "full",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #723. Extends `getReplayStats()` with three diagnostic fields aimed at benches and tests, without touching the public operation API.

- `peakSequenceRecordCount` — high-water mark of the ranked B-tree's live record count. Survives later deletes/coalescing, so transient pressure during a concurrent merge stays visible.
- `criticalCheckpointHits` / `criticalCheckpointMisses` — outcomes of `CriticalCheckpointStore.pickFor`. A miss means no retained critical version dominated the divergence and the replica had to full-replay.
- `lastReplaySource` — `"incremental" | "partial" | "full" | null`, sourced from a const object `REPLAY_SOURCE` (no TS enum per project rule). Tells benches which of the three paths in `EgWalkerReplica.advanceWithEvent` handled the most recent event.

Per the original plan, the work is split into one commit per TODO item:

1. `peakSequenceRecordCount` tracked in engine
2. `CriticalCheckpointStore` hits/misses
3. `REPLAY_SOURCE` const object + `lastReplaySource` wiring + new fields exposed via `getReplayStats`
4. 10 unit tests in `src/test/replay-stats.test.ts`
5. Bench output includes new fields; `checkpoint-effectiveness` asserts `criticalCheckpointHits > 0`
6. CLAUDE.md Benchmarks section documents each field

## Test plan

- [x] `pnpm --filter @softmaple/eg-walker test -- --run` — 286 / 286 pass
- [x] `pnpm --filter @softmaple/eg-walker typecheck`
- [x] `pnpm --filter @softmaple/eg-walker build`
- [x] `pnpm --filter @softmaple/eg-walker lint`
- [x] `pnpm --filter @softmaple/eg-walker bench` — new fields show up in every stats line, e.g. `[bench:checkpoint-effectiveness] … peakSequenceRecords=21 checkpointHits=19 checkpointMisses=0 lastReplaySource=partial`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added replay source tracking to identify which replay strategy was last used (incremental, partial, or full).
  * Added checkpoint hit/miss diagnostic counters to measure checkpoint store effectiveness.
  * Added peak sequence record count tracking for memory monitoring.

* **Tests**
  * Added comprehensive test suite for replay statistics and diagnostics.

* **Documentation**
  * Updated documentation for extended diagnostic metrics output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->