### PR TITLE
test(packages/awareness): add textarea selection mapping coverage

### DIFF
--- a/packages/awareness/src/hooks/index.ts
+++ b/packages/awareness/src/hooks/index.ts
@@ -1,4 +1,9 @@
 export {
+  mapTextareaSelectionThroughOperation,
+  type TextareaSelection,
+  type TextareaSelectionDirection,
+} from "./textarea-selection-sync";
+export {
   useActivityByType,
   useRecentActivity,
   useUserActivity,

--- a/packages/awareness/src/hooks/textarea-selection-sync.test.ts
+++ b/packages/awareness/src/hooks/textarea-selection-sync.test.ts
@@ -62,11 +62,11 @@ describe("mapTextareaSelectionThroughOperation", () => {
     expect(mapped).toEqual({
       selectionStart: 3,
       selectionEnd: 3,
-      selectionDirection: "forward",
+      selectionDirection: "none",
     });
   });
 
-  it("preserves backward selection direction while normalising offsets", () => {
+  it("preserves backward selection direction for a non-collapsed mapped selection", () => {
     const mapped = mapTextareaSelectionThroughOperation(
       {
         selectionStart: 4,
@@ -84,6 +84,48 @@ describe("mapTextareaSelectionThroughOperation", () => {
       selectionStart: 4,
       selectionEnd: 12,
       selectionDirection: "backward",
+    });
+  });
+
+  it("keeps a remote insert at the trailing boundary outside the selection", () => {
+    const mapped = mapTextareaSelectionThroughOperation(
+      {
+        selectionStart: 2,
+        selectionEnd: 6,
+        selectionDirection: "forward",
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Insert,
+        index: 6,
+        length: 3,
+      },
+    );
+
+    expect(mapped).toEqual({
+      selectionStart: 2,
+      selectionEnd: 6,
+      selectionDirection: "forward",
+    });
+  });
+
+  it("shrinks a selection when a remote delete lands inside it", () => {
+    const mapped = mapTextareaSelectionThroughOperation(
+      {
+        selectionStart: 2,
+        selectionEnd: 10,
+        selectionDirection: "forward",
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Delete,
+        index: 5,
+        length: 3,
+      },
+    );
+
+    expect(mapped).toEqual({
+      selectionStart: 2,
+      selectionEnd: 7,
+      selectionDirection: "forward",
     });
   });
 

--- a/packages/awareness/src/hooks/textarea-selection-sync.test.ts
+++ b/packages/awareness/src/hooks/textarea-selection-sync.test.ts
@@ -45,6 +45,27 @@ describe("mapTextareaSelectionThroughOperation", () => {
     });
   });
 
+  it("leaves a cursor at the remote delete index unchanged", () => {
+    const mapped = mapTextareaSelectionThroughOperation(
+      {
+        selectionStart: 5,
+        selectionEnd: 5,
+        selectionDirection: "none",
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Delete,
+        index: 5,
+        length: 3,
+      },
+    );
+
+    expect(mapped).toEqual({
+      selectionStart: 5,
+      selectionEnd: 5,
+      selectionDirection: "none",
+    });
+  });
+
   it("collapses a selection covered by a remote delete", () => {
     const mapped = mapTextareaSelectionThroughOperation(
       {

--- a/packages/awareness/src/hooks/textarea-selection-sync.test.ts
+++ b/packages/awareness/src/hooks/textarea-selection-sync.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { POSITION_OPERATION_TYPE } from "../mapping/position-operation";
+import { mapTextareaSelectionThroughOperation } from "./textarea-selection-sync";
+
+describe("mapTextareaSelectionThroughOperation", () => {
+  it("remaps a cursor forward when a remote insert lands before it", () => {
+    const mapped = mapTextareaSelectionThroughOperation(
+      {
+        selectionStart: 6,
+        selectionEnd: 6,
+        selectionDirection: "none",
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Insert,
+        index: 2,
+        length: 4,
+      },
+    );
+
+    expect(mapped).toEqual({
+      selectionStart: 10,
+      selectionEnd: 10,
+      selectionDirection: "none",
+    });
+  });
+
+  it("remaps a cursor backward when a remote delete lands before it", () => {
+    const mapped = mapTextareaSelectionThroughOperation(
+      {
+        selectionStart: 10,
+        selectionEnd: 10,
+        selectionDirection: "none",
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Delete,
+        index: 2,
+        length: 4,
+      },
+    );
+
+    expect(mapped).toEqual({
+      selectionStart: 6,
+      selectionEnd: 6,
+      selectionDirection: "none",
+    });
+  });
+
+  it("collapses a selection covered by a remote delete", () => {
+    const mapped = mapTextareaSelectionThroughOperation(
+      {
+        selectionStart: 4,
+        selectionEnd: 8,
+        selectionDirection: "forward",
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Delete,
+        index: 3,
+        length: 8,
+      },
+    );
+
+    expect(mapped).toEqual({
+      selectionStart: 3,
+      selectionEnd: 3,
+      selectionDirection: "forward",
+    });
+  });
+
+  it("preserves backward selection direction while normalising offsets", () => {
+    const mapped = mapTextareaSelectionThroughOperation(
+      {
+        selectionStart: 4,
+        selectionEnd: 9,
+        selectionDirection: "backward",
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Insert,
+        index: 6,
+        length: 3,
+      },
+    );
+
+    expect(mapped).toEqual({
+      selectionStart: 4,
+      selectionEnd: 12,
+      selectionDirection: "backward",
+    });
+  });
+
+  it("defaults missing textarea direction to none", () => {
+    const mapped = mapTextareaSelectionThroughOperation(
+      {
+        selectionStart: 1,
+        selectionEnd: 1,
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Insert,
+        index: 0,
+        length: 2,
+      },
+    );
+
+    expect(mapped.selectionDirection).toBe("none");
+  });
+});

--- a/packages/awareness/src/hooks/textarea-selection-sync.ts
+++ b/packages/awareness/src/hooks/textarea-selection-sync.ts
@@ -1,0 +1,36 @@
+import { mapSelectionThroughOperation } from "../mapping/map-selection";
+import type { PositionOperation } from "../mapping/position-operation";
+
+export type TextareaSelectionDirection = "forward" | "backward" | "none";
+
+export type TextareaSelection = {
+  readonly selectionStart: number;
+  readonly selectionEnd: number;
+  readonly selectionDirection?: TextareaSelectionDirection;
+};
+
+/**
+ * Map a textarea's local selection through a remote text operation.
+ *
+ * This helper is DOM-independent so the textarea hook can keep browser wiring
+ * small while sharing the same operation-based selection behavior as other
+ * awareness consumers.
+ */
+export const mapTextareaSelectionThroughOperation = (
+  selection: TextareaSelection,
+  operation: PositionOperation,
+): Required<TextareaSelection> => {
+  const mapped = mapSelectionThroughOperation(
+    {
+      from: selection.selectionStart,
+      to: selection.selectionEnd,
+    },
+    operation,
+  );
+
+  return {
+    selectionStart: mapped.from,
+    selectionEnd: mapped.to,
+    selectionDirection: selection.selectionDirection ?? "none",
+  };
+};

--- a/packages/awareness/src/hooks/textarea-selection-sync.ts
+++ b/packages/awareness/src/hooks/textarea-selection-sync.ts
@@ -14,7 +14,8 @@ export type TextareaSelection = {
  *
  * This helper is DOM-independent so the textarea hook can keep browser wiring
  * small while sharing the same operation-based selection behavior as other
- * awareness consumers.
+ * awareness consumers. Collapsed results clear direction because there is no
+ * longer a meaningful anchor/head orientation.
  */
 export const mapTextareaSelectionThroughOperation = (
   selection: TextareaSelection,
@@ -31,6 +32,9 @@ export const mapTextareaSelectionThroughOperation = (
   return {
     selectionStart: mapped.from,
     selectionEnd: mapped.to,
-    selectionDirection: selection.selectionDirection ?? "none",
+    selectionDirection:
+      mapped.from === mapped.to
+        ? "none"
+        : (selection.selectionDirection ?? "none"),
   };
 };

--- a/packages/awareness/src/index.ts
+++ b/packages/awareness/src/index.ts
@@ -52,7 +52,10 @@ export {
   usePresenceLayerOffset,
 } from "./components";
 export {
+  mapTextareaSelectionThroughOperation,
   type PeerCursor,
+  type TextareaSelection,
+  type TextareaSelectionDirection,
   type UsePeerCursorsOptions,
   type UsePeersInBlockOptions,
   useActivityByType,

--- a/packages/awareness/src/index.ts
+++ b/packages/awareness/src/index.ts
@@ -52,10 +52,7 @@ export {
   usePresenceLayerOffset,
 } from "./components";
 export {
-  mapTextareaSelectionThroughOperation,
   type PeerCursor,
-  type TextareaSelection,
-  type TextareaSelectionDirection,
   type UsePeerCursorsOptions,
   type UsePeersInBlockOptions,
   useActivityByType,

--- a/packages/awareness/src/mapping/map-selection.test.ts
+++ b/packages/awareness/src/mapping/map-selection.test.ts
@@ -128,7 +128,7 @@ describe("mapSelectionThroughOperation: delete", () => {
     });
   });
 
-  it("collapses a selection fully covered by a deletion to the deletion start", () => {
+  it("collapses a selection whose endpoints extend past the deletion edges", () => {
     expect(
       mapSelectionThroughOperation({ from: 5, to: 9 }, deleteAt(3, 10)),
     ).toEqual({

--- a/packages/awareness/src/mapping/map-selection.test.ts
+++ b/packages/awareness/src/mapping/map-selection.test.ts
@@ -127,6 +127,15 @@ describe("mapSelectionThroughOperation: delete", () => {
       to: 8,
     });
   });
+
+  it("collapses a selection fully covered by a deletion to the deletion start", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 5, to: 9 }, deleteAt(3, 10)),
+    ).toEqual({
+      from: 3,
+      to: 3,
+    });
+  });
 });
 
 describe("mapSelectionThroughOperation: invariants", () => {
@@ -147,6 +156,12 @@ describe("mapSelectionThroughOperation: invariants", () => {
     expect(
       mapSelectionThroughOperation({ from: 9, to: 3 }, insertAt(5, 2)),
     ).toEqual({ from: 3, to: 11 });
+  });
+
+  it("normalises reversed input before mapping a delete overlap", () => {
+    expect(
+      mapSelectionThroughOperation({ from: 9, to: 3 }, deleteAt(5, 2)),
+    ).toEqual({ from: 3, to: 7 });
   });
 
   it("maps equivalent forward and reversed ranges identically at insert boundaries", () => {


### PR DESCRIPTION
Closes #738

## Summary

- Add a DOM-independent `mapTextareaSelectionThroughOperation` helper in `@softmaple/awareness/hooks` that wraps `mapSelectionThroughOperation` and translates between `{from, to}` and textarea-style `{selectionStart, selectionEnd, selectionDirection}`.
- Clear `selectionDirection` to `"none"` when a remote operation collapses the mapped range (no meaningful anchor/head orientation).
- Add 8 vitest cases covering insert-before-cursor, delete-before-cursor, cursor-at-delete-index, full-cover delete, trailing-boundary insert, interior delete, backward-direction passthrough, and direction default.
- Add 2 `map-selection.test.ts` cases for delete fully covering a selection and reversed-input delete overlap.
- Export the helper and types from the hooks barrel only; intentionally not added to the package root so the textarea-shaped public API does not pin a DOM type before editor bindings move under `bindings/<editor>` (issue B2).

## Why

Issue #738 asks for focused awareness cursor/selection mapping and textarea selection sync coverage before the later collaboration-layer hook and playground refactors. Keeping the helper here avoids importing `@softmaple/eg-walker` or duplicating playground-specific logic.

## Validation

- `pnpm --filter @softmaple/awareness test -- --run`
- `pnpm --filter @softmaple/awareness typecheck`
- `pnpm --filter @softmaple/awareness build`
- `pnpm --filter @softmaple/awareness check`