### PR TITLE
feat(packages/awareness): add textarea selection sync hook

### DIFF
--- a/packages/awareness/package.json
+++ b/packages/awareness/package.json
@@ -142,6 +142,10 @@
     "./hooks/use-peers-in-block": {
       "types": "./dist/hooks/use-peers-in-block.d.ts",
       "import": "./dist/hooks/use-peers-in-block.js"
+    },
+    "./hooks/use-textarea-selection-sync": {
+      "types": "./dist/hooks/use-textarea-selection-sync.d.ts",
+      "import": "./dist/hooks/use-textarea-selection-sync.js"
     }
   },
   "files": [

--- a/packages/awareness/src/hooks/index.ts
+++ b/packages/awareness/src/hooks/index.ts
@@ -27,6 +27,10 @@ export {
 } from "./use-presence-cursors";
 export { useSelf, useSelfSelector } from "./use-self";
 export {
+  type UseTextareaSelectionSyncResult,
+  useTextareaSelectionSync,
+} from "./use-textarea-selection-sync";
+export {
   useUpdateCursor,
   useUpdatePresence,
   useUpdateSelection,

--- a/packages/awareness/src/hooks/use-textarea-selection-sync.test.tsx
+++ b/packages/awareness/src/hooks/use-textarea-selection-sync.test.tsx
@@ -1,6 +1,6 @@
 import { act, type JSX, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { POSITION_OPERATION_TYPE } from "../mapping/position-operation";
 import {
   type UseTextareaSelectionSyncResult,
@@ -10,11 +10,13 @@ import {
 const reactActGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
+const previousReactActEnvironment = reactActGlobal.IS_REACT_ACT_ENVIRONMENT;
 reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true;
 
 type Harness = {
   readonly getApi: () => UseTextareaSelectionSyncResult;
   readonly getTextarea: () => HTMLTextAreaElement;
+  readonly rerender: () => void;
   readonly setValue: (value: string) => void;
   readonly unmount: () => void;
 };
@@ -29,14 +31,28 @@ const renderHarness = (initialValue: string): Harness => {
   const setValueRef: { current: ((value: string) => void) | null } = {
     current: null,
   };
+  const rerenderRef: { current: (() => void) | null } = {
+    current: null,
+  };
 
   const HarnessComponent = (): JSX.Element => {
     const [value, setValue] = useState(initialValue);
+    const [renderVersion, setRenderVersion] = useState(0);
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
     apiRef.current = useTextareaSelectionSync(textareaRef);
     setValueRef.current = setValue;
+    rerenderRef.current = () => {
+      setRenderVersion((version) => version + 1);
+    };
 
-    return <textarea ref={textareaRef} readOnly value={value} />;
+    return (
+      <textarea
+        data-render-version={renderVersion}
+        ref={textareaRef}
+        readOnly
+        value={value}
+      />
+    );
   };
 
   act(() => {
@@ -57,6 +73,12 @@ const renderHarness = (initialValue: string): Harness => {
       }
       return textarea;
     },
+    rerender: () => {
+      if (!rerenderRef.current) {
+        throw new Error("Textarea rerender callback was not rendered");
+      }
+      rerenderRef.current();
+    },
     setValue: (value: string) => {
       if (!setValueRef.current) {
         throw new Error("Textarea value setter was not rendered");
@@ -76,6 +98,10 @@ afterEach(() => {
   document.body.replaceChildren();
 });
 
+afterAll(() => {
+  reactActGlobal.IS_REACT_ACT_ENVIRONMENT = previousReactActEnvironment;
+});
+
 describe("useTextareaSelectionSync", () => {
   it("captures the current textarea selection", () => {
     const harness = renderHarness("hello world");
@@ -88,6 +114,25 @@ describe("useTextareaSelectionSync", () => {
       selectionStart: 2,
       selectionEnd: 7,
       selectionDirection: "forward",
+    });
+    harness.unmount();
+  });
+
+  it("defaults unknown textarea selection directions to none", () => {
+    const harness = renderHarness("hello world");
+    const textarea = harness.getTextarea();
+    textarea.setSelectionRange(2, 7, "forward");
+    Object.defineProperty(textarea, "selectionDirection", {
+      configurable: true,
+      value: "sideways",
+    });
+
+    const selection = harness.getApi().captureSelection();
+
+    expect(selection).toEqual({
+      selectionStart: 2,
+      selectionEnd: 7,
+      selectionDirection: "none",
     });
     harness.unmount();
   });
@@ -107,6 +152,27 @@ describe("useTextareaSelectionSync", () => {
     expect(textarea.selectionStart).toBe(6);
     expect(textarea.selectionEnd).toBe(11);
     expect(textarea.selectionDirection).toBe("forward");
+    harness.unmount();
+  });
+
+  it("does not replay a restore on an unrelated re-render", () => {
+    const harness = renderHarness("hello world");
+    const textarea = harness.getTextarea();
+    const api = harness.getApi();
+    api.restoreSelection({
+      selectionStart: 0,
+      selectionEnd: 0,
+      selectionDirection: "none",
+    });
+    textarea.setSelectionRange(5, 5, "none");
+
+    act(() => {
+      harness.rerender();
+    });
+
+    expect(textarea.selectionStart).toBe(5);
+    expect(textarea.selectionEnd).toBe(5);
+    expect(textarea.selectionDirection).toBe("none");
     harness.unmount();
   });
 
@@ -130,13 +196,35 @@ describe("useTextareaSelectionSync", () => {
     });
 
     expect(mappedSelection).toEqual({
-      selectionStart: 16,
-      selectionEnd: 16,
+      selectionStart: 11,
+      selectionEnd: 11,
       selectionDirection: "none",
     });
     expect(textarea.selectionStart).toBe(16);
     expect(textarea.selectionEnd).toBe(16);
     expect(textarea.selectionDirection).toBe("none");
+    harness.unmount();
+  });
+
+  it("preserves backward direction through a non-collapsing insert", () => {
+    const harness = renderHarness("abcdef");
+    const textarea = harness.getTextarea();
+    textarea.setSelectionRange(2, 5, "backward");
+    const api = harness.getApi();
+    api.captureSelection();
+
+    act(() => {
+      harness.setValue("abcXXdef");
+      api.mapAndRestoreSelection({
+        type: POSITION_OPERATION_TYPE.Insert,
+        index: 3,
+        length: 2,
+      });
+    });
+
+    expect(textarea.selectionStart).toBe(2);
+    expect(textarea.selectionEnd).toBe(7);
+    expect(textarea.selectionDirection).toBe("backward");
     harness.unmount();
   });
 
@@ -182,5 +270,96 @@ describe("useTextareaSelectionSync", () => {
     expect(textarea.selectionEnd).toBe(5);
     expect(textarea.selectionDirection).toBe("none");
     harness.unmount();
+  });
+
+  it("returns the clamped selection applied to the textarea", () => {
+    const harness = renderHarness("hello");
+    const textarea = harness.getTextarea();
+
+    const selection = harness.getApi().restoreSelection({
+      selectionStart: 2,
+      selectionEnd: 12,
+      selectionDirection: "forward",
+    });
+
+    expect(selection).toEqual({
+      selectionStart: 2,
+      selectionEnd: 5,
+      selectionDirection: "forward",
+    });
+    expect(textarea.selectionStart).toBe(2);
+    expect(textarea.selectionEnd).toBe(5);
+    expect(textarea.selectionDirection).toBe("forward");
+    harness.unmount();
+  });
+
+  it("normalizes inverted selections before restoring", () => {
+    const harness = renderHarness("hello world");
+    const textarea = harness.getTextarea();
+
+    const selection = harness.getApi().restoreSelection({
+      selectionStart: 8,
+      selectionEnd: 3,
+      selectionDirection: "forward",
+    });
+
+    expect(selection).toEqual({
+      selectionStart: 3,
+      selectionEnd: 8,
+      selectionDirection: "backward",
+    });
+    expect(textarea.selectionStart).toBe(3);
+    expect(textarea.selectionEnd).toBe(8);
+    expect(textarea.selectionDirection).toBe("backward");
+    harness.unmount();
+  });
+
+  it("flips backward direction when normalizing inverted selections", () => {
+    const harness = renderHarness("hello world");
+
+    const selection = harness.getApi().restoreSelection({
+      selectionStart: 8,
+      selectionEnd: 3,
+      selectionDirection: "backward",
+    });
+
+    expect(selection).toEqual({
+      selectionStart: 3,
+      selectionEnd: 8,
+      selectionDirection: "forward",
+    });
+    harness.unmount();
+  });
+
+  it("normalizes inverted selections without a direction to none", () => {
+    const harness = renderHarness("hello world");
+
+    const selection = harness.getApi().restoreSelection({
+      selectionStart: 8,
+      selectionEnd: 3,
+    });
+
+    expect(selection).toEqual({
+      selectionStart: 3,
+      selectionEnd: 8,
+      selectionDirection: "none",
+    });
+    harness.unmount();
+  });
+
+  it("returns null when the textarea ref is unavailable", () => {
+    const harness = renderHarness("hello world");
+    const api = harness.getApi();
+    harness.unmount();
+
+    expect(api.captureSelection()).toBeNull();
+    expect(api.restoreSelection()).toBeNull();
+    expect(
+      api.mapAndRestoreSelection({
+        type: POSITION_OPERATION_TYPE.Insert,
+        index: 0,
+        length: 1,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/awareness/src/hooks/use-textarea-selection-sync.test.tsx
+++ b/packages/awareness/src/hooks/use-textarea-selection-sync.test.tsx
@@ -1,0 +1,186 @@
+import { act, type JSX, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { POSITION_OPERATION_TYPE } from "../mapping/position-operation";
+import {
+  type UseTextareaSelectionSyncResult,
+  useTextareaSelectionSync,
+} from "./use-textarea-selection-sync";
+
+const reactActGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+type Harness = {
+  readonly getApi: () => UseTextareaSelectionSyncResult;
+  readonly getTextarea: () => HTMLTextAreaElement;
+  readonly setValue: (value: string) => void;
+  readonly unmount: () => void;
+};
+
+const renderHarness = (initialValue: string): Harness => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const apiRef: { current: UseTextareaSelectionSyncResult | null } = {
+    current: null,
+  };
+  const setValueRef: { current: ((value: string) => void) | null } = {
+    current: null,
+  };
+
+  const HarnessComponent = (): JSX.Element => {
+    const [value, setValue] = useState(initialValue);
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    apiRef.current = useTextareaSelectionSync(textareaRef);
+    setValueRef.current = setValue;
+
+    return <textarea ref={textareaRef} readOnly value={value} />;
+  };
+
+  act(() => {
+    root.render(<HarnessComponent />);
+  });
+
+  return {
+    getApi: () => {
+      if (!apiRef.current) {
+        throw new Error("Textarea selection sync API was not rendered");
+      }
+      return apiRef.current;
+    },
+    getTextarea: () => {
+      const textarea = container.querySelector("textarea");
+      if (!textarea) {
+        throw new Error("Textarea was not rendered");
+      }
+      return textarea;
+    },
+    setValue: (value: string) => {
+      if (!setValueRef.current) {
+        throw new Error("Textarea value setter was not rendered");
+      }
+      setValueRef.current(value);
+    },
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("useTextareaSelectionSync", () => {
+  it("captures the current textarea selection", () => {
+    const harness = renderHarness("hello world");
+    const textarea = harness.getTextarea();
+    textarea.setSelectionRange(2, 7, "forward");
+
+    const selection = harness.getApi().captureSelection();
+
+    expect(selection).toEqual({
+      selectionStart: 2,
+      selectionEnd: 7,
+      selectionDirection: "forward",
+    });
+    harness.unmount();
+  });
+
+  it("restores a captured selection after a React value update", () => {
+    const harness = renderHarness("hello world");
+    const textarea = harness.getTextarea();
+    textarea.setSelectionRange(6, 11, "forward");
+    const api = harness.getApi();
+    const captured = api.captureSelection();
+
+    act(() => {
+      harness.setValue("hello brave world");
+      api.restoreSelection(captured);
+    });
+
+    expect(textarea.selectionStart).toBe(6);
+    expect(textarea.selectionEnd).toBe(11);
+    expect(textarea.selectionDirection).toBe("forward");
+    harness.unmount();
+  });
+
+  it("maps and restores a cursor through a remote insert before it", () => {
+    const harness = renderHarness("hello world");
+    const textarea = harness.getTextarea();
+    textarea.setSelectionRange(11, 11, "none");
+    const api = harness.getApi();
+    api.captureSelection();
+    let mappedSelection: ReturnType<
+      UseTextareaSelectionSyncResult["mapAndRestoreSelection"]
+    > | null = null;
+
+    act(() => {
+      harness.setValue("hey, hello world");
+      mappedSelection = api.mapAndRestoreSelection({
+        type: POSITION_OPERATION_TYPE.Insert,
+        index: 0,
+        length: 5,
+      });
+    });
+
+    expect(mappedSelection).toEqual({
+      selectionStart: 16,
+      selectionEnd: 16,
+      selectionDirection: "none",
+    });
+    expect(textarea.selectionStart).toBe(16);
+    expect(textarea.selectionEnd).toBe(16);
+    expect(textarea.selectionDirection).toBe("none");
+    harness.unmount();
+  });
+
+  it("maps and restores a cursor through a remote delete before it", () => {
+    const harness = renderHarness("hello brave world");
+    const textarea = harness.getTextarea();
+    textarea.setSelectionRange(12, 12, "none");
+    const api = harness.getApi();
+    api.captureSelection();
+
+    act(() => {
+      harness.setValue("hello world");
+      api.mapAndRestoreSelection({
+        type: POSITION_OPERATION_TYPE.Delete,
+        index: 5,
+        length: 6,
+      });
+    });
+
+    expect(textarea.selectionStart).toBe(6);
+    expect(textarea.selectionEnd).toBe(6);
+    expect(textarea.selectionDirection).toBe("none");
+    harness.unmount();
+  });
+
+  it("collapses an overlapping delete selection to the mapped boundary", () => {
+    const harness = renderHarness("hello brave world");
+    const textarea = harness.getTextarea();
+    textarea.setSelectionRange(6, 12, "forward");
+    const api = harness.getApi();
+    api.captureSelection();
+
+    act(() => {
+      harness.setValue("hello world");
+      api.mapAndRestoreSelection({
+        type: POSITION_OPERATION_TYPE.Delete,
+        index: 5,
+        length: 7,
+      });
+    });
+
+    expect(textarea.selectionStart).toBe(5);
+    expect(textarea.selectionEnd).toBe(5);
+    expect(textarea.selectionDirection).toBe("none");
+    harness.unmount();
+  });
+});

--- a/packages/awareness/src/hooks/use-textarea-selection-sync.test.tsx
+++ b/packages/awareness/src/hooks/use-textarea-selection-sync.test.tsx
@@ -1,6 +1,6 @@
 import { act, type JSX, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { POSITION_OPERATION_TYPE } from "../mapping/position-operation";
 import {
   type UseTextareaSelectionSyncResult,
@@ -173,6 +173,31 @@ describe("useTextareaSelectionSync", () => {
     expect(textarea.selectionStart).toBe(5);
     expect(textarea.selectionEnd).toBe(5);
     expect(textarea.selectionDirection).toBe("none");
+    harness.unmount();
+  });
+
+  it("does not replay a restore on a later unrelated value update", async () => {
+    const harness = renderHarness("hello world");
+    const textarea = harness.getTextarea();
+    const api = harness.getApi();
+    api.restoreSelection({
+      selectionStart: 0,
+      selectionEnd: 0,
+      selectionDirection: "none",
+    });
+    textarea.setSelectionRange(5, 5, "none");
+
+    await Promise.resolve();
+
+    const setSelectionRange = vi.spyOn(textarea, "setSelectionRange");
+    act(() => {
+      harness.setValue("hello world!");
+    });
+
+    expect(setSelectionRange).not.toHaveBeenCalled();
+    expect(textarea.selectionStart).not.toBe(0);
+    expect(textarea.selectionEnd).not.toBe(0);
+    setSelectionRange.mockRestore();
     harness.unmount();
   });
 

--- a/packages/awareness/src/hooks/use-textarea-selection-sync.ts
+++ b/packages/awareness/src/hooks/use-textarea-selection-sync.ts
@@ -46,8 +46,13 @@ export type UseTextareaSelectionSyncResult = {
 };
 
 type PendingTextareaSelectionRestore = {
+  readonly id: number;
   readonly selection: TextareaSelection;
   readonly value: string;
+};
+
+type PendingTextareaSelectionRestoreRef = {
+  current: PendingTextareaSelectionRestore | null;
 };
 
 const normalizeSelectionDirection = (
@@ -112,10 +117,22 @@ const restoreToTextarea = (
   return nextSelection;
 };
 
+const schedulePendingRestoreExpiration = (
+  restoreId: number,
+  pendingRestoreRef: PendingTextareaSelectionRestoreRef,
+): void => {
+  queueMicrotask(() => {
+    if (pendingRestoreRef.current?.id === restoreId) {
+      pendingRestoreRef.current = null;
+    }
+  });
+};
+
 export const useTextareaSelectionSync = (
   textareaRef: RefObject<HTMLTextAreaElement | null>,
 ): UseTextareaSelectionSyncResult => {
   const selectionRef = useRef<TextareaSelection | null>(null);
+  const restoreIdRef = useRef(0);
   const pendingRestoreRef = useRef<PendingTextareaSelectionRestore | null>(
     null,
   );
@@ -145,10 +162,14 @@ export const useTextareaSelectionSync = (
       }
 
       const restoredSelection = restoreToTextarea(textarea, selection);
+      const restoreId = restoreIdRef.current + 1;
+      restoreIdRef.current = restoreId;
       pendingRestoreRef.current = {
+        id: restoreId,
         selection,
         value: textarea.value,
       };
+      schedulePendingRestoreExpiration(restoreId, pendingRestoreRef);
       selectionRef.current = restoredSelection;
       return restoredSelection;
     },
@@ -176,6 +197,7 @@ export const useTextareaSelectionSync = (
 
   // Intentionally runs after every commit so a restore requested in the same
   // batch as a textarea value update can be re-applied after the new value lands.
+  // Pending restores expire in a microtask, so they cannot leak into later work.
   useLayoutEffect(() => {
     const pendingSelection = pendingRestoreRef.current;
     if (!pendingSelection) {

--- a/packages/awareness/src/hooks/use-textarea-selection-sync.ts
+++ b/packages/awareness/src/hooks/use-textarea-selection-sync.ts
@@ -23,6 +23,11 @@ export type UseTextareaSelectionSyncResult = {
   ) => TextareaSelection | null;
 };
 
+type PendingTextareaSelectionRestore = {
+  readonly selection: TextareaSelection;
+  readonly value: string;
+};
+
 const normalizeSelectionDirection = (
   direction: string | null,
 ): TextareaSelectionDirection => {
@@ -36,33 +41,62 @@ const normalizeSelectionDirection = (
   return "none";
 };
 
+const flipSelectionDirection = (
+  direction: TextareaSelectionDirection | undefined,
+): TextareaSelectionDirection => {
+  if (direction === "forward") {
+    return "backward";
+  }
+  if (direction === "backward") {
+    return "forward";
+  }
+  return "none";
+};
+
 const clampSelectionToValue = (
   selection: TextareaSelection,
   valueLength: number,
 ): Required<TextareaSelection> => {
-  const selectionStart = Math.min(
+  const clampedStart = Math.min(
     Math.max(selection.selectionStart, 0),
     valueLength,
   );
-  const selectionEnd = Math.min(
-    Math.max(selection.selectionEnd, 0),
-    valueLength,
-  );
+  const clampedEnd = Math.min(Math.max(selection.selectionEnd, 0), valueLength);
+  const selectionStart = Math.min(clampedStart, clampedEnd);
+  const selectionEnd = Math.max(clampedStart, clampedEnd);
+  const selectionDirection =
+    clampedStart > clampedEnd
+      ? flipSelectionDirection(selection.selectionDirection)
+      : (selection.selectionDirection ?? "none");
+
   return {
     selectionStart,
     selectionEnd,
     selectionDirection:
-      selectionStart === selectionEnd
-        ? "none"
-        : (selection.selectionDirection ?? "none"),
+      selectionStart === selectionEnd ? "none" : selectionDirection,
   };
+};
+
+const restoreToTextarea = (
+  textarea: HTMLTextAreaElement,
+  selection: TextareaSelection,
+): Required<TextareaSelection> => {
+  const nextSelection = clampSelectionToValue(selection, textarea.value.length);
+  textarea.setSelectionRange(
+    nextSelection.selectionStart,
+    nextSelection.selectionEnd,
+    nextSelection.selectionDirection,
+  );
+  return nextSelection;
 };
 
 export const useTextareaSelectionSync = (
   textareaRef: RefObject<HTMLTextAreaElement | null>,
 ): UseTextareaSelectionSyncResult => {
   const selectionRef = useRef<TextareaSelection | null>(null);
-  const pendingRestoreRef = useRef<TextareaSelection | null>(null);
+  const pendingRestoreRef = useRef<PendingTextareaSelectionRestore | null>(
+    null,
+  );
 
   const captureSelection = useCallback((): TextareaSelection | null => {
     const textarea = textareaRef.current;
@@ -81,53 +115,36 @@ export const useTextareaSelectionSync = (
     return selection;
   }, [textareaRef]);
 
-  const restoreToTextarea = useCallback(
-    (selection: TextareaSelection): Required<TextareaSelection> | null => {
+  const restoreSelection = useCallback(
+    (selection: TextareaSelection | null = selectionRef.current) => {
       const textarea = textareaRef.current;
-      if (!textarea) {
+      if (!selection || !textarea) {
         return null;
       }
 
-      const nextSelection = clampSelectionToValue(
+      const restoredSelection = restoreToTextarea(textarea, selection);
+      pendingRestoreRef.current = {
         selection,
-        textarea.value.length,
-      );
-      textarea.setSelectionRange(
-        nextSelection.selectionStart,
-        nextSelection.selectionEnd,
-        nextSelection.selectionDirection,
-      );
-      return nextSelection;
+        value: textarea.value,
+      };
+      selectionRef.current = restoredSelection;
+      return restoredSelection;
     },
     [textareaRef],
   );
 
-  const restoreSelection = useCallback(
-    (selection: TextareaSelection | null = selectionRef.current) => {
-      if (!selection) {
-        return null;
-      }
-
-      pendingRestoreRef.current = selection;
-      selectionRef.current = selection;
-      restoreToTextarea(selection);
-      return selection;
-    },
-    [restoreToTextarea],
-  );
-
   const mapAndRestoreSelection = useCallback(
-    (
-      operation: PositionOperation,
-      selection: TextareaSelection | null = selectionRef.current ??
-        captureSelection(),
-    ) => {
-      if (!selection) {
+    (operation: PositionOperation, selection?: TextareaSelection | null) => {
+      const currentSelection =
+        selection === undefined
+          ? (selectionRef.current ?? captureSelection())
+          : selection;
+      if (!currentSelection) {
         return null;
       }
 
       const mappedSelection = mapTextareaSelectionThroughOperation(
-        selection,
+        currentSelection,
         operation,
       );
       return restoreSelection(mappedSelection);
@@ -142,8 +159,15 @@ export const useTextareaSelectionSync = (
     }
 
     pendingRestoreRef.current = null;
-    const restoredSelection = restoreToTextarea(pendingSelection);
-    selectionRef.current = restoredSelection ?? pendingSelection;
+    const textarea = textareaRef.current;
+    if (!textarea || textarea.value === pendingSelection.value) {
+      return;
+    }
+
+    selectionRef.current = restoreToTextarea(
+      textarea,
+      pendingSelection.selection,
+    );
   });
 
   return useMemo(

--- a/packages/awareness/src/hooks/use-textarea-selection-sync.ts
+++ b/packages/awareness/src/hooks/use-textarea-selection-sync.ts
@@ -1,0 +1,157 @@
+import {
+  type RefObject,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+import type { PositionOperation } from "../mapping/position-operation";
+import {
+  mapTextareaSelectionThroughOperation,
+  type TextareaSelection,
+  type TextareaSelectionDirection,
+} from "./textarea-selection-sync";
+
+export type UseTextareaSelectionSyncResult = {
+  readonly captureSelection: () => TextareaSelection | null;
+  readonly restoreSelection: (
+    selection?: TextareaSelection | null,
+  ) => TextareaSelection | null;
+  readonly mapAndRestoreSelection: (
+    operation: PositionOperation,
+    selection?: TextareaSelection | null,
+  ) => TextareaSelection | null;
+};
+
+const normalizeSelectionDirection = (
+  direction: string | null,
+): TextareaSelectionDirection => {
+  if (
+    direction === "forward" ||
+    direction === "backward" ||
+    direction === "none"
+  ) {
+    return direction;
+  }
+  return "none";
+};
+
+const clampSelectionToValue = (
+  selection: TextareaSelection,
+  valueLength: number,
+): Required<TextareaSelection> => {
+  const selectionStart = Math.min(
+    Math.max(selection.selectionStart, 0),
+    valueLength,
+  );
+  const selectionEnd = Math.min(
+    Math.max(selection.selectionEnd, 0),
+    valueLength,
+  );
+  return {
+    selectionStart,
+    selectionEnd,
+    selectionDirection:
+      selectionStart === selectionEnd
+        ? "none"
+        : (selection.selectionDirection ?? "none"),
+  };
+};
+
+export const useTextareaSelectionSync = (
+  textareaRef: RefObject<HTMLTextAreaElement | null>,
+): UseTextareaSelectionSyncResult => {
+  const selectionRef = useRef<TextareaSelection | null>(null);
+  const pendingRestoreRef = useRef<TextareaSelection | null>(null);
+
+  const captureSelection = useCallback((): TextareaSelection | null => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return null;
+    }
+
+    const selection = {
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+      selectionDirection: normalizeSelectionDirection(
+        textarea.selectionDirection,
+      ),
+    } satisfies Required<TextareaSelection>;
+    selectionRef.current = selection;
+    return selection;
+  }, [textareaRef]);
+
+  const restoreToTextarea = useCallback(
+    (selection: TextareaSelection): Required<TextareaSelection> | null => {
+      const textarea = textareaRef.current;
+      if (!textarea) {
+        return null;
+      }
+
+      const nextSelection = clampSelectionToValue(
+        selection,
+        textarea.value.length,
+      );
+      textarea.setSelectionRange(
+        nextSelection.selectionStart,
+        nextSelection.selectionEnd,
+        nextSelection.selectionDirection,
+      );
+      return nextSelection;
+    },
+    [textareaRef],
+  );
+
+  const restoreSelection = useCallback(
+    (selection: TextareaSelection | null = selectionRef.current) => {
+      if (!selection) {
+        return null;
+      }
+
+      pendingRestoreRef.current = selection;
+      selectionRef.current = selection;
+      restoreToTextarea(selection);
+      return selection;
+    },
+    [restoreToTextarea],
+  );
+
+  const mapAndRestoreSelection = useCallback(
+    (
+      operation: PositionOperation,
+      selection: TextareaSelection | null = selectionRef.current ??
+        captureSelection(),
+    ) => {
+      if (!selection) {
+        return null;
+      }
+
+      const mappedSelection = mapTextareaSelectionThroughOperation(
+        selection,
+        operation,
+      );
+      return restoreSelection(mappedSelection);
+    },
+    [captureSelection, restoreSelection],
+  );
+
+  useLayoutEffect(() => {
+    const pendingSelection = pendingRestoreRef.current;
+    if (!pendingSelection) {
+      return;
+    }
+
+    pendingRestoreRef.current = null;
+    const restoredSelection = restoreToTextarea(pendingSelection);
+    selectionRef.current = restoredSelection ?? pendingSelection;
+  });
+
+  return useMemo(
+    () => ({
+      captureSelection,
+      restoreSelection,
+      mapAndRestoreSelection,
+    }),
+    [captureSelection, restoreSelection, mapAndRestoreSelection],
+  );
+};

--- a/packages/awareness/src/hooks/use-textarea-selection-sync.ts
+++ b/packages/awareness/src/hooks/use-textarea-selection-sync.ts
@@ -13,10 +13,29 @@ import {
 } from "./textarea-selection-sync";
 
 export type UseTextareaSelectionSyncResult = {
+  /**
+   * Capture the textarea's current DOM selection.
+   */
   readonly captureSelection: () => TextareaSelection | null;
+  /**
+   * Restore a selection immediately against the textarea's current value.
+   *
+   * The returned selection reflects that synchronous restore and may be
+   * clamped to the current value length. If React commits a textarea value
+   * change in the same batch, the hook re-applies the requested selection
+   * after commit against the new value.
+   */
   readonly restoreSelection: (
     selection?: TextareaSelection | null,
   ) => TextareaSelection | null;
+  /**
+   * Map a selection through an operation and restore it immediately.
+   *
+   * The returned selection reflects the synchronous restore against the
+   * textarea's current value. When the textarea value changes in the same
+   * React batch, the post-commit layout effect restores the mapped selection
+   * again against the new value.
+   */
   readonly mapAndRestoreSelection: (
     operation: PositionOperation,
     selection?: TextareaSelection | null,
@@ -152,6 +171,8 @@ export const useTextareaSelectionSync = (
     [captureSelection, restoreSelection],
   );
 
+  // Intentionally runs after every commit so a restore requested in the same
+  // batch as a textarea value update can be re-applied after the new value lands.
   useLayoutEffect(() => {
     const pendingSelection = pendingRestoreRef.current;
     if (!pendingSelection) {

--- a/packages/awareness/src/hooks/use-textarea-selection-sync.ts
+++ b/packages/awareness/src/hooks/use-textarea-selection-sync.ts
@@ -35,6 +35,9 @@ export type UseTextareaSelectionSyncResult = {
    * textarea's current value. When the textarea value changes in the same
    * React batch, the post-commit layout effect restores the mapped selection
    * again against the new value.
+   *
+   * Omit `selection` to use the last captured selection; pass `null` to return
+   * `null` without restoring.
    */
   readonly mapAndRestoreSelection: (
     operation: PositionOperation,

--- a/packages/awareness/src/index.ts
+++ b/packages/awareness/src/index.ts
@@ -52,9 +52,13 @@ export {
   usePresenceLayerOffset,
 } from "./components";
 export {
+  mapTextareaSelectionThroughOperation,
   type PeerCursor,
+  type TextareaSelection,
+  type TextareaSelectionDirection,
   type UsePeerCursorsOptions,
   type UsePeersInBlockOptions,
+  type UseTextareaSelectionSyncResult,
   useActivityByType,
   useConnectionState,
   useIsConnected,
@@ -68,6 +72,7 @@ export {
   useRecentActivity,
   useSelf,
   useSelfSelector,
+  useTextareaSelectionSync,
   useUpdateCursor,
   useUpdatePresence,
   useUpdateSelection,

--- a/packages/awareness/vite.config.ts
+++ b/packages/awareness/vite.config.ts
@@ -124,6 +124,10 @@ export default defineConfig({
           __dirname,
           "src/hooks/use-peers-in-block.ts",
         ),
+        "hooks/use-textarea-selection-sync": path.resolve(
+          __dirname,
+          "src/hooks/use-textarea-selection-sync.ts",
+        ),
       },
       formats: ["es"],
       fileName: (format, entryName) => `${entryName}.js`,


### PR DESCRIPTION
## Summary
- add useTextareaSelectionSync for capturing, restoring, and operation-mapping textarea selections
- export the hook from @softmaple/awareness root and hooks entrypoints
- add focused jsdom coverage for restore, insert mapping, delete mapping, and overlapping delete collapse

## Validation
- pnpm --filter @softmaple/awareness check
- pnpm --filter @softmaple/awareness test -- --run
- pnpm --filter @softmaple/awareness typecheck
- pnpm --filter @softmaple/awareness build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hook for capturing, restoring, and mapping textarea text selection state across text operations
  * Exported accompanying types for textarea selection management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->