### PR TITLE
refactor(playground): operation-based selection mapping in collaborative editor

### DIFF
--- a/apps/playground/biome.json
+++ b/apps/playground/biome.json
@@ -13,6 +13,7 @@
       "**/.vscode/**/*",
       "**/index.html",
       "**/vite.config.js",
+      "**/workspace-aliases.ts",
       "**/package.json",
       "**/tsconfig.json",
       "!**/src/routeTree.gen.ts",

--- a/apps/playground/e2e/collaborative-editor.spec.ts
+++ b/apps/playground/e2e/collaborative-editor.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("Collaborative Text Editor", () => {
+  test.describe.configure({ mode: "serial" });
+
   test.beforeEach(async ({ page }) => {
     await page.goto("/demo/collaborative-editor");
     // Wait for DOM to load and editors to be rendered
@@ -79,7 +81,7 @@ test.describe("Collaborative Text Editor", () => {
     await expect(replica2).toHaveValue("hello", { timeout: 5000 });
 
     // Replace by selecting all and typing new text
-    await replica1.press("Control+A");
+    await replica1.press("ControlOrMeta+A");
     await replica1.pressSequentially("HELLO", { delay: 100 });
     await expect(replica2).toHaveValue("HELLO", { timeout: 5000 });
   });

--- a/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
+++ b/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
@@ -5,6 +5,7 @@ import {
   useTextareaSelectionSync,
 } from "@softmaple/awareness/hooks";
 import {
+  findChangedSpan,
   POSITION_OPERATION_TYPE,
   type PositionOperation,
 } from "@softmaple/awareness/mapping";
@@ -18,61 +19,9 @@ import {
   useState,
 } from "react";
 
-export type {
-  TextareaSelection,
-  UseTextareaSelectionSyncResult,
-} from "@softmaple/awareness/hooks";
-export {
-  mapTextareaSelectionThroughOperation,
-  useTextareaSelectionSync,
-} from "@softmaple/awareness/hooks";
-export type { PositionOperation } from "@softmaple/awareness/mapping";
-export {
-  findDeletePosition,
-  findDifferingRange,
-  findInsertPosition,
-  POSITION_OPERATION_TYPE,
-} from "@softmaple/awareness/mapping";
-
 export type LocalEdit = {
   readonly mappingOperations: readonly PositionOperation[];
   readonly apply: (replica: EgWalkerReplica) => void;
-};
-
-export type DifferingSpan = {
-  readonly prefix: number;
-  readonly suffix: number;
-  readonly oldEnd: number;
-  readonly newEnd: number;
-};
-
-export const findChangedSpan = (
-  oldText: string,
-  newText: string,
-): DifferingSpan => {
-  const minLength = Math.min(oldText.length, newText.length);
-  let prefix = 0;
-
-  while (prefix < minLength && oldText[prefix] === newText[prefix]) {
-    prefix++;
-  }
-
-  let suffix = 0;
-  while (
-    suffix < oldText.length - prefix &&
-    suffix < newText.length - prefix &&
-    oldText[oldText.length - suffix - 1] ===
-      newText[newText.length - suffix - 1]
-  ) {
-    suffix++;
-  }
-
-  return {
-    prefix,
-    suffix,
-    oldEnd: oldText.length - suffix,
-    newEnd: newText.length - suffix,
-  };
 };
 
 export const computeLocalEdit = (
@@ -161,15 +110,19 @@ export const runReplicaChange = async (
     return;
   }
 
-  // Capture cursor positions before any state mutation so we can restore the
-  // local cursor and map the remote cursor through the local operation(s).
-  localSync.captureSelection();
+  // Capture cursor positions into local vars (not just the hook's shared ref)
+  // so a concurrent edit firing during the await below cannot overwrite the
+  // selection this handler will restore.
+  const localSelection = localSync.captureSelection();
   const remoteSelection = remoteSync.captureSelection();
 
+  // Snapshot the event graph length before applying so we walk exactly the
+  // events this edit produced, without assuming "one replica call = one
+  // event" or N == mappingOperations.length.
+  const eventsBeforeApply = localReplica.exportEventGraph().length;
   edit.apply(localReplica);
+  const newEvents = localReplica.exportEventGraph().slice(eventsBeforeApply);
 
-  const events = localReplica.exportEventGraph();
-  const newEvents = events.slice(-edit.mappingOperations.length);
   const appliedMappingOperations: PositionOperation[] = [];
   try {
     for (const [index, remoteEvent] of newEvents.entries()) {
@@ -185,7 +138,7 @@ export const runReplicaChange = async (
   }
 
   setLocalText(localReplica.getText());
-  localSync.restoreSelection();
+  localSync.restoreSelection(localSelection);
 
   setRemoteText(remoteReplica.getText());
   if (remoteSelection && appliedMappingOperations.length > 0) {

--- a/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
+++ b/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
@@ -13,6 +13,7 @@ import { EgWalkerReplica } from "@softmaple/eg-walker";
 import {
   type ChangeEvent,
   type Dispatch,
+  type RefObject,
   type SetStateAction,
   useCallback,
   useRef,
@@ -66,7 +67,7 @@ export const computeLocalEdit = (
   };
 };
 
-export const mapSelectionThroughOperations = (
+const mapSelectionThroughOperations = (
   selection: TextareaSelection,
   operations: readonly PositionOperation[],
 ): TextareaSelection =>
@@ -148,7 +149,20 @@ export const runReplicaChange = async (
   }
 };
 
-export const useCollaborativeEditor = () => {
+export type UseCollaborativeEditorResult = {
+  readonly replica1Text: string;
+  readonly replica2Text: string;
+  readonly replica1Ref: RefObject<HTMLTextAreaElement | null>;
+  readonly replica2Ref: RefObject<HTMLTextAreaElement | null>;
+  readonly handleReplica1Change: (
+    event: ChangeEvent<HTMLTextAreaElement>,
+  ) => Promise<void>;
+  readonly handleReplica2Change: (
+    event: ChangeEvent<HTMLTextAreaElement>,
+  ) => Promise<void>;
+};
+
+export const useCollaborativeEditor = (): UseCollaborativeEditorResult => {
   const [replica1Text, setReplica1Text] = useState("");
   const [replica2Text, setReplica2Text] = useState("");
   const [api1] = useState(() => new EgWalkerReplica("replica-1"));

--- a/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
+++ b/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
@@ -170,9 +170,15 @@ export const runReplicaChange = async (
 
   const events = localReplica.exportEventGraph();
   const newEvents = events.slice(-edit.mappingOperations.length);
+  const appliedMappingOperations: PositionOperation[] = [];
   try {
-    for (const remoteEvent of newEvents) {
+    for (const [index, remoteEvent] of newEvents.entries()) {
+      const textBeforeRemoteApply = remoteReplica.getText();
       await remoteReplica.applyRemoteEvent(remoteEvent);
+      const operation = edit.mappingOperations[index];
+      if (operation && remoteReplica.getText() !== textBeforeRemoteApply) {
+        appliedMappingOperations.push(operation);
+      }
     }
   } catch (error) {
     console.error(`Failed to sync edit to ${remoteLabel}:`, error);
@@ -182,9 +188,9 @@ export const runReplicaChange = async (
   localSync.restoreSelection();
 
   setRemoteText(remoteReplica.getText());
-  if (remoteSelection) {
+  if (remoteSelection && appliedMappingOperations.length > 0) {
     remoteSync.restoreSelection(
-      mapSelectionThroughOperations(remoteSelection, edit.mappingOperations),
+      mapSelectionThroughOperations(remoteSelection, appliedMappingOperations),
     );
   }
 };

--- a/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
+++ b/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
@@ -1,0 +1,238 @@
+import {
+  mapTextareaSelectionThroughOperation,
+  type TextareaSelection,
+  type UseTextareaSelectionSyncResult,
+  useTextareaSelectionSync,
+} from "@softmaple/awareness/hooks";
+import {
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+} from "@softmaple/awareness/mapping";
+import { EgWalkerReplica } from "@softmaple/eg-walker";
+import {
+  type ChangeEvent,
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
+
+export type {
+  TextareaSelection,
+  UseTextareaSelectionSyncResult,
+} from "@softmaple/awareness/hooks";
+export {
+  mapTextareaSelectionThroughOperation,
+  useTextareaSelectionSync,
+} from "@softmaple/awareness/hooks";
+export type { PositionOperation } from "@softmaple/awareness/mapping";
+export {
+  findDeletePosition,
+  findDifferingRange,
+  findInsertPosition,
+  POSITION_OPERATION_TYPE,
+} from "@softmaple/awareness/mapping";
+
+export type LocalEdit = {
+  readonly mappingOperations: readonly PositionOperation[];
+  readonly apply: (replica: EgWalkerReplica) => void;
+};
+
+export type DifferingSpan = {
+  readonly prefix: number;
+  readonly suffix: number;
+  readonly oldEnd: number;
+  readonly newEnd: number;
+};
+
+export const findChangedSpan = (
+  oldText: string,
+  newText: string,
+): DifferingSpan => {
+  const minLength = Math.min(oldText.length, newText.length);
+  let prefix = 0;
+
+  while (prefix < minLength && oldText[prefix] === newText[prefix]) {
+    prefix++;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < oldText.length - prefix &&
+    suffix < newText.length - prefix &&
+    oldText[oldText.length - suffix - 1] ===
+      newText[newText.length - suffix - 1]
+  ) {
+    suffix++;
+  }
+
+  return {
+    prefix,
+    suffix,
+    oldEnd: oldText.length - suffix,
+    newEnd: newText.length - suffix,
+  };
+};
+
+export const computeLocalEdit = (
+  oldText: string,
+  newText: string,
+): LocalEdit | null => {
+  if (newText === oldText) {
+    return null;
+  }
+
+  const { prefix, suffix } = findChangedSpan(oldText, newText);
+  const deletedLength = oldText.length - prefix - suffix;
+  const insertedText = newText.slice(prefix, newText.length - suffix);
+  const mappingOperations: PositionOperation[] = [];
+
+  if (deletedLength > 0) {
+    mappingOperations.push({
+      type: POSITION_OPERATION_TYPE.Delete,
+      index: prefix,
+      length: deletedLength,
+    });
+  }
+
+  if (insertedText.length > 0) {
+    mappingOperations.push({
+      type: POSITION_OPERATION_TYPE.Insert,
+      index: prefix,
+      length: insertedText.length,
+    });
+  }
+
+  return {
+    mappingOperations,
+    apply: (replica) => {
+      if (deletedLength > 0) {
+        replica.delete(prefix, deletedLength);
+      }
+      if (insertedText.length > 0) {
+        replica.insert(prefix, insertedText);
+      }
+    },
+  };
+};
+
+export const mapSelectionThroughOperations = (
+  selection: TextareaSelection,
+  operations: readonly PositionOperation[],
+): TextareaSelection =>
+  operations.reduce<TextareaSelection>(
+    (current, operation) =>
+      mapTextareaSelectionThroughOperation(current, operation),
+    selection,
+  );
+
+export type ReplicaChangeContext = {
+  readonly localReplica: EgWalkerReplica;
+  readonly remoteReplica: EgWalkerReplica;
+  readonly localSync: UseTextareaSelectionSyncResult;
+  readonly remoteSync: UseTextareaSelectionSyncResult;
+  readonly setLocalText: Dispatch<SetStateAction<string>>;
+  readonly setRemoteText: Dispatch<SetStateAction<string>>;
+  readonly remoteLabel: string;
+};
+
+export const runReplicaChange = async (
+  event: ChangeEvent<HTMLTextAreaElement>,
+  context: ReplicaChangeContext,
+): Promise<void> => {
+  const {
+    localReplica,
+    remoteReplica,
+    localSync,
+    remoteSync,
+    setLocalText,
+    setRemoteText,
+    remoteLabel,
+  } = context;
+
+  const newText = event.target.value;
+  const oldText = localReplica.getText();
+  const edit = computeLocalEdit(oldText, newText);
+
+  if (!edit) {
+    setLocalText(localReplica.getText());
+    setRemoteText(remoteReplica.getText());
+    return;
+  }
+
+  // Capture cursor positions before any state mutation so we can restore the
+  // local cursor and map the remote cursor through the local operation(s).
+  localSync.captureSelection();
+  const remoteSelection = remoteSync.captureSelection();
+
+  edit.apply(localReplica);
+
+  const events = localReplica.exportEventGraph();
+  const newEvents = events.slice(-edit.mappingOperations.length);
+  try {
+    for (const remoteEvent of newEvents) {
+      await remoteReplica.applyRemoteEvent(remoteEvent);
+    }
+  } catch (error) {
+    console.error(`Failed to sync edit to ${remoteLabel}:`, error);
+  }
+
+  setLocalText(localReplica.getText());
+  localSync.restoreSelection();
+
+  setRemoteText(remoteReplica.getText());
+  if (remoteSelection) {
+    remoteSync.restoreSelection(
+      mapSelectionThroughOperations(remoteSelection, edit.mappingOperations),
+    );
+  }
+};
+
+export const useCollaborativeEditor = () => {
+  const [replica1Text, setReplica1Text] = useState("");
+  const [replica2Text, setReplica2Text] = useState("");
+  const [api1] = useState(() => new EgWalkerReplica("replica-1"));
+  const [api2] = useState(() => new EgWalkerReplica("replica-2"));
+  const replica1Ref = useRef<HTMLTextAreaElement>(null);
+  const replica2Ref = useRef<HTMLTextAreaElement>(null);
+  const replica1Sync = useTextareaSelectionSync(replica1Ref);
+  const replica2Sync = useTextareaSelectionSync(replica2Ref);
+
+  const handleReplica1Change = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) =>
+      runReplicaChange(event, {
+        localReplica: api1,
+        remoteReplica: api2,
+        localSync: replica1Sync,
+        remoteSync: replica2Sync,
+        setLocalText: setReplica1Text,
+        setRemoteText: setReplica2Text,
+        remoteLabel: "replica-2",
+      }),
+    [api1, api2, replica1Sync, replica2Sync],
+  );
+
+  const handleReplica2Change = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) =>
+      runReplicaChange(event, {
+        localReplica: api2,
+        remoteReplica: api1,
+        localSync: replica2Sync,
+        remoteSync: replica1Sync,
+        setLocalText: setReplica2Text,
+        setRemoteText: setReplica1Text,
+        remoteLabel: "replica-1",
+      }),
+    [api1, api2, replica1Sync, replica2Sync],
+  );
+
+  return {
+    replica1Text,
+    replica2Text,
+    replica1Ref,
+    replica2Ref,
+    handleReplica1Change,
+    handleReplica2Change,
+  };
+};

--- a/apps/playground/src/routes/demo/collaborative-editor.tsx
+++ b/apps/playground/src/routes/demo/collaborative-editor.tsx
@@ -1,3 +1,16 @@
+import {
+  mapTextareaSelectionThroughOperation,
+  type TextareaSelection,
+  type UseTextareaSelectionSyncResult,
+  useTextareaSelectionSync,
+} from "@softmaple/awareness/hooks";
+import {
+  findDeletePosition,
+  findDifferingRange,
+  findInsertPosition,
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+} from "@softmaple/awareness/mapping";
 import { EgWalkerReplica } from "@softmaple/eg-walker";
 import {
   Card,
@@ -8,15 +21,155 @@ import {
 import { Textarea } from "@softmaple/ui/components/textarea";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useRef, useState } from "react";
-import {
-  findDeletePosition,
-  findDifferingRange,
-  findInsertPosition,
-} from "@/lib/text-diff";
 
 export const Route = createFileRoute("/demo/collaborative-editor")({
   component: CollaborativeEditor,
 });
+
+type LocalEdit = {
+  readonly mappingOperations: readonly PositionOperation[];
+  readonly apply: (replica: EgWalkerReplica) => void;
+};
+
+const computeLocalEdit = (
+  oldText: string,
+  newText: string,
+): LocalEdit | null => {
+  if (newText === oldText) {
+    return null;
+  }
+
+  if (newText.length > oldText.length) {
+    const insertPos = findInsertPosition(oldText, newText);
+    const insertedText = newText.slice(
+      insertPos,
+      insertPos + (newText.length - oldText.length),
+    );
+    return {
+      mappingOperations: [
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: insertPos,
+          length: insertedText.length,
+        },
+      ],
+      apply: (replica) => {
+        replica.insert(insertPos, insertedText);
+      },
+    };
+  }
+
+  if (newText.length < oldText.length) {
+    const deletePos = findDeletePosition(oldText, newText);
+    const deleteCount = oldText.length - newText.length;
+    return {
+      mappingOperations: [
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: deletePos,
+          length: deleteCount,
+        },
+      ],
+      apply: (replica) => {
+        replica.delete(deletePos, deleteCount);
+      },
+    };
+  }
+
+  const { start, end } = findDifferingRange(oldText, newText);
+  const length = end - start + 1;
+  const replacementText = newText.slice(start, end + 1);
+  return {
+    mappingOperations: [
+      {
+        type: POSITION_OPERATION_TYPE.Delete,
+        index: start,
+        length,
+      },
+      {
+        type: POSITION_OPERATION_TYPE.Insert,
+        index: start,
+        length: replacementText.length,
+      },
+    ],
+    apply: (replica) => {
+      replica.delete(start, length);
+      replica.insert(start, replacementText);
+    },
+  };
+};
+
+const mapSelectionThroughOperations = (
+  selection: TextareaSelection,
+  operations: readonly PositionOperation[],
+): TextareaSelection =>
+  operations.reduce<TextareaSelection>(
+    (current, operation) =>
+      mapTextareaSelectionThroughOperation(current, operation),
+    selection,
+  );
+
+type ReplicaChangeContext = {
+  readonly localReplica: EgWalkerReplica;
+  readonly remoteReplica: EgWalkerReplica;
+  readonly localSync: UseTextareaSelectionSyncResult;
+  readonly remoteSync: UseTextareaSelectionSyncResult;
+  readonly setLocalText: React.Dispatch<React.SetStateAction<string>>;
+  readonly setRemoteText: React.Dispatch<React.SetStateAction<string>>;
+  readonly remoteLabel: string;
+};
+
+const runReplicaChange = async (
+  event: React.ChangeEvent<HTMLTextAreaElement>,
+  context: ReplicaChangeContext,
+): Promise<void> => {
+  const {
+    localReplica,
+    remoteReplica,
+    localSync,
+    remoteSync,
+    setLocalText,
+    setRemoteText,
+    remoteLabel,
+  } = context;
+
+  const newText = event.target.value;
+  const oldText = localReplica.getText();
+  const edit = computeLocalEdit(oldText, newText);
+
+  if (!edit) {
+    setLocalText(localReplica.getText());
+    setRemoteText(remoteReplica.getText());
+    return;
+  }
+
+  // Capture cursor positions before any state mutation so we can restore the
+  // local cursor and map the remote cursor through the local operation(s).
+  localSync.captureSelection();
+  const remoteSelection = remoteSync.captureSelection();
+
+  edit.apply(localReplica);
+
+  const events = localReplica.exportEventGraph();
+  const newEvents = events.slice(-edit.mappingOperations.length);
+  try {
+    for (const remoteEvent of newEvents) {
+      await remoteReplica.applyRemoteEvent(remoteEvent);
+    }
+  } catch (error) {
+    console.error(`Failed to sync edit to ${remoteLabel}:`, error);
+  }
+
+  setLocalText(localReplica.getText());
+  localSync.restoreSelection();
+
+  setRemoteText(remoteReplica.getText());
+  if (remoteSelection) {
+    remoteSync.restoreSelection(
+      mapSelectionThroughOperations(remoteSelection, edit.mappingOperations),
+    );
+  }
+};
 
 function CollaborativeEditor() {
   const [replica1Text, setReplica1Text] = useState("");
@@ -25,298 +178,35 @@ function CollaborativeEditor() {
   const [api2] = useState(() => new EgWalkerReplica("replica-2"));
   const replica1Ref = useRef<HTMLTextAreaElement>(null);
   const replica2Ref = useRef<HTMLTextAreaElement>(null);
-
-  // Helper to preserve cursor position when updating text from remote changes
-  const updateTextPreservingCursor = useCallback(
-    (
-      textareaRef: React.RefObject<HTMLTextAreaElement | null>,
-      setText: React.Dispatch<React.SetStateAction<string>>,
-      newText: string,
-    ) => {
-      // Save current cursor position before update
-      const currentStart = textareaRef.current?.selectionStart ?? 0;
-      const currentEnd = textareaRef.current?.selectionEnd ?? 0;
-
-      // Update the text
-      setText(newText);
-
-      // Restore cursor position after React re-render
-      setTimeout(() => {
-        if (textareaRef.current) {
-          // Ensure cursor position doesn't exceed new text length
-          const safeStart = Math.min(currentStart, newText.length);
-          const safeEnd = Math.min(currentEnd, newText.length);
-          textareaRef.current.setSelectionRange(safeStart, safeEnd);
-        }
-      }, 0);
-    },
-    [],
-  );
+  const replica1Sync = useTextareaSelectionSync(replica1Ref);
+  const replica2Sync = useTextareaSelectionSync(replica2Ref);
 
   const handleReplica1Change = useCallback(
-    async (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const newText = e.target.value;
-      const oldText = api1.getText();
-
-      if (newText.length > oldText.length) {
-        // Insertion
-        const insertPos = findInsertPosition(oldText, newText);
-        const insertedText = newText.slice(
-          insertPos,
-          insertPos + (newText.length - oldText.length),
-        );
-        const expectedCursorPos = insertPos + insertedText.length;
-
-        api1.insert(insertPos, insertedText);
-
-        // Get the latest event from replica1 and propagate to replica2 asynchronously
-        const events = api1.exportEventGraph();
-        const latestEvent = events[events.length - 1];
-        if (latestEvent) {
-          try {
-            await api2.applyRemoteEvent(latestEvent);
-            // Update replica2 text while preserving its cursor position
-            updateTextPreservingCursor(
-              replica2Ref,
-              setReplica2Text,
-              api2.getText(),
-            );
-          } catch (error) {
-            console.error("Failed to sync insert to replica2:", error);
-          }
-        }
-
-        // Update local state and preserve cursor position after insertion
-        setReplica1Text(api1.getText());
-        setTimeout(() => {
-          if (replica1Ref.current) {
-            replica1Ref.current.setSelectionRange(
-              expectedCursorPos,
-              expectedCursorPos,
-            );
-          }
-        }, 0);
-        return;
-      } else if (newText.length < oldText.length) {
-        // Deletion
-        const deletePos = findDeletePosition(oldText, newText);
-        const deleteCount = oldText.length - newText.length;
-        const expectedCursorPos = deletePos;
-
-        api1.delete(deletePos, deleteCount);
-
-        // Get the latest event from replica1 and propagate to replica2 asynchronously
-        const events = api1.exportEventGraph();
-        const latestEvent = events[events.length - 1];
-        if (latestEvent) {
-          try {
-            await api2.applyRemoteEvent(latestEvent);
-            // Update replica2 text while preserving its cursor position
-            updateTextPreservingCursor(
-              replica2Ref,
-              setReplica2Text,
-              api2.getText(),
-            );
-          } catch (error) {
-            console.error("Failed to sync delete to replica2:", error);
-          }
-        }
-
-        // Update local state and restore cursor position
-        setReplica1Text(api1.getText());
-        // Use setTimeout to ensure cursor restoration happens after React re-render
-        setTimeout(() => {
-          if (replica1Ref.current) {
-            replica1Ref.current.setSelectionRange(
-              expectedCursorPos,
-              expectedCursorPos,
-            );
-          }
-        }, 0);
-        return; // Early return to avoid duplicate state updates at the end
-      } else if (newText.length === oldText.length && newText !== oldText) {
-        // Replacement (same length, different content)
-        const { start, end } = findDifferingRange(oldText, newText);
-        const deleteCount = end - start + 1;
-        const replacementText = newText.slice(start, end + 1);
-        const expectedCursorPos = end + 1;
-
-        // Perform delete then insert
-        api1.delete(start, deleteCount);
-        api1.insert(start, replacementText);
-
-        // Get the latest two events (delete + insert) and propagate to replica2 asynchronously
-        const events = api1.exportEventGraph();
-        const latestEvents = events.slice(-2);
-        try {
-          for (const event of latestEvents) {
-            await api2.applyRemoteEvent(event);
-          }
-          // Update replica2 text while preserving its cursor position
-          updateTextPreservingCursor(
-            replica2Ref,
-            setReplica2Text,
-            api2.getText(),
-          );
-        } catch (error) {
-          console.error("Failed to sync replacement to replica2:", error);
-        }
-
-        // Update local state and preserve cursor position
-        setReplica1Text(api1.getText());
-        setTimeout(() => {
-          if (replica1Ref.current) {
-            replica1Ref.current.setSelectionRange(
-              expectedCursorPos,
-              expectedCursorPos,
-            );
-          }
-        }, 0);
-        return;
-      }
-
-      // Sync local state with API's getText() to ensure consistency
-      setReplica1Text(api1.getText());
-      setReplica2Text(api2.getText());
-    },
-    [
-      api1,
-      api2, // Update replica2 text while preserving its cursor position
-      updateTextPreservingCursor,
-    ],
+    (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+      runReplicaChange(event, {
+        localReplica: api1,
+        remoteReplica: api2,
+        localSync: replica1Sync,
+        remoteSync: replica2Sync,
+        setLocalText: setReplica1Text,
+        setRemoteText: setReplica2Text,
+        remoteLabel: "replica-2",
+      }),
+    [api1, api2, replica1Sync, replica2Sync],
   );
 
   const handleReplica2Change = useCallback(
-    async (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const newText = e.target.value;
-      const oldText = api2.getText();
-
-      if (newText.length > oldText.length) {
-        // Insertion
-        const insertPos = findInsertPosition(oldText, newText);
-        const insertedText = newText.slice(
-          insertPos,
-          insertPos + (newText.length - oldText.length),
-        );
-        const expectedCursorPos = insertPos + insertedText.length;
-
-        api2.insert(insertPos, insertedText);
-
-        // Get the latest event from replica2 and propagate to replica1 asynchronously
-        const events = api2.exportEventGraph();
-        const latestEvent = events[events.length - 1];
-        if (latestEvent) {
-          try {
-            await api1.applyRemoteEvent(latestEvent);
-            // Update replica1 text while preserving its cursor position
-            updateTextPreservingCursor(
-              replica1Ref,
-              setReplica1Text,
-              api1.getText(),
-            );
-          } catch (error) {
-            console.error("Failed to sync insert to replica1:", error);
-          }
-        }
-
-        // Update local state and preserve cursor position after insertion
-        setReplica2Text(api2.getText());
-        setTimeout(() => {
-          if (replica2Ref.current) {
-            replica2Ref.current.setSelectionRange(
-              expectedCursorPos,
-              expectedCursorPos,
-            );
-          }
-        }, 0);
-        return;
-      } else if (newText.length < oldText.length) {
-        // Deletion
-        const deletePos = findDeletePosition(oldText, newText);
-        const deleteCount = oldText.length - newText.length;
-        const expectedCursorPos = deletePos;
-
-        api2.delete(deletePos, deleteCount);
-
-        // Get the latest event from replica2 and propagate to replica1 asynchronously
-        const events = api2.exportEventGraph();
-        const latestEvent = events[events.length - 1];
-        if (latestEvent) {
-          try {
-            await api1.applyRemoteEvent(latestEvent);
-            // Update replica1 text while preserving its cursor position
-            updateTextPreservingCursor(
-              replica1Ref,
-              setReplica1Text,
-              api1.getText(),
-            );
-          } catch (error) {
-            console.error("Failed to sync delete to replica1:", error);
-          }
-        }
-
-        // Update local state and restore cursor position
-        setReplica2Text(api2.getText());
-        // Use setTimeout to ensure cursor restoration happens after React re-render
-        setTimeout(() => {
-          if (replica2Ref.current) {
-            replica2Ref.current.setSelectionRange(
-              expectedCursorPos,
-              expectedCursorPos,
-            );
-          }
-        }, 0);
-        return; // Early return to avoid duplicate state updates at the end
-      } else if (newText.length === oldText.length && newText !== oldText) {
-        // Replacement (same length, different content)
-        const { start, end } = findDifferingRange(oldText, newText);
-        const deleteCount = end - start + 1;
-        const replacementText = newText.slice(start, end + 1);
-        const expectedCursorPos = end + 1;
-
-        // Perform delete then insert
-        api2.delete(start, deleteCount);
-        api2.insert(start, replacementText);
-
-        // Get the latest two events (delete + insert) and propagate to replica1 asynchronously
-        const events = api2.exportEventGraph();
-        const latestEvents = events.slice(-2);
-        try {
-          for (const event of latestEvents) {
-            await api1.applyRemoteEvent(event);
-          }
-          // Update replica1 text while preserving its cursor position
-          updateTextPreservingCursor(
-            replica1Ref,
-            setReplica1Text,
-            api1.getText(),
-          );
-        } catch (error) {
-          console.error("Failed to sync replacement to replica1:", error);
-        }
-
-        // Update local state and preserve cursor position
-        setReplica2Text(api2.getText());
-        setTimeout(() => {
-          if (replica2Ref.current) {
-            replica2Ref.current.setSelectionRange(
-              expectedCursorPos,
-              expectedCursorPos,
-            );
-          }
-        }, 0);
-        return;
-      }
-
-      // Sync local state with API's getText() to ensure consistency
-      setReplica2Text(api2.getText());
-      setReplica1Text(api1.getText());
-    },
-    [
-      api1,
-      api2, // Update replica1 text while preserving its cursor position
-      updateTextPreservingCursor,
-    ],
+    (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+      runReplicaChange(event, {
+        localReplica: api2,
+        remoteReplica: api1,
+        localSync: replica2Sync,
+        remoteSync: replica1Sync,
+        setLocalText: setReplica2Text,
+        setRemoteText: setReplica1Text,
+        remoteLabel: "replica-1",
+      }),
+    [api1, api2, replica1Sync, replica2Sync],
   );
 
   return (

--- a/apps/playground/src/routes/demo/collaborative-editor.tsx
+++ b/apps/playground/src/routes/demo/collaborative-editor.tsx
@@ -1,18 +1,4 @@
 import {
-  mapTextareaSelectionThroughOperation,
-  type TextareaSelection,
-  type UseTextareaSelectionSyncResult,
-  useTextareaSelectionSync,
-} from "@softmaple/awareness/hooks";
-import {
-  findDeletePosition,
-  findDifferingRange,
-  findInsertPosition,
-  POSITION_OPERATION_TYPE,
-  type PositionOperation,
-} from "@softmaple/awareness/mapping";
-import { EgWalkerReplica } from "@softmaple/eg-walker";
-import {
   Card,
   CardContent,
   CardHeader,
@@ -20,194 +6,21 @@ import {
 } from "@softmaple/ui/components/card";
 import { Textarea } from "@softmaple/ui/components/textarea";
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useRef, useState } from "react";
+import { useCollaborativeEditor } from "@/modules/collaborative-editor/use-collaborative-editor";
 
 export const Route = createFileRoute("/demo/collaborative-editor")({
   component: CollaborativeEditor,
 });
 
-type LocalEdit = {
-  readonly mappingOperations: readonly PositionOperation[];
-  readonly apply: (replica: EgWalkerReplica) => void;
-};
-
-const computeLocalEdit = (
-  oldText: string,
-  newText: string,
-): LocalEdit | null => {
-  if (newText === oldText) {
-    return null;
-  }
-
-  if (newText.length > oldText.length) {
-    const insertPos = findInsertPosition(oldText, newText);
-    const insertedText = newText.slice(
-      insertPos,
-      insertPos + (newText.length - oldText.length),
-    );
-    return {
-      mappingOperations: [
-        {
-          type: POSITION_OPERATION_TYPE.Insert,
-          index: insertPos,
-          length: insertedText.length,
-        },
-      ],
-      apply: (replica) => {
-        replica.insert(insertPos, insertedText);
-      },
-    };
-  }
-
-  if (newText.length < oldText.length) {
-    const deletePos = findDeletePosition(oldText, newText);
-    const deleteCount = oldText.length - newText.length;
-    return {
-      mappingOperations: [
-        {
-          type: POSITION_OPERATION_TYPE.Delete,
-          index: deletePos,
-          length: deleteCount,
-        },
-      ],
-      apply: (replica) => {
-        replica.delete(deletePos, deleteCount);
-      },
-    };
-  }
-
-  const { start, end } = findDifferingRange(oldText, newText);
-  const length = end - start + 1;
-  const replacementText = newText.slice(start, end + 1);
-  return {
-    mappingOperations: [
-      {
-        type: POSITION_OPERATION_TYPE.Delete,
-        index: start,
-        length,
-      },
-      {
-        type: POSITION_OPERATION_TYPE.Insert,
-        index: start,
-        length: replacementText.length,
-      },
-    ],
-    apply: (replica) => {
-      replica.delete(start, length);
-      replica.insert(start, replacementText);
-    },
-  };
-};
-
-const mapSelectionThroughOperations = (
-  selection: TextareaSelection,
-  operations: readonly PositionOperation[],
-): TextareaSelection =>
-  operations.reduce<TextareaSelection>(
-    (current, operation) =>
-      mapTextareaSelectionThroughOperation(current, operation),
-    selection,
-  );
-
-type ReplicaChangeContext = {
-  readonly localReplica: EgWalkerReplica;
-  readonly remoteReplica: EgWalkerReplica;
-  readonly localSync: UseTextareaSelectionSyncResult;
-  readonly remoteSync: UseTextareaSelectionSyncResult;
-  readonly setLocalText: React.Dispatch<React.SetStateAction<string>>;
-  readonly setRemoteText: React.Dispatch<React.SetStateAction<string>>;
-  readonly remoteLabel: string;
-};
-
-const runReplicaChange = async (
-  event: React.ChangeEvent<HTMLTextAreaElement>,
-  context: ReplicaChangeContext,
-): Promise<void> => {
-  const {
-    localReplica,
-    remoteReplica,
-    localSync,
-    remoteSync,
-    setLocalText,
-    setRemoteText,
-    remoteLabel,
-  } = context;
-
-  const newText = event.target.value;
-  const oldText = localReplica.getText();
-  const edit = computeLocalEdit(oldText, newText);
-
-  if (!edit) {
-    setLocalText(localReplica.getText());
-    setRemoteText(remoteReplica.getText());
-    return;
-  }
-
-  // Capture cursor positions before any state mutation so we can restore the
-  // local cursor and map the remote cursor through the local operation(s).
-  localSync.captureSelection();
-  const remoteSelection = remoteSync.captureSelection();
-
-  edit.apply(localReplica);
-
-  const events = localReplica.exportEventGraph();
-  const newEvents = events.slice(-edit.mappingOperations.length);
-  try {
-    for (const remoteEvent of newEvents) {
-      await remoteReplica.applyRemoteEvent(remoteEvent);
-    }
-  } catch (error) {
-    console.error(`Failed to sync edit to ${remoteLabel}:`, error);
-  }
-
-  setLocalText(localReplica.getText());
-  localSync.restoreSelection();
-
-  setRemoteText(remoteReplica.getText());
-  if (remoteSelection) {
-    remoteSync.restoreSelection(
-      mapSelectionThroughOperations(remoteSelection, edit.mappingOperations),
-    );
-  }
-};
-
 function CollaborativeEditor() {
-  const [replica1Text, setReplica1Text] = useState("");
-  const [replica2Text, setReplica2Text] = useState("");
-  const [api1] = useState(() => new EgWalkerReplica("replica-1"));
-  const [api2] = useState(() => new EgWalkerReplica("replica-2"));
-  const replica1Ref = useRef<HTMLTextAreaElement>(null);
-  const replica2Ref = useRef<HTMLTextAreaElement>(null);
-  const replica1Sync = useTextareaSelectionSync(replica1Ref);
-  const replica2Sync = useTextareaSelectionSync(replica2Ref);
-
-  const handleReplica1Change = useCallback(
-    (event: React.ChangeEvent<HTMLTextAreaElement>) =>
-      runReplicaChange(event, {
-        localReplica: api1,
-        remoteReplica: api2,
-        localSync: replica1Sync,
-        remoteSync: replica2Sync,
-        setLocalText: setReplica1Text,
-        setRemoteText: setReplica2Text,
-        remoteLabel: "replica-2",
-      }),
-    [api1, api2, replica1Sync, replica2Sync],
-  );
-
-  const handleReplica2Change = useCallback(
-    (event: React.ChangeEvent<HTMLTextAreaElement>) =>
-      runReplicaChange(event, {
-        localReplica: api2,
-        remoteReplica: api1,
-        localSync: replica2Sync,
-        remoteSync: replica1Sync,
-        setLocalText: setReplica2Text,
-        setRemoteText: setReplica1Text,
-        remoteLabel: "replica-1",
-      }),
-    [api1, api2, replica1Sync, replica2Sync],
-  );
+  const {
+    replica1Text,
+    replica2Text,
+    replica1Ref,
+    replica2Ref,
+    handleReplica1Change,
+    handleReplica2Change,
+  } = useCollaborativeEditor();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900 text-white p-8">

--- a/apps/playground/src/test/collaborative-editor-utils.test.ts
+++ b/apps/playground/src/test/collaborative-editor-utils.test.ts
@@ -1,11 +1,13 @@
+import type {
+  TextareaSelection,
+  UseTextareaSelectionSyncResult,
+} from "@softmaple/awareness/hooks";
 import { EgWalkerReplica } from "@softmaple/eg-walker";
 import type { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { describe, expect, it, vi } from "vitest";
 import {
   computeLocalEdit,
   runReplicaChange,
-  type TextareaSelection,
-  type UseTextareaSelectionSyncResult,
 } from "../modules/collaborative-editor/use-collaborative-editor";
 
 const applyLocalEditToReplicaPair = (
@@ -19,9 +21,9 @@ const applyLocalEditToReplicaPair = (
     return;
   }
 
+  const eventsBeforeApply = localReplica.exportEventGraph().length;
   edit.apply(localReplica);
-  const events = localReplica.exportEventGraph();
-  const newEvents = events.slice(-edit.mappingOperations.length);
+  const newEvents = localReplica.exportEventGraph().slice(eventsBeforeApply);
   for (const event of newEvents) {
     remoteReplica.applyRemoteEvent(event);
   }

--- a/apps/playground/src/test/collaborative-editor-utils.test.ts
+++ b/apps/playground/src/test/collaborative-editor-utils.test.ts
@@ -1,6 +1,12 @@
 import { EgWalkerReplica } from "@softmaple/eg-walker";
-import { describe, expect, it } from "vitest";
-import { computeLocalEdit } from "../modules/collaborative-editor/use-collaborative-editor";
+import type { ChangeEvent, Dispatch, SetStateAction } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  computeLocalEdit,
+  runReplicaChange,
+  type TextareaSelection,
+  type UseTextareaSelectionSyncResult,
+} from "../modules/collaborative-editor/use-collaborative-editor";
 
 const applyLocalEditToReplicaPair = (
   localReplica: EgWalkerReplica,
@@ -42,4 +48,98 @@ describe("collaborative editor utilities", () => {
     expect(localReplica.getText()).toBe("abc12345def");
     expect(remoteReplica.getText()).toBe("abc12345def");
   });
+
+  it("remaps remote selection only through successfully applied operations", async () => {
+    const localReplica = new EgWalkerReplica("local");
+    const remoteReplica = new EgWalkerReplica("remote");
+    applyLocalEditToReplicaPair(localReplica, remoteReplica, "abcXYZdef");
+
+    const localSync = createTextareaSelectionSync(null);
+    const remoteSync = createTextareaSelectionSync({
+      selectionStart: 8,
+      selectionEnd: 8,
+      selectionDirection: "none",
+    });
+    const setLocalText: Dispatch<SetStateAction<string>> = vi.fn();
+    const setRemoteText: Dispatch<SetStateAction<string>> = vi.fn();
+    const applyRemoteEvent = remoteReplica.applyRemoteEvent.bind(remoteReplica);
+    let applyCount = 0;
+    vi.spyOn(remoteReplica, "applyRemoteEvent").mockImplementation((event) => {
+      applyCount++;
+      if (applyCount === 2) {
+        throw new Error("sync failed");
+      }
+      applyRemoteEvent(event);
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      await runReplicaChange(
+        {
+          target: { value: "abc12345def" },
+        } as ChangeEvent<HTMLTextAreaElement>,
+        {
+          localReplica,
+          remoteReplica,
+          localSync,
+          remoteSync,
+          setLocalText,
+          setRemoteText,
+          remoteLabel: "remote",
+        },
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(remoteReplica.getText()).toBe("abcdef");
+    expect(remoteSync.restoreSelection).toHaveBeenCalledWith({
+      selectionStart: 5,
+      selectionEnd: 5,
+      selectionDirection: "none",
+    });
+  });
+
+  it("does not remap remote selection for buffered remote events", async () => {
+    const localReplica = new EgWalkerReplica("local");
+    const remoteReplica = new EgWalkerReplica("remote");
+    const initialEdit = computeLocalEdit("", "abcXYZdef");
+    initialEdit?.apply(localReplica);
+
+    const localSync = createTextareaSelectionSync(null);
+    const remoteSync = createTextareaSelectionSync({
+      selectionStart: 0,
+      selectionEnd: 0,
+      selectionDirection: "none",
+    });
+
+    await runReplicaChange(
+      {
+        target: { value: "abc12345def" },
+      } as ChangeEvent<HTMLTextAreaElement>,
+      {
+        localReplica,
+        remoteReplica,
+        localSync,
+        remoteSync,
+        setLocalText: vi.fn(),
+        setRemoteText: vi.fn(),
+        remoteLabel: "remote",
+      },
+    );
+
+    expect(remoteReplica.getText()).toBe("");
+    expect(remoteReplica.getPendingRemoteCount()).toBeGreaterThan(0);
+    expect(remoteSync.restoreSelection).not.toHaveBeenCalled();
+  });
+});
+
+const createTextareaSelectionSync = (
+  selection: TextareaSelection | null,
+): UseTextareaSelectionSyncResult => ({
+  captureSelection: vi.fn(() => selection),
+  restoreSelection: vi.fn((nextSelection = selection) => nextSelection),
+  mapAndRestoreSelection: vi.fn(() => selection),
 });

--- a/apps/playground/src/test/collaborative-editor-utils.test.ts
+++ b/apps/playground/src/test/collaborative-editor-utils.test.ts
@@ -104,6 +104,57 @@ describe("collaborative editor utilities", () => {
     });
   });
 
+  it("restores the local selection captured at handler-start, not whatever a later capture would return", async () => {
+    // Regression guard for the explicit-pass fix: localSync.captureSelection's
+    // return value is stored in a local var and passed explicitly to
+    // restoreSelection, so a concurrent edit's overwrite of the hook's shared
+    // ref cannot leak into this handler's restore. If someone reverts to
+    // `localSync.restoreSelection()` (no args), the mock receives `undefined`
+    // and this test fails.
+    const localReplica = new EgWalkerReplica("local");
+    const remoteReplica = new EgWalkerReplica("remote");
+
+    const capturedAtHandlerStart: TextareaSelection = {
+      selectionStart: 1,
+      selectionEnd: 1,
+      selectionDirection: "none",
+    };
+    const wouldBeFromAConcurrentEdit: TextareaSelection = {
+      selectionStart: 99,
+      selectionEnd: 99,
+      selectionDirection: "none",
+    };
+    const localCapture = vi
+      .fn<() => TextareaSelection | null>()
+      .mockReturnValueOnce(capturedAtHandlerStart)
+      .mockReturnValue(wouldBeFromAConcurrentEdit);
+    const localRestore = vi.fn();
+    const localSync: UseTextareaSelectionSyncResult = {
+      captureSelection: localCapture,
+      restoreSelection: localRestore,
+      mapAndRestoreSelection: vi.fn(),
+    };
+
+    await runReplicaChange(
+      {
+        target: { value: "x" },
+      } as ChangeEvent<HTMLTextAreaElement>,
+      {
+        localReplica,
+        remoteReplica,
+        localSync,
+        remoteSync: createTextareaSelectionSync(null),
+        setLocalText: vi.fn(),
+        setRemoteText: vi.fn(),
+        remoteLabel: "remote",
+      },
+    );
+
+    expect(localRestore).toHaveBeenCalledTimes(1);
+    expect(localRestore).toHaveBeenCalledWith(capturedAtHandlerStart);
+    expect(localRestore).not.toHaveBeenCalledWith(wouldBeFromAConcurrentEdit);
+  });
+
   it("does not remap remote selection for buffered remote events", async () => {
     const localReplica = new EgWalkerReplica("local");
     const remoteReplica = new EgWalkerReplica("remote");

--- a/apps/playground/src/test/collaborative-editor-utils.test.ts
+++ b/apps/playground/src/test/collaborative-editor-utils.test.ts
@@ -1,0 +1,45 @@
+import { EgWalkerReplica } from "@softmaple/eg-walker";
+import { describe, expect, it } from "vitest";
+import { computeLocalEdit } from "../modules/collaborative-editor/use-collaborative-editor";
+
+const applyLocalEditToReplicaPair = (
+  localReplica: EgWalkerReplica,
+  remoteReplica: EgWalkerReplica,
+  newText: string,
+): void => {
+  const edit = computeLocalEdit(localReplica.getText(), newText);
+
+  if (!edit) {
+    return;
+  }
+
+  edit.apply(localReplica);
+  const events = localReplica.exportEventGraph();
+  const newEvents = events.slice(-edit.mappingOperations.length);
+  for (const event of newEvents) {
+    remoteReplica.applyRemoteEvent(event);
+  }
+};
+
+describe("collaborative editor utilities", () => {
+  it("syncs pure insertions between actual replicas", () => {
+    const localReplica = new EgWalkerReplica("local");
+    const remoteReplica = new EgWalkerReplica("remote");
+
+    applyLocalEditToReplicaPair(localReplica, remoteReplica, "Hello");
+
+    expect(localReplica.getText()).toBe("Hello");
+    expect(remoteReplica.getText()).toBe("Hello");
+  });
+
+  it("syncs replacements with net length changes between actual replicas", () => {
+    const localReplica = new EgWalkerReplica("local");
+    const remoteReplica = new EgWalkerReplica("remote");
+
+    applyLocalEditToReplicaPair(localReplica, remoteReplica, "abcXYZdef");
+    applyLocalEditToReplicaPair(localReplica, remoteReplica, "abc12345def");
+
+    expect(localReplica.getText()).toBe("abc12345def");
+    expect(remoteReplica.getText()).toBe("abc12345def");
+  });
+});

--- a/apps/playground/src/test/collaborative-editor.test.ts
+++ b/apps/playground/src/test/collaborative-editor.test.ts
@@ -1,3 +1,4 @@
+import { POSITION_OPERATION_TYPE } from "@softmaple/awareness/mapping";
 import { EgWalkerReplica } from "@softmaple/eg-walker";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -5,10 +6,7 @@ import {
   findDifferingRange,
   findInsertPosition,
 } from "../lib/text-diff";
-import {
-  computeLocalEdit,
-  POSITION_OPERATION_TYPE,
-} from "../modules/collaborative-editor/use-collaborative-editor";
+import { computeLocalEdit } from "../modules/collaborative-editor/use-collaborative-editor";
 
 interface MockEgWalkerReplica {
   insert: (position: number, text: string) => void;

--- a/apps/playground/src/test/collaborative-editor.test.ts
+++ b/apps/playground/src/test/collaborative-editor.test.ts
@@ -5,6 +5,10 @@ import {
   findDifferingRange,
   findInsertPosition,
 } from "../lib/text-diff";
+import {
+  computeLocalEdit,
+  POSITION_OPERATION_TYPE,
+} from "../modules/collaborative-editor/use-collaborative-editor";
 
 interface MockEgWalkerReplica {
   insert: (position: number, text: string) => void;
@@ -119,6 +123,52 @@ describe("Collaborative Editor Integration", () => {
   });
 
   describe("Replacement operations", () => {
+    it("should derive delete and insert for replacements with net insertion", () => {
+      const oldText = "abcXYZdef";
+      const newText = "abc12345def";
+      const edit = computeLocalEdit(oldText, newText);
+
+      edit?.apply(api as unknown as EgWalkerReplica);
+
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 3,
+          length: 3,
+        },
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 3,
+          length: 5,
+        },
+      ]);
+      expect(vi.mocked(api.delete)).toHaveBeenCalledWith(3, 3);
+      expect(vi.mocked(api.insert)).toHaveBeenCalledWith(3, "12345");
+    });
+
+    it("should derive delete and insert for replacements with net deletion", () => {
+      const oldText = "abc12345def";
+      const newText = "abcXYdef";
+      const edit = computeLocalEdit(oldText, newText);
+
+      edit?.apply(api as unknown as EgWalkerReplica);
+
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 3,
+          length: 5,
+        },
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 3,
+          length: 2,
+        },
+      ]);
+      expect(vi.mocked(api.delete)).toHaveBeenCalledWith(3, 5);
+      expect(vi.mocked(api.insert)).toHaveBeenCalledWith(3, "XY");
+    });
+
     it("should call delete and insert for replacement at the beginning", () => {
       const oldText = "hello world";
       const newText = "HELLO world";

--- a/apps/playground/workspace-aliases.ts
+++ b/apps/playground/workspace-aliases.ts
@@ -30,6 +30,9 @@ export const workspaceAlias: Readonly<Record<string, string>> = {
   "@softmaple/awareness/mapping": fromPlayground(
     "../../packages/awareness/src/mapping/index.ts",
   ),
+  "@softmaple/awareness/hooks": fromPlayground(
+    "../../packages/awareness/src/hooks/index.ts",
+  ),
   "@softmaple/awareness": fromPlayground(
     "../../packages/awareness/src/index.ts",
   ),

--- a/packages/awareness/src/mapping/index.ts
+++ b/packages/awareness/src/mapping/index.ts
@@ -9,6 +9,8 @@ export {
   type PositionRange,
 } from "./position-operation";
 export {
+  type ChangedSpan,
+  findChangedSpan,
   findDeletePosition,
   findDifferingRange,
   findInsertPosition,

--- a/packages/awareness/src/mapping/text-diff.test.ts
+++ b/packages/awareness/src/mapping/text-diff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  findChangedSpan,
   findDeletePosition,
   findDifferingRange,
   findInsertPosition,
@@ -105,5 +106,64 @@ describe("findDifferingRange", () => {
       start: 2,
       end: 2,
     });
+  });
+});
+
+describe("findChangedSpan", () => {
+  it("returns zero-length span for equal strings", () => {
+    expect(findChangedSpan("abc", "abc")).toEqual({ prefix: 3, suffix: 0 });
+  });
+
+  it("identifies a pure prefix insert", () => {
+    expect(findChangedSpan("world", "hello world")).toEqual({
+      prefix: 0,
+      suffix: 5,
+    });
+  });
+
+  it("identifies a pure suffix delete", () => {
+    expect(findChangedSpan("hello world", "hello")).toEqual({
+      prefix: 5,
+      suffix: 0,
+    });
+  });
+
+  it("identifies a same-length middle replacement", () => {
+    // "abc" + "XYZ" + "def" → "abc" + "123" + "def"
+    expect(findChangedSpan("abcXYZdef", "abc123def")).toEqual({
+      prefix: 3,
+      suffix: 3,
+    });
+  });
+
+  it("identifies a net-insertion middle replacement", () => {
+    // "abc" + "XYZ" + "def" → "abc" + "12345" + "def"
+    expect(findChangedSpan("abcXYZdef", "abc12345def")).toEqual({
+      prefix: 3,
+      suffix: 3,
+    });
+  });
+
+  it("identifies a net-deletion middle replacement", () => {
+    // "abc" + "12345" + "def" → "abc" + "XY" + "def"
+    expect(findChangedSpan("abc12345def", "abcXYdef")).toEqual({
+      prefix: 3,
+      suffix: 3,
+    });
+  });
+
+  it("does not double-count overlapping prefix and suffix on shrinks", () => {
+    // Prefix walks "ab" (matches), then stops at index 2. Suffix walks back
+    // through "b" and "a" but must not cross into the prefix — `suffix` is
+    // capped by the remaining length on each side.
+    expect(findChangedSpan("abab", "ab")).toEqual({ prefix: 2, suffix: 0 });
+  });
+
+  it("handles insert into empty string", () => {
+    expect(findChangedSpan("", "abc")).toEqual({ prefix: 0, suffix: 0 });
+  });
+
+  it("handles delete to empty string", () => {
+    expect(findChangedSpan("abc", "")).toEqual({ prefix: 0, suffix: 0 });
   });
 });

--- a/packages/awareness/src/mapping/text-diff.ts
+++ b/packages/awareness/src/mapping/text-diff.ts
@@ -33,6 +33,49 @@ export const findDeletePosition = (
   return newText.length;
 };
 
+export type ChangedSpan = {
+  /** Length of the common prefix shared by `oldText` and `newText`. */
+  readonly prefix: number;
+  /** Length of the common suffix shared by `oldText` and `newText`. */
+  readonly suffix: number;
+};
+
+/**
+ * Identify the changed span between `oldText` and `newText` by stripping the
+ * longest common prefix and longest common suffix. Handles inserts, deletes,
+ * and net-length-changing replacements in a single pass — unlike the
+ * `find{Insert,Delete}Position` / `findDifferingRange` helpers above, which
+ * each assume one specific shape of edit.
+ *
+ * Callers derive the edit from `{ prefix, suffix }`:
+ *   - `deletedLength = oldText.length - prefix - suffix`
+ *   - `insertedText  = newText.slice(prefix, newText.length - suffix)`
+ *
+ * Both can be zero (pure insert, pure delete, or no-op).
+ */
+export const findChangedSpan = (
+  oldText: string,
+  newText: string,
+): ChangedSpan => {
+  const minLength = Math.min(oldText.length, newText.length);
+  let prefix = 0;
+  while (prefix < minLength && oldText[prefix] === newText[prefix]) {
+    prefix++;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < oldText.length - prefix &&
+    suffix < newText.length - prefix &&
+    oldText[oldText.length - suffix - 1] ===
+      newText[newText.length - suffix - 1]
+  ) {
+    suffix++;
+  }
+
+  return { prefix, suffix };
+};
+
 export const findDifferingRange = (
   oldText: string,
   newText: string,

--- a/packages/awareness/src/mapping/text-diff.ts
+++ b/packages/awareness/src/mapping/text-diff.ts
@@ -52,6 +52,11 @@ export type ChangedSpan = {
  *   - `insertedText  = newText.slice(prefix, newText.length - suffix)`
  *
  * Both can be zero (pure insert, pure delete, or no-op).
+ *
+ * Encoding convention: prefix is consumed greedily first, then suffix. So
+ * equal strings return `{ prefix: len, suffix: 0 }` rather than the
+ * symmetrically-valid `{ prefix: 0, suffix: len }`. Consumers that derive
+ * `deletedLength` / `insertedText` from the result are unaffected.
  */
 export const findChangedSpan = (
   oldText: string,


### PR DESCRIPTION
Closes #737 

## Summary

- Replaces the playground's naive `updateTextPreservingCursor` helper with `useTextareaSelectionSync` from `@softmaple/awareness/hooks`; the local cursor is captured and restored through the hook, and the remote cursor is mapped through the local `PositionOperation`(s) before restore.
- Collapses `handleReplica1Change` and `handleReplica2Change` into one shared `runReplicaChange(event, context)` helper so the demo stays as wiring only and awareness owns cursor/selection mapping.
- Addresses finding 737. Step 4 in the implementation order tracked by finding 741.

## Test plan

- [x] `pnpm --filter playground typecheck`
- [x] `pnpm --filter playground test`
- [x] `pnpm --filter @softmaple/awareness test -- --run`
- [x] `pnpm --filter @softmaple/awareness build`
- [x] `biome check --write` clean
- [ ] Manual: open `/demo/collaborative-editor`; with caret mid-text in replica 1, type into replica 2 before that caret — replica 1's caret tracks the inserted text instead of staying at its byte index. Repeat for delete-before-cursor and overlapping-selection delete.

## Related

- Follow-up filed as finding 745 to apply the same mapping pattern to the awareness-collab demo's inbound BroadcastChannel path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved selection and cursor synchronization in the collaborative editor for more accurate, real-time coordination of changes across multiple editors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->