### PR TITLE
feat(packages/eg-walker): structural result from applyRemoteEvent

### DIFF
--- a/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
+++ b/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
@@ -80,6 +80,14 @@ const mapSelectionThroughOperations = (
     selection,
   );
 
+/**
+ * Derive the mapping operation(s) implied by the remote replica's
+ * pre/post text. Reuses `computeLocalEdit` — same plain-text 1D diff
+ * shape, different replica — so the engine's `null` cases (partial/full
+ * replay, multi-op coalesced delete, visible no-op) still produce a
+ * faithful mapping op for selection remap. Visible no-ops correctly
+ * return an empty array because both texts compare equal.
+ */
 const computeMappingOperationsFromTextChange = (
   oldText: string,
   newText: string,

--- a/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
+++ b/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
@@ -9,7 +9,10 @@ import {
   POSITION_OPERATION_TYPE,
   type PositionOperation,
 } from "@softmaple/awareness/mapping";
-import { EgWalkerReplica } from "@softmaple/eg-walker";
+import {
+  APPLY_REMOTE_EVENT_STATUS,
+  EgWalkerReplica,
+} from "@softmaple/eg-walker";
 import {
   type ChangeEvent,
   type Dispatch,
@@ -127,11 +130,21 @@ export const runReplicaChange = async (
   const appliedMappingOperations: PositionOperation[] = [];
   try {
     for (const [index, remoteEvent] of newEvents.entries()) {
-      const textBeforeRemoteApply = remoteReplica.getText();
-      await remoteReplica.applyRemoteEvent(remoteEvent);
-      const operation = edit.mappingOperations[index];
-      if (operation && remoteReplica.getText() !== textBeforeRemoteApply) {
-        appliedMappingOperations.push(operation);
+      const result = await remoteReplica.applyRemoteEvent(remoteEvent);
+      if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
+        continue;
+      }
+      // Prefer the engine-attributed PositionOperation: it reflects the
+      // actual effect-index integration on the remote replica, which is
+      // what selection mapping needs. Fall back to the locally-computed
+      // mapping operation only when the engine returned `null` (visible
+      // no-op, multi-op coalesced delete, or partial/full replay path)
+      // — in that case the local mapping op is still the best available
+      // approximation for the simple two-replica scenario.
+      const mappingOperation =
+        result.operation ?? edit.mappingOperations[index] ?? null;
+      if (mappingOperation) {
+        appliedMappingOperations.push(mappingOperation);
       }
     }
   } catch (error) {

--- a/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
+++ b/apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts
@@ -80,6 +80,14 @@ const mapSelectionThroughOperations = (
     selection,
   );
 
+const computeMappingOperationsFromTextChange = (
+  oldText: string,
+  newText: string,
+): readonly PositionOperation[] => {
+  const edit = computeLocalEdit(oldText, newText);
+  return edit?.mappingOperations ?? [];
+};
+
 export type ReplicaChangeContext = {
   readonly localReplica: EgWalkerReplica;
   readonly remoteReplica: EgWalkerReplica;
@@ -129,23 +137,23 @@ export const runReplicaChange = async (
 
   const appliedMappingOperations: PositionOperation[] = [];
   try {
-    for (const [index, remoteEvent] of newEvents.entries()) {
+    for (const remoteEvent of newEvents) {
+      const textBeforeRemoteApply = remoteReplica.getText();
       const result = await remoteReplica.applyRemoteEvent(remoteEvent);
       if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
         continue;
       }
-      // Prefer the engine-attributed PositionOperation: it reflects the
-      // actual effect-index integration on the remote replica, which is
-      // what selection mapping needs. Fall back to the locally-computed
-      // mapping operation only when the engine returned `null` (visible
-      // no-op, multi-op coalesced delete, or partial/full replay path)
-      // — in that case the local mapping op is still the best available
-      // approximation for the simple two-replica scenario.
-      const mappingOperation =
-        result.operation ?? edit.mappingOperations[index] ?? null;
-      if (mappingOperation) {
-        appliedMappingOperations.push(mappingOperation);
+      if (result.operation) {
+        appliedMappingOperations.push(result.operation);
+        continue;
       }
+      const textAfterRemoteApply = remoteReplica.getText();
+      appliedMappingOperations.push(
+        ...computeMappingOperationsFromTextChange(
+          textBeforeRemoteApply,
+          textAfterRemoteApply,
+        ),
+      );
     }
   } catch (error) {
     console.error(`Failed to sync edit to ${remoteLabel}:`, error);

--- a/apps/playground/src/test/collaborative-editor-utils.test.ts
+++ b/apps/playground/src/test/collaborative-editor-utils.test.ts
@@ -71,7 +71,7 @@ describe("collaborative editor utilities", () => {
       if (applyCount === 2) {
         throw new Error("sync failed");
       }
-      applyRemoteEvent(event);
+      return applyRemoteEvent(event);
     });
     const consoleError = vi
       .spyOn(console, "error")

--- a/apps/playground/src/test/collaborative-editor-utils.test.ts
+++ b/apps/playground/src/test/collaborative-editor-utils.test.ts
@@ -187,6 +187,45 @@ describe("collaborative editor utilities", () => {
     expect(remoteReplica.getPendingRemoteCount()).toBeGreaterThan(0);
     expect(remoteSync.restoreSelection).not.toHaveBeenCalled();
   });
+
+  it("does not remap remote selection when a null remote operation is a visible no-op", async () => {
+    const seed = new EgWalkerReplica("seed");
+    seed.insert(0, "abcd");
+    const [seedEvent] = seed.exportEventGraph();
+    expect(seedEvent).toBeDefined();
+
+    const localReplica = new EgWalkerReplica("local");
+    const remoteReplica = new EgWalkerReplica("remote");
+    localReplica.applyRemoteEvent(seedEvent!);
+    remoteReplica.applyRemoteEvent(seedEvent!);
+
+    remoteReplica.delete(1, 2);
+
+    const remoteSync = createTextareaSelectionSync({
+      selectionStart: 2,
+      selectionEnd: 2,
+      selectionDirection: "none",
+    });
+
+    await runReplicaChange(
+      {
+        target: { value: "ad" },
+      } as ChangeEvent<HTMLTextAreaElement>,
+      {
+        localReplica,
+        remoteReplica,
+        localSync: createTextareaSelectionSync(null),
+        remoteSync,
+        setLocalText: vi.fn(),
+        setRemoteText: vi.fn(),
+        remoteLabel: "remote",
+      },
+    );
+
+    expect(localReplica.getText()).toBe("ad");
+    expect(remoteReplica.getText()).toBe("ad");
+    expect(remoteSync.restoreSelection).not.toHaveBeenCalled();
+  });
 });
 
 const createTextareaSelectionSync = (

--- a/docs/design/collaboration-layers.md
+++ b/docs/design/collaboration-layers.md
@@ -271,7 +271,10 @@ That works in practice but is brittle:
   through a coalescing path, IME compositions in #704) would silently
   flip the inferred outcome.
 - It materialises the full text twice per event. The structural API
-  has zero per-event text cost.
+  is free on the common (incremental-advance) path; consumers that
+  need a mapping op only fall back to a text diff when the engine
+  returns `operation: null` (partial/full replay, multi-op coalesced
+  delete, visible no-op), which is the minority case.
 - It conflates "integrated" with "buffered" with "duplicate" into a
   single boolean. The new API distinguishes them so a buffered event
   cannot be mistaken for an integrated one.

--- a/docs/design/collaboration-layers.md
+++ b/docs/design/collaboration-layers.md
@@ -214,6 +214,77 @@ following shapes:
   y, width, height }`) so a canvas integration never has to round-trip
   through `CursorPosition`.
 
+### Structural remote-event result (issue [#747](https://github.com/softmaple/softmaple/issues/747))
+
+`EgWalkerReplica.applyRemoteEvent` returns an
+`ApplyRemoteEventResult` describing the integration outcome
+structurally, so consumers do not have to infer it from a `getText()`
+pre/post comparison:
+
+```ts
+type ApplyRemoteEventResult =
+  | { status: "integrated"; operation: PositionOperation | null }
+  | { status: "buffered" }
+  | { status: "duplicate" };
+```
+
+- **`"integrated"`** — the event landed in the graph and advanced the
+  document. `operation` carries the engine-attributed
+  `PositionOperation` when the engine took the incremental advance
+  path and produced exactly one transformed op; otherwise `null`
+  (visible no-op, multi-op coalesced delete, or partial/full replay).
+  Consumers driving selection mapping should treat `null` as
+  "remap from text diff", not "skip the remap".
+- **`"buffered"`** — at least one parent is missing, the event is
+  queued, and the document is unchanged. The buffered event flushes
+  automatically when its last parent arrives, as a side effect of the
+  parent's `applyRemoteEvent` call. That flush is **not** reported
+  through a separate result — a consumer that needs per-flush
+  notifications must currently re-derive them by walking the post-call
+  text.
+- **`"duplicate"`** — the event id is already in the graph or already
+  buffered; the call is a no-op.
+
+The `PositionOperation` shape returned from eg-walker mirrors the type
+defined by `@softmaple/awareness/mapping`. Each package owns its own
+copy so the layer boundary holds (eg-walker still does not depend on
+awareness), and structural typing lets consumers pass either through
+`mapTextareaSelectionThroughOperation` interchangeably.
+
+#### Why this is safer than a `getText()` comparison
+
+The pre-#747 consumer code in
+`apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts`
+inferred integration from a text side effect:
+
+```ts
+const before = remoteReplica.getText();
+remoteReplica.applyRemoteEvent(event);
+if (remoteReplica.getText() !== before) { /* assume integrated */ }
+```
+
+That works in practice but is brittle:
+
+- It is *behavioral*, not *structural*. Any future change that lets an
+  integrated event produce a zero-width visible change (a delete that
+  fully overlaps already-deleted characters, an empty insert sliding
+  through a coalescing path, IME compositions in #704) would silently
+  flip the inferred outcome.
+- It materialises the full text twice per event. The structural API
+  has zero per-event text cost.
+- It conflates "integrated" with "buffered" with "duplicate" into a
+  single boolean. The new API distinguishes them so a buffered event
+  cannot be mistaken for an integrated one.
+
+#### Buffering semantics
+
+`RemoteEventBuffer` (in `core/internals/`) still owns the same
+state machine: an event with a missing parent is keyed on the
+missing parent id; when that parent later arrives, every queued child
+is re-tried in causal order via recursive `tryAccept` calls. The only
+behavioral change is the return shape — pending/applied/duplicate
+ordering, idempotence, and causal-flush semantics are preserved.
+
 ### Audit (issue [#727](https://github.com/softmaple/softmaple/issues/727))
 
 Both packages' public types were audited against the contract above and

--- a/packages/eg-walker/src/core/internals/remote-event-buffer.ts
+++ b/packages/eg-walker/src/core/internals/remote-event-buffer.ts
@@ -16,9 +16,11 @@ interface RemoteEventBufferDeps {
   /**
    * Apply the event on top of existing replica state. The dependency
    * returns the position operation produced by the integration when the
-   * engine can attribute one to this event in isolation (incremental
-   * advance, single transformed op); otherwise `null` (partial/full
-   * replay, multi-op coalesced delete, visible no-op).
+   * engine can attribute one to this event in isolation: the incremental
+   * advance path and the cold-start single-event full replay both
+   * surface the single transformed op. Returns `null` for partial/full
+   * replay on an existing engine (concurrent integration retransforms
+   * multiple events), multi-op coalesced deletes, and visible no-ops.
    *
    * See `IntegratedApplyRemoteEventResult.operation` for the contract.
    */
@@ -82,6 +84,12 @@ export class RemoteEventBuffer {
     try {
       graph.addEvent(event);
     } catch (error) {
+      // `EventAlreadyExistsError` overlaps with the fast-path check at
+      // the top of this method; the graph is the source of truth.
+      // `MissingParentError` here would be a race (we just checked
+      // every parent via `findMissingParent` and found none missing) —
+      // there is no useful new status to surface, so we coalesce it
+      // into `DUPLICATE_RESULT` rather than letting it propagate.
       if (
         error instanceof EventAlreadyExistsError ||
         error instanceof MissingParentError

--- a/packages/eg-walker/src/core/internals/remote-event-buffer.ts
+++ b/packages/eg-walker/src/core/internals/remote-event-buffer.ts
@@ -3,12 +3,35 @@ import {
   MissingParentError,
   type EventGraph,
 } from "../../graph/event-graph";
-import type { EventId, GraphEvent } from "../../types";
+import {
+  APPLY_REMOTE_EVENT_STATUS,
+  type ApplyRemoteEventResult,
+  type EventId,
+  type GraphEvent,
+  type PositionOperation,
+} from "../../types";
 
 interface RemoteEventBufferDeps {
   readonly graph: EventGraph;
-  readonly advanceWithEvent: (event: GraphEvent) => void;
+  /**
+   * Apply the event on top of existing replica state. The dependency
+   * returns the position operation produced by the integration when the
+   * engine can attribute one to this event in isolation (incremental
+   * advance, single transformed op); otherwise `null` (partial/full
+   * replay, multi-op coalesced delete, visible no-op).
+   *
+   * See `IntegratedApplyRemoteEventResult.operation` for the contract.
+   */
+  readonly advanceWithEvent: (event: GraphEvent) => PositionOperation | null;
 }
+
+const BUFFERED_RESULT = {
+  status: APPLY_REMOTE_EVENT_STATUS.Buffered,
+} as const;
+
+const DUPLICATE_RESULT = {
+  status: APPLY_REMOTE_EVENT_STATUS.Duplicate,
+} as const;
 
 export class RemoteEventBuffer {
   private readonly pendingByMissingParent = new Map<EventId, GraphEvent[]>();
@@ -28,18 +51,23 @@ export class RemoteEventBuffer {
   /**
    * Apply a remote event, or buffer it until its missing parents arrive.
    *
-   * If `event` is already in the graph or already buffered it is ignored.
-   * If any parent is unknown the event is queued against the missing parent
-   * id; the queue is flushed when that parent is later accepted. Otherwise
-   * the event is added to the graph and `deps.advanceWithEvent` is invoked,
-   * then any waiters queued on this event's id are recursively accepted.
+   * If `event` is already in the graph or already buffered the call is a
+   * no-op and reports `"duplicate"`. If any parent is unknown the event
+   * is queued against the missing parent id and reports `"buffered"`;
+   * the queue is flushed when that parent is later accepted. Otherwise
+   * the event is added to the graph, `deps.advanceWithEvent` is invoked,
+   * any waiters queued on this event's id are recursively accepted as a
+   * side effect (not reported), and the call reports `"integrated"` with
+   * the engine-attributed position operation (or `null`; see the type
+   * docstring for when).
    *
    * @param {GraphEvent} event remote event to accept or buffer.
+   * @returns {ApplyRemoteEventResult} structural integration status.
    */
-  tryAccept(event: GraphEvent): void {
+  tryAccept(event: GraphEvent): ApplyRemoteEventResult {
     const { graph } = this.deps;
     if (graph.hasEvent(event.id) || this.bufferedEventIds.has(event.id)) {
-      return;
+      return DUPLICATE_RESULT;
     }
 
     const missingParent = this.findMissingParent(event);
@@ -48,7 +76,7 @@ export class RemoteEventBuffer {
       queue.push(event);
       this.pendingByMissingParent.set(missingParent, queue);
       this.bufferedEventIds.add(event.id);
-      return;
+      return BUFFERED_RESULT;
     }
 
     try {
@@ -58,13 +86,17 @@ export class RemoteEventBuffer {
         error instanceof EventAlreadyExistsError ||
         error instanceof MissingParentError
       ) {
-        return;
+        return DUPLICATE_RESULT;
       }
       throw error;
     }
 
-    this.deps.advanceWithEvent(event);
+    const operation = this.deps.advanceWithEvent(event);
     this.flushPendingChildrenOf(event.id);
+    return {
+      status: APPLY_REMOTE_EVENT_STATUS.Integrated,
+      operation,
+    };
   }
 
   private findMissingParent(event: GraphEvent): EventId | null {

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -10,10 +10,12 @@
 import { OPERATION_TYPE } from "../constants/operation-types";
 import { REPLAY_SOURCE, type ReplaySource } from "../constants/replay-source";
 import type {
+  ApplyRemoteEventResult,
   ExternalOperation,
   DocumentState,
   GraphEvent,
   EventId,
+  PositionOperation,
   Version,
   SerializedGraphInput,
   SerializedGraphOutput,
@@ -203,16 +205,26 @@ export class EgWalkerReplica {
       throw error;
     }
 
+    // Local edits don't expose the engine's transformed operation; the
+    // caller already knows what they typed. Discard the helper's return.
     this.advanceWithEvent(event);
   }
 
   /**
    * Apply a remote event. Buffers events with unknown parents until they can
    * be applied in causal order, so callers do not need to deliver in order.
+   *
+   * Returns a structural {@link ApplyRemoteEventResult} so consumers can
+   * react to integration / buffering / duplicate paths without inferring
+   * them from a `getText()` pre/post comparison. When the event is
+   * integrated through the engine's incremental advance path and the
+   * apply produces a single transformed operation, that operation is
+   * surfaced in the `integrated` result; see the type docstring for the
+   * paths where `operation` is `null`.
    */
-  applyRemoteEvent(event: GraphEvent): void {
+  applyRemoteEvent(event: GraphEvent): ApplyRemoteEventResult {
     assertRemoteEventWellFormed(event);
-    this.remoteEvents.tryAccept(event);
+    return this.remoteEvents.tryAccept(event);
   }
 
   /**
@@ -366,7 +378,7 @@ export class EgWalkerReplica {
     return replica;
   }
 
-  private fullReplay(): void {
+  private fullReplay(): ReadonlyArray<ExternalOperation> {
     // Section 3.4 of the paper: walk the event graph in branch-preserving
     // order so each parent transition matches the engine's current version
     // and triggers the non-conflicting-run fast path instead of forcing a
@@ -384,6 +396,10 @@ export class EgWalkerReplica {
     this.engine = engine;
     this.fullReplayCount++;
     this.lastReplaySource = REPLAY_SOURCE.FULL;
+    // Returned for the cold-start single-event path in {@link advanceWithEvent};
+    // other callers (constructor seed, retreat-needed full replay) ignore
+    // this because the array spans the whole graph, not a single event.
+    return generated.transformedOperations;
   }
 
   /**
@@ -418,22 +434,39 @@ export class EgWalkerReplica {
    *      Replays only events in `expand(frontier) \ expand(checkpoint)`.
    *   3. Full replay — only when no checkpoint dominates the divergent
    *      region (e.g. concurrent root inserts with no critical ancestor).
+   *
+   * Returns the position operation attributable to {@link event} when
+   * the incremental path is taken and the engine produced a single
+   * transformed operation; `null` otherwise. The partial/full replay
+   * paths return `null` because concurrent integration retransforms
+   * multiple events and there is no single insert/delete on the
+   * pre-event document that captures the visible effect of this one
+   * event. See {@link ApplyRemoteEventResult} for the contract.
    */
-  private advanceWithEvent(event: GraphEvent): void {
+  private advanceWithEvent(event: GraphEvent): PositionOperation | null {
     if (!this.engine) {
-      this.fullReplay();
+      // Cold-start: this code path only fires on a replica that started
+      // with an empty event graph and is now seeing its first event. The
+      // event was already added to the graph before we got here, so the
+      // graph contains exactly that event — `fullReplay` runs the engine
+      // on a single-event trace and its `transformedOperations` is the
+      // visible effect of this one event, which is exactly what we want
+      // to surface to the caller. A replica constructed from a non-empty
+      // prebuilt graph already ran `fullReplay` in the constructor, so
+      // multi-event cold starts cannot reach this branch.
+      const transformed = this.fullReplay();
       this.maybeAdvanceCheckpoint();
-      return;
+      return toPositionOperation(transformed);
     }
 
     if (this.canIncrementallyAdvance(event)) {
-      this.engine.applyEvent(event, this.eventGraph);
+      const applied = this.engine.applyEvent(event, this.eventGraph);
       this.document = this.engine.getText();
       this.currentVersion = this.eventGraph.getFrontier();
       this.incrementalApplyCount++;
       this.lastReplaySource = REPLAY_SOURCE.INCREMENTAL;
       this.maybeAdvanceCheckpoint();
-      return;
+      return toPositionOperation(applied.transformedOperations);
     }
 
     const checkpoint = this.criticalCheckpoints.pickFor(this.eventGraph);
@@ -443,6 +476,7 @@ export class EgWalkerReplica {
       this.fullReplay();
     }
     this.maybeAdvanceCheckpoint();
+    return null;
   }
 
   /**
@@ -513,4 +547,47 @@ export function createEgWalkerReplica(
   initialText?: string,
 ): EgWalkerReplica {
   return new EgWalkerReplica(replicaId, initialText);
+}
+
+/**
+ * Reduce the engine's per-event transformed operations to a single
+ * editor-agnostic {@link PositionOperation}, or `null` when no single
+ * operation captures the visible effect of the event.
+ *
+ * - Zero ops → `null` (visible no-op: empty insert, zero-length delete,
+ *   or a delete that fully overlaps already-deleted characters).
+ * - Multiple ops → `null` (a delete that coalesced into disjoint runs;
+ *   the caller would need a multi-op API to represent it faithfully).
+ * - One op → mapped to `PositionOperation`. Insert payloads strip the
+ *   `text` field because awareness consumers only need the length in
+ *   UTF-16 code units.
+ */
+function toPositionOperation(
+  transformed: ReadonlyArray<ExternalOperation>,
+): PositionOperation | null {
+  if (transformed.length !== 1) {
+    return null;
+  }
+  const [op] = transformed;
+  if (!op) {
+    return null;
+  }
+  if (op.type === OPERATION_TYPE.INSERT) {
+    if (op.text.length === 0) {
+      return null;
+    }
+    return {
+      type: OPERATION_TYPE.INSERT,
+      index: op.index,
+      length: op.text.length,
+    };
+  }
+  if (op.length === 0) {
+    return null;
+  }
+  return {
+    type: OPERATION_TYPE.DELETE,
+    index: op.index,
+    length: op.length,
+  };
 }

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -558,9 +558,9 @@ export function createEgWalkerReplica(
  *   or a delete that fully overlaps already-deleted characters).
  * - Multiple ops → `null` (a delete that coalesced into disjoint runs;
  *   the caller would need a multi-op API to represent it faithfully).
- * - One op → mapped to `PositionOperation`. Insert payloads strip the
- *   `text` field because awareness consumers only need the length in
- *   UTF-16 code units.
+ * - One op → mapped to `PositionOperation`. Insert payloads convert
+ *   `text` to `length` (UTF-16 code units) because awareness consumers
+ *   address positions by length, not by inserted string.
  */
 function toPositionOperation(
   transformed: ReadonlyArray<ExternalOperation>,

--- a/packages/eg-walker/src/test/apply-remote-event-result.test.ts
+++ b/packages/eg-walker/src/test/apply-remote-event-result.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the structural {@link ApplyRemoteEventResult} surfaced by
+ * {@link EgWalkerReplica.applyRemoteEvent}. Pins the contract that
+ * consumers rely on so they don't have to infer integration state by
+ * comparing `getText()` before and after the call.
+ */
+import { describe, expect, it } from "vitest";
+
+import { OPERATION_TYPE } from "../constants/operation-types";
+import { EgWalkerReplica } from "../core/replica";
+import {
+  APPLY_REMOTE_EVENT_STATUS,
+  type ApplyRemoteEventResult,
+} from "../types";
+import { cloneEvent } from "./test-helpers";
+
+describe("EgWalkerReplica.applyRemoteEvent — structural result", () => {
+  it("reports `integrated` with a PositionOperation for a simple insert", () => {
+    const author = new EgWalkerReplica("author");
+    author.insert(0, "hi");
+    const [event] = author.exportEventGraph();
+    expect(event).toBeDefined();
+
+    const replica = new EgWalkerReplica("replica");
+    const result = replica.applyRemoteEvent(cloneEvent(event!));
+
+    expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
+    if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
+      throw new Error("status narrowing");
+    }
+    expect(result.operation).toEqual({
+      type: OPERATION_TYPE.INSERT,
+      index: 0,
+      length: 2,
+    });
+    expect(replica.getText()).toBe("hi");
+  });
+
+  it("reports `integrated` with a delete PositionOperation", () => {
+    const author = new EgWalkerReplica("author");
+    author.insert(0, "hello");
+    author.delete(1, 3);
+    const events = author.exportEventGraph();
+    expect(events).toHaveLength(2);
+
+    const replica = new EgWalkerReplica("replica");
+    replica.applyRemoteEvent(cloneEvent(events[0]!));
+    const result = replica.applyRemoteEvent(cloneEvent(events[1]!));
+
+    expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
+    if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
+      throw new Error("status narrowing");
+    }
+    expect(result.operation).toEqual({
+      type: OPERATION_TYPE.DELETE,
+      index: 1,
+      length: 3,
+    });
+    expect(replica.getText()).toBe("ho");
+  });
+
+  it("reports `duplicate` when the same event is delivered twice", () => {
+    const author = new EgWalkerReplica("author");
+    author.insert(0, "x");
+    const [event] = author.exportEventGraph();
+
+    const replica = new EgWalkerReplica("replica");
+    const first = replica.applyRemoteEvent(cloneEvent(event!));
+    const second = replica.applyRemoteEvent(cloneEvent(event!));
+
+    expect(first.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
+    expect(second.status).toBe(APPLY_REMOTE_EVENT_STATUS.Duplicate);
+    expect(replica.getText()).toBe("x");
+  });
+
+  it("reports `buffered` when a parent is missing and `integrated` once the parent arrives", () => {
+    const author = new EgWalkerReplica("author");
+    author.insert(0, "a");
+    author.insert(1, "b");
+    const [first, second] = author.exportEventGraph();
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+
+    const replica = new EgWalkerReplica("replica");
+    // Deliver child before parent: must buffer, document stays empty.
+    const bufferedResult = replica.applyRemoteEvent(cloneEvent(second!));
+    expect(bufferedResult.status).toBe(APPLY_REMOTE_EVENT_STATUS.Buffered);
+    expect(replica.getText()).toBe("");
+    expect(replica.getPendingRemoteCount()).toBe(1);
+
+    // Buffering the same event again should be a duplicate, not a re-buffer.
+    const reBuffered = replica.applyRemoteEvent(cloneEvent(second!));
+    expect(reBuffered.status).toBe(APPLY_REMOTE_EVENT_STATUS.Duplicate);
+    expect(replica.getPendingRemoteCount()).toBe(1);
+
+    // Parent arrives: caller's event integrates, buffered child flushes
+    // as a side effect (not reported by this call).
+    const parentResult = replica.applyRemoteEvent(cloneEvent(first!));
+    expect(parentResult.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
+    if (parentResult.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
+      throw new Error("status narrowing");
+    }
+    expect(parentResult.operation).toEqual({
+      type: OPERATION_TYPE.INSERT,
+      index: 0,
+      length: 1,
+    });
+    expect(replica.getPendingRemoteCount()).toBe(0);
+    expect(replica.getText()).toBe("ab");
+  });
+
+  it("reports `duplicate` when the event is already in the graph", () => {
+    const author = new EgWalkerReplica("author");
+    author.insert(0, "x");
+    const [event] = author.exportEventGraph();
+
+    // Seed the replica from the graph so the event lives in the graph
+    // (not in the buffer) before the duplicate delivery.
+    const replica = EgWalkerReplica.fromEventGraph("replica", [
+      cloneEvent(event!),
+    ]);
+    const result = replica.applyRemoteEvent(cloneEvent(event!));
+    expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Duplicate);
+  });
+
+  it("buffered children flush in causal order when their parent integrates", () => {
+    const author = new EgWalkerReplica("author");
+    author.insert(0, "a");
+    author.insert(1, "b");
+    author.insert(2, "c");
+    const events = author.exportEventGraph();
+    expect(events).toHaveLength(3);
+
+    const replica = new EgWalkerReplica("replica");
+    // Deliver out of causal order: c (depends on b), b (depends on a), a.
+    expect(replica.applyRemoteEvent(cloneEvent(events[2]!)).status).toBe(
+      APPLY_REMOTE_EVENT_STATUS.Buffered,
+    );
+    expect(replica.applyRemoteEvent(cloneEvent(events[1]!)).status).toBe(
+      APPLY_REMOTE_EVENT_STATUS.Buffered,
+    );
+    expect(replica.getPendingRemoteCount()).toBe(2);
+    expect(replica.getText()).toBe("");
+
+    const aResult = replica.applyRemoteEvent(cloneEvent(events[0]!));
+    expect(aResult.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
+    // The two buffered children flushed transitively; replica text now
+    // reflects the full causal chain even though their flush isn't
+    // reported through this call.
+    expect(replica.getPendingRemoteCount()).toBe(0);
+    expect(replica.getText()).toBe("abc");
+  });
+
+  it("a partial/full replay returns `integrated` with operation === null", () => {
+    // Two replicas branch from the same root then merge. The merge event
+    // arrives on a replica whose current version is concurrent with the
+    // merge's parent, forcing a retreat — i.e. the engine cannot take
+    // the incremental path and the contract says `operation` is null.
+    const seedAuthor = new EgWalkerReplica("seed");
+    seedAuthor.insert(0, "abc");
+    const seed = seedAuthor.exportEventGraph();
+    expect(seed).toHaveLength(1);
+
+    const alice = new EgWalkerReplica("alice");
+    alice.applyRemoteEvent(cloneEvent(seed[0]!));
+    const bob = new EgWalkerReplica("bob");
+    bob.applyRemoteEvent(cloneEvent(seed[0]!));
+
+    // Alice and bob each insert concurrently after the same seed.
+    alice.insert(0, "A");
+    bob.insert(3, "B");
+    const aliceLocal = alice.exportEventGraph().slice(1);
+    const bobLocal = bob.exportEventGraph().slice(1);
+    expect(aliceLocal).toHaveLength(1);
+    expect(bobLocal).toHaveLength(1);
+
+    // Replica that already integrated alice's edit then sees bob's
+    // concurrent edit. Bob's parentVersion = {seed}, but the replica's
+    // current frontier = {alice's event}. canIncrementallyAdvance is
+    // false ⇒ partial/full replay path ⇒ operation must be null.
+    const result = alice.applyRemoteEvent(cloneEvent(bobLocal[0]!));
+    expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
+    if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
+      throw new Error("status narrowing");
+    }
+    expect(result.operation).toBeNull();
+    // Sanity: text reflects the merged document so the replay actually ran.
+    expect(alice.getText()).toBe("AabcB");
+  });
+
+  it("result is exhaustively narrowable via discriminated union", () => {
+    // Compile-time guard: the discriminant must cover all branches.
+    const author = new EgWalkerReplica("author");
+    author.insert(0, "x");
+    const [event] = author.exportEventGraph();
+    const replica = new EgWalkerReplica("replica");
+    const result: ApplyRemoteEventResult = replica.applyRemoteEvent(
+      cloneEvent(event!),
+    );
+    switch (result.status) {
+      case APPLY_REMOTE_EVENT_STATUS.Integrated: {
+        expect(result.operation).toBeTruthy();
+        break;
+      }
+      case APPLY_REMOTE_EVENT_STATUS.Buffered:
+      case APPLY_REMOTE_EVENT_STATUS.Duplicate: {
+        throw new Error(`unexpected status: ${result.status}`);
+      }
+      default: {
+        // exhaustiveness — fails at compile time if a branch is missed.
+        const _exhaustive: never = result;
+        return _exhaustive;
+      }
+    }
+  });
+});

--- a/packages/eg-walker/src/types/apply-remote-event-result.ts
+++ b/packages/eg-walker/src/types/apply-remote-event-result.ts
@@ -1,0 +1,67 @@
+import type { PositionOperation } from "./position-operation";
+
+/**
+ * Discriminated status returned by
+ * {@link EgWalkerReplica.applyRemoteEvent}.
+ *
+ * - `"integrated"` — the event was added to the event graph and the
+ *   document state advanced. When the engine took the incremental
+ *   apply path and produced exactly one transformed operation, that
+ *   operation is reported in {@link IntegratedApplyRemoteEventResult.operation}.
+ *   Otherwise (partial/full replay, multi-op coalesced delete,
+ *   no-op insert/delete) the operation is `null` — see
+ *   {@link IntegratedApplyRemoteEventResult.operation} for details.
+ * - `"buffered"` — at least one parent of the event has not been seen
+ *   yet, so the event is held in the replica's buffer. The document
+ *   text is unchanged. The event will be flushed automatically once
+ *   every parent arrives via a later `applyRemoteEvent` call.
+ * - `"duplicate"` — the event id is already in the graph or already
+ *   buffered. The call is a no-op.
+ */
+export const APPLY_REMOTE_EVENT_STATUS = {
+  Integrated: "integrated",
+  Buffered: "buffered",
+  Duplicate: "duplicate",
+} as const;
+
+export type ApplyRemoteEventStatus =
+  (typeof APPLY_REMOTE_EVENT_STATUS)[keyof typeof APPLY_REMOTE_EVENT_STATUS];
+
+export interface IntegratedApplyRemoteEventResult {
+  readonly status: typeof APPLY_REMOTE_EVENT_STATUS.Integrated;
+  /**
+   * The visible position operation produced by integrating this event,
+   * in the replica's UTF-16 code-unit index unit.
+   *
+   * `null` when the engine cannot attribute a single
+   * {@link PositionOperation} to this event in isolation:
+   *
+   * - The event triggered a partial or full replay (concurrent
+   *   integration retransforms multiple events, so the per-event
+   *   effect is no longer expressible as one insert/delete on the
+   *   pre-event document).
+   * - The integrated insert or delete coalesced into multiple disjoint
+   *   effect-index runs (rare; happens when concurrent inserts split
+   *   the visible deletion span).
+   * - The event was a no-op at the visible layer (empty insert,
+   *   zero-length delete, or a delete fully covering already-deleted
+   *   characters).
+   *
+   * Consumers driving selection mapping should treat `null` as
+   * "remap from text diff" rather than skipping the remap entirely.
+   */
+  readonly operation: PositionOperation | null;
+}
+
+export interface BufferedApplyRemoteEventResult {
+  readonly status: typeof APPLY_REMOTE_EVENT_STATUS.Buffered;
+}
+
+export interface DuplicateApplyRemoteEventResult {
+  readonly status: typeof APPLY_REMOTE_EVENT_STATUS.Duplicate;
+}
+
+export type ApplyRemoteEventResult =
+  | IntegratedApplyRemoteEventResult
+  | BufferedApplyRemoteEventResult
+  | DuplicateApplyRemoteEventResult;

--- a/packages/eg-walker/src/types/index.ts
+++ b/packages/eg-walker/src/types/index.ts
@@ -9,6 +9,20 @@
  */
 
 import { OPERATION_TYPE } from "../constants/operation-types";
+
+export type {
+  PositionOperation,
+  InsertPositionOperation,
+  DeletePositionOperation,
+} from "./position-operation";
+export {
+  APPLY_REMOTE_EVENT_STATUS,
+  type ApplyRemoteEventResult,
+  type ApplyRemoteEventStatus,
+  type IntegratedApplyRemoteEventResult,
+  type BufferedApplyRemoteEventResult,
+  type DuplicateApplyRemoteEventResult,
+} from "./apply-remote-event-result";
 // ============================================================================
 // External API Types (Index-based, no CRDT exposure)
 // ============================================================================

--- a/packages/eg-walker/src/types/position-operation.ts
+++ b/packages/eg-walker/src/types/position-operation.ts
@@ -1,0 +1,30 @@
+/**
+ * Editor-agnostic position operation shape returned alongside
+ * structural results from {@link EgWalkerReplica.applyRemoteEvent}.
+ *
+ * This mirrors the `PositionOperation` shape that
+ * `@softmaple/awareness/mapping` defines for selection mapping, but the
+ * type is owned by eg-walker so the package does not need to depend on
+ * `@softmaple/awareness` (see `docs/design/collaboration-layers.md`).
+ * Consumers that need to drive awareness mapping from a remote event can
+ * pass the returned operation straight through; structural typing makes
+ * the shapes interchangeable at the consumer boundary.
+ *
+ * The `length` is measured in the replica's index unit — UTF-16 code
+ * units. Inserts report the inserted span, deletes the removed span.
+ */
+export type InsertPositionOperation = {
+  readonly type: "insert";
+  readonly index: number;
+  readonly length: number;
+};
+
+export type DeletePositionOperation = {
+  readonly type: "delete";
+  readonly index: number;
+  readonly length: number;
+};
+
+export type PositionOperation =
+  | InsertPositionOperation
+  | DeletePositionOperation;


### PR DESCRIPTION
## Summary

Replaces the `getText()` pre/post side-effect check in collaboration consumers with a structural `ApplyRemoteEventResult` returned from `EgWalkerReplica.applyRemoteEvent`:

```ts
type ApplyRemoteEventResult =
  | { status: "integrated"; operation: PositionOperation | null }
  | { status: "buffered" }
  | { status: "duplicate" };
```

- **`integrated`** carries the engine-attributed `PositionOperation` for the incremental-advance path and the cold-start single-event full replay; `operation` is `null` for partial/full replay on an existing engine, multi-op coalesced deletes, and visible no-ops.
- **`buffered`** signals a missing parent; the event flushes automatically when its last parent arrives (side-effect flush, not reported separately).
- **`duplicate`** covers events already in the graph or already buffered; also folds in a `MissingParentError` race fallback that can't happen during normal use.

`PositionOperation` is owned by eg-walker (structurally mirrors `@softmaple/awareness/mapping`'s shape) so the collaboration-layer boundary holds — eg-walker still does not depend on awareness.

Consumer migration in `apps/playground/.../use-collaborative-editor.ts` uses `result.status` for the structural gate and `result.operation` directly when present; when the engine returns `operation: null`, falls back to a text diff of the remote replica's pre/post `getText()` so visible no-ops correctly skip the remap (fix from review).

Documents the new contract, why it's safer than `getText()` comparison, the partial-fallback performance profile, and the preserved buffering semantics in `docs/design/collaboration-layers.md`.

Closes #747.

## Commits

- `feat(packages/eg-walker): structural result from applyRemoteEvent` — types, replica/buffer refactor, consumer migration, tests, docs.
- `fix(apps/playground): avoid remapping no-op remote edits` — when `result.operation` is `null`, re-derive the mapping op from the remote replica's text delta instead of falling back to the locally-typed mapping op (fixes cursor drift on integrated-but-visible-no-op events flagged in review). Adds a regression test.
- `docs(eg-walker): clarify result contract and consumer fallback` — review nits: soften "zero per-event text cost" claim, note cold-start surfaces the op, clarify INSERT mapping converts `text` to `length` (UTF-16 code units), comment the `MissingParentError` race coalesce, document the remote-text diff fallback.

## Test plan

- [x] `pnpm --filter @softmaple/eg-walker test --run` — 28 files, 296 tests
- [x] `pnpm --filter @softmaple/eg-walker typecheck`
- [x] `pnpm --filter @softmaple/eg-walker build`
- [x] `pnpm --filter @softmaple/eg-walker lint`
- [x] `pnpm --filter playground test --run` — 6 files, 49 tests (incl. the new no-op regression test)
- [x] `pnpm --filter playground typecheck`
- [x] `pnpm --filter @softmaple/awareness test --run` — 30 files, 438 tests
- [x] New test file `packages/eg-walker/src/test/apply-remote-event-result.test.ts` covers integrated/duplicate/buffered/transitive-flush/partial-replay/compile-time-exhaustiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)