### PR TITLE
Fix awareness collab remote selection mapping

### DIFF
--- a/apps/playground/src/components/awareness-collab/EditorSurface.tsx
+++ b/apps/playground/src/components/awareness-collab/EditorSurface.tsx
@@ -17,7 +17,19 @@ import {
   useUpdateSelection,
   useUpdateTyping,
 } from "@softmaple/awareness";
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import {
+  mapTextareaSelectionThroughOperation,
+  type TextareaSelection,
+  useTextareaSelectionSync,
+} from "@softmaple/awareness/hooks";
+import type { PositionOperation } from "@softmaple/awareness/mapping";
+import {
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { BlockActivityBadge } from "./BlockActivityBadge";
 
 /**
@@ -33,6 +45,16 @@ interface EditorSurfaceProps {
   readonly onTextChange: (newText: string) => void;
   readonly textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   readonly trainerId: string;
+  /**
+   * Mapping operations queued by the route's BroadcastChannel handler for
+   * remote events that have just been integrated into the local replica.
+   * The post-commit layout effect drains and applies them to the captured
+   * local selection so the caret rides through peer inserts/deletes
+   * instead of staying pinned at its raw byte offset. Owned by the route
+   * (a ref so accumulation across multiple events in one tick doesn't
+   * race React state); consumed exactly once per `text` commit.
+   */
+  readonly pendingMappingOperationsRef: RefObject<PositionOperation[]>;
 }
 
 export function EditorSurface({
@@ -41,11 +63,13 @@ export function EditorSurface({
   onTextChange,
   textareaRef,
   trainerId,
+  pendingMappingOperationsRef,
 }: EditorSurfaceProps) {
   const others = useOthers();
   const updateCursor = useUpdateCursor();
   const updateSelection = useUpdateSelection();
   const updateTyping = useUpdateTyping();
+  const textareaSelectionSync = useTextareaSelectionSync(textareaRef);
 
   const editorBoxRef = useRef<HTMLDivElement>(null);
   const typingTimerRef = useRef<number | null>(null);
@@ -75,8 +99,16 @@ export function EditorSurface({
   //
   // Instead we own the DOM `value` imperatively here: on every commit
   // where `text` differs from the live DOM value, write it and restore
-  // the caret. Mid-composition we skip the write so we never collapse an
-  // in-progress IME composition.
+  // the caret via `useTextareaSelectionSync`. Mid-composition we skip
+  // the write so we never collapse an in-progress IME composition.
+  //
+  // When `pendingMappingOperationsRef` has entries, the route's
+  // BroadcastChannel handler integrated one or more remote events for
+  // this commit; chain the captured selection through those ops so a
+  // peer insert before the caret shifts it right (and a peer delete
+  // shifts it left / collapses overlapping selections) instead of
+  // leaving it pinned at the now-stale raw byte index.
+  //
   // `composingRef` is intentionally NOT in the dependency array — it's a
   // ref, and we read its current value at effect time. Adding it would
   // do nothing (refs don't trigger re-renders) and removing the
@@ -86,12 +118,22 @@ export function EditorSurface({
     if (!el) return;
     if (composingRef.current) return;
     if (el.value === text) return;
-    const { selectionStart, selectionEnd } = el;
+    const captured = textareaSelectionSync.captureSelection();
     el.value = text;
-    // setSelectionRange clamps to value.length internally, so peer
-    // inserts that shrink the doc past the local caret are safe.
-    el.setSelectionRange(selectionStart, selectionEnd);
-  }, [text, textareaRef]);
+    const operations = pendingMappingOperationsRef.current;
+    if (captured && operations.length > 0) {
+      const mapped = operations.reduce<TextareaSelection>(
+        (current, op) => mapTextareaSelectionThroughOperation(current, op),
+        captured,
+      );
+      textareaSelectionSync.restoreSelection(mapped);
+    } else {
+      // `restoreSelection` clamps to `value.length` internally, so peer
+      // inserts that shrink the doc past the local caret are safe.
+      textareaSelectionSync.restoreSelection(captured);
+    }
+    pendingMappingOperationsRef.current = [];
+  }, [text, textareaRef, textareaSelectionSync, pendingMappingOperationsRef]);
 
   // Clear typing indicator after a short idle period.
   useEffect(() => {

--- a/apps/playground/src/routes/demo/awareness-collab.tsx
+++ b/apps/playground/src/routes/demo/awareness-collab.tsx
@@ -1,4 +1,10 @@
 import {
+  findChangedSpan,
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+} from "@softmaple/awareness/mapping";
+import {
+  APPLY_REMOTE_EVENT_STATUS,
   EgWalkerReplica,
   type EventId,
   type GraphEvent,
@@ -25,6 +31,51 @@ export const Route = createFileRoute("/demo/awareness-collab")({
 
 const ROOM_ID = "awareness-collab-demo";
 const SYNC_CHANNEL = `eg-walker-sync:${ROOM_ID}`;
+
+/**
+ * Reconstruct the visible position operation(s) implied by a remote
+ * replica's pre/post text. Used as a fallback when
+ * `applyRemoteEvent` returns `status: "integrated"` with `operation: null`
+ * (partial/full replay, multi-op coalesced delete, or a visible no-op
+ * the engine cannot attribute to a single op). Mirrors
+ * `apps/playground/src/modules/collaborative-editor/use-collaborative-editor.ts`
+ * — same plain-text 1D diff shape, different replica path. Visible
+ * no-ops correctly return an empty array because both texts compare
+ * equal.
+ */
+const computeMappingOperationsFromTextChange = (
+  oldText: string,
+  newText: string,
+): readonly PositionOperation[] => {
+  if (oldText === newText) return [];
+  const { prefix, suffix } = findChangedSpan(oldText, newText);
+  const deletedLength = oldText.length - prefix - suffix;
+  const insertedText = newText.slice(prefix, newText.length - suffix);
+  const operations: PositionOperation[] = [];
+  if (deletedLength > 0) {
+    operations.push({
+      type: POSITION_OPERATION_TYPE.Delete,
+      index: prefix,
+      length: deletedLength,
+    });
+  }
+  if (insertedText.length > 0) {
+    operations.push({
+      type: POSITION_OPERATION_TYPE.Insert,
+      index: prefix,
+      length: insertedText.length,
+    });
+  }
+  return operations;
+};
+
+const isSamePositionOperation = (
+  left: PositionOperation,
+  right: PositionOperation,
+): boolean =>
+  left.type === right.type &&
+  left.index === right.index &&
+  left.length === right.length;
 
 function AwarenessCollabDemo() {
   const [trainer, setTrainer] = useState<string | null>(null);
@@ -86,6 +137,14 @@ function CollabSession({
   // dedupe — this just bounds the iteration.
   const scannedPrefixRef = useRef(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Mapping operations accumulated by `acceptRemote` for the events
+  // integrated in the current React tick. The post-commit layout effect
+  // in `EditorSurface` drains and applies them to the captured local
+  // selection so the caret rides through peer inserts/deletes correctly.
+  // Owned here (not in `EditorSurface`) so a snapshot of N events
+  // accumulates ops across the whole batch before the single `setText`
+  // triggers the layout effect.
+  const pendingMappingOperationsRef = useRef<PositionOperation[]>([]);
 
   // Separate BroadcastChannel for CRDT event sync. Awareness adapter
   // already opens its own channel for presence — keeping them isolated
@@ -95,12 +154,75 @@ function CollabSession({
     const channel = new BroadcastChannel(SYNC_CHANNEL);
     broadcastRef.current = channel;
     const selfId = userInfo.userId;
+    const pendingByMissingParent = new Map<EventId, GraphEvent[]>();
+    const bufferedEventIds = new Set<EventId>();
+
+    const getIntegratedEventIds = (): Set<EventId> =>
+      new Set(replica.exportEventGraph().map((event) => event.id));
+
+    const findMissingParent = (event: GraphEvent): EventId | null => {
+      const integratedIds = getIntegratedEventIds();
+      for (const parentId of event.parentVersion) {
+        if (!integratedIds.has(parentId)) {
+          return parentId;
+        }
+      }
+      return null;
+    };
+
+    const bufferRemote = (event: GraphEvent, missingParent: EventId): void => {
+      if (bufferedEventIds.has(event.id)) return;
+      const waiters = pendingByMissingParent.get(missingParent) ?? [];
+      waiters.push(event);
+      pendingByMissingParent.set(missingParent, waiters);
+      bufferedEventIds.add(event.id);
+    };
+
+    const drainPendingChildren = (parentId: EventId): void => {
+      const waiters = pendingByMissingParent.get(parentId);
+      if (!waiters) return;
+      pendingByMissingParent.delete(parentId);
+      for (const waiter of waiters) {
+        bufferedEventIds.delete(waiter.id);
+        acceptRemote(waiter);
+      }
+    };
 
     const acceptRemote = (event: GraphEvent): void => {
-      replica.applyRemoteEvent(event);
+      if (getIntegratedEventIds().has(event.id)) return;
+      const missingParent = findMissingParent(event);
+      if (missingParent) {
+        bufferRemote(event, missingParent);
+        return;
+      }
+      const textBefore = replica.getText();
+      const result = replica.applyRemoteEvent(event);
+      const textAfter = replica.getText();
       // Mark as published-from-elsewhere so our outbound loop doesn't
       // bounce it back to peers.
       publishedIdsRef.current.add(event.id);
+      if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) return;
+      const fallbackOperations = computeMappingOperationsFromTextChange(
+        textBefore,
+        textAfter,
+      );
+      const [fallbackOperation] = fallbackOperations;
+      if (
+        result.operation &&
+        fallbackOperations.length === 1 &&
+        fallbackOperation &&
+        isSamePositionOperation(result.operation, fallbackOperation)
+      ) {
+        pendingMappingOperationsRef.current.push(result.operation);
+        drainPendingChildren(event.id);
+        return;
+      }
+      // Engine couldn't attribute a single op (partial/full replay or
+      // multi-op coalesced delete), or `applyRemoteEvent` flushed buffered
+      // child events as a side effect. Reconstruct from pre/post text so
+      // the selection mapping still covers the whole visible commit.
+      pendingMappingOperationsRef.current.push(...fallbackOperations);
+      drainPendingChildren(event.id);
     };
 
     channel.onmessage = (e: MessageEvent<SyncMessage>) => {
@@ -275,6 +397,7 @@ function CollabSession({
             onTextChange={handleTextChange}
             textareaRef={textareaRef}
             trainerId={trainerId}
+            pendingMappingOperationsRef={pendingMappingOperationsRef}
           />
         </AwarenessOverlay>
 

--- a/apps/playground/src/test/editor-surface-ime.test.tsx
+++ b/apps/playground/src/test/editor-surface-ime.test.tsx
@@ -44,17 +44,25 @@ vi.mock("@/components/awareness-collab/BlockActivityBadge", () => ({
   BlockActivityBadge: () => null,
 }));
 
+import {
+  POSITION_OPERATION_TYPE,
+  type PositionOperation,
+} from "@softmaple/awareness/mapping";
+import type { RefObject } from "react";
 import { useRef } from "react";
 import { EditorSurface } from "@/components/awareness-collab/EditorSurface";
 
 const Harness = ({
   text,
   onTextChange,
+  pendingMappingOperationsRef,
 }: {
   text: string;
   onTextChange: (next: string) => void;
+  pendingMappingOperationsRef?: RefObject<PositionOperation[]>;
 }): React.ReactNode => {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const defaultPendingMappingOperationsRef = useRef<PositionOperation[]>([]);
   return (
     <EditorSurface
       blockId="block-1"
@@ -62,6 +70,9 @@ const Harness = ({
       onTextChange={onTextChange}
       textareaRef={textareaRef}
       trainerId="trainer-1"
+      pendingMappingOperationsRef={
+        pendingMappingOperationsRef ?? defaultPendingMappingOperationsRef
+      }
     />
   );
 };
@@ -165,3 +176,148 @@ describe("EditorSurface — IME composition handling", () => {
     expect(onTextChange).toHaveBeenCalledWith("hello");
   });
 });
+
+describe("EditorSurface — remote selection mapping", () => {
+  it("maps the caret through a remote insert before the cursor", () => {
+    // Arrange
+    const pendingMappingOperationsRef = createPendingMappingOperationsRef();
+    const { container, rerender } = render(
+      <Harness
+        text="hello"
+        onTextChange={vi.fn()}
+        pendingMappingOperationsRef={pendingMappingOperationsRef}
+      />,
+    );
+    const textarea = getTextarea(container);
+    textarea.setSelectionRange(3, 3);
+    pendingMappingOperationsRef.current.push({
+      type: POSITION_OPERATION_TYPE.Insert,
+      index: 1,
+      length: 2,
+    });
+
+    // Act
+    rerender(
+      <Harness
+        text="hXXello"
+        onTextChange={vi.fn()}
+        pendingMappingOperationsRef={pendingMappingOperationsRef}
+      />,
+    );
+
+    // Assert
+    expect(textarea.selectionStart).toBe(5);
+    expect(textarea.selectionEnd).toBe(5);
+    expect(pendingMappingOperationsRef.current).toEqual([]);
+  });
+
+  it("maps the caret through a remote delete before the cursor", () => {
+    // Arrange
+    const pendingMappingOperationsRef = createPendingMappingOperationsRef();
+    const { container, rerender } = render(
+      <Harness
+        text="hello world"
+        onTextChange={vi.fn()}
+        pendingMappingOperationsRef={pendingMappingOperationsRef}
+      />,
+    );
+    const textarea = getTextarea(container);
+    textarea.setSelectionRange(5, 5);
+    pendingMappingOperationsRef.current.push({
+      type: POSITION_OPERATION_TYPE.Delete,
+      index: 1,
+      length: 3,
+    });
+
+    // Act
+    rerender(
+      <Harness
+        text="ho world"
+        onTextChange={vi.fn()}
+        pendingMappingOperationsRef={pendingMappingOperationsRef}
+      />,
+    );
+
+    // Assert
+    expect(textarea.selectionStart).toBe(2);
+    expect(textarea.selectionEnd).toBe(2);
+  });
+
+  it("collapses the selection when a remote delete overlaps it", () => {
+    // Arrange
+    const pendingMappingOperationsRef = createPendingMappingOperationsRef();
+    const { container, rerender } = render(
+      <Harness
+        text="abcdefg"
+        onTextChange={vi.fn()}
+        pendingMappingOperationsRef={pendingMappingOperationsRef}
+      />,
+    );
+    const textarea = getTextarea(container);
+    textarea.setSelectionRange(2, 5);
+    pendingMappingOperationsRef.current.push({
+      type: POSITION_OPERATION_TYPE.Delete,
+      index: 1,
+      length: 5,
+    });
+
+    // Act
+    rerender(
+      <Harness
+        text="ag"
+        onTextChange={vi.fn()}
+        pendingMappingOperationsRef={pendingMappingOperationsRef}
+      />,
+    );
+
+    // Assert
+    expect(textarea.selectionStart).toBe(1);
+    expect(textarea.selectionEnd).toBe(1);
+  });
+
+  it("does not expand the selection for a remote insert at selection end", () => {
+    // Arrange
+    const pendingMappingOperationsRef = createPendingMappingOperationsRef();
+    const { container, rerender } = render(
+      <Harness
+        text="abcd"
+        onTextChange={vi.fn()}
+        pendingMappingOperationsRef={pendingMappingOperationsRef}
+      />,
+    );
+    const textarea = getTextarea(container);
+    textarea.setSelectionRange(1, 3);
+    pendingMappingOperationsRef.current.push({
+      type: POSITION_OPERATION_TYPE.Insert,
+      index: 3,
+      length: 2,
+    });
+
+    // Act
+    rerender(
+      <Harness
+        text="abcXXd"
+        onTextChange={vi.fn()}
+        pendingMappingOperationsRef={pendingMappingOperationsRef}
+      />,
+    );
+
+    // Assert
+    expect(textarea.selectionStart).toBe(1);
+    expect(textarea.selectionEnd).toBe(3);
+  });
+});
+
+// Helpers
+const createPendingMappingOperationsRef = (): RefObject<
+  PositionOperation[]
+> => ({
+  current: [],
+});
+
+const getTextarea = (container: HTMLElement): HTMLTextAreaElement => {
+  const textarea = container.querySelector("textarea");
+  expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+  if (!textarea) throw new Error("expected textarea");
+  return textarea;
+};


### PR DESCRIPTION
Closes: #745

## Summary

- Thread remote `PositionOperation` mappings from the awareness-collab BroadcastChannel path into `EditorSurface`.
- Restore textarea selections through `useTextareaSelectionSync` instead of raw DOM offsets after remote text commits.
- Queue out-of-order remote events at the route layer so buffered child events are mapped one at a time when their parents arrive.
- Add component regression coverage for remote insert/delete selection mapping cases while preserving IME composition behavior.

## Why

Remote peer inserts and deletes previously updated the textarea text while restoring the local caret at the same raw offset. That made the caret appear to jump relative to the edited text, especially for inserts before the cursor and deletes that crossed the cursor or active selection.

## Validation

- `pnpm --filter playground exec biome lint src/components/awareness-collab/EditorSurface.tsx src/routes/demo/awareness-collab.tsx src/test/editor-surface-ime.test.tsx`
- `pnpm --filter playground typecheck`
- `pnpm --filter playground test -- editor-surface-ime.test.tsx --run`
- `pnpm --filter @softmaple/awareness typecheck`
- `pnpm --filter @softmaple/awareness test -- --run`

Note: full `pnpm lint` is currently blocked by existing unrelated lint issues in generated `.next` output and older playground demo files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved caret and selection synchronization during collaborative editing. When remote collaborators insert or delete text, the local user's cursor position and text selection now accurately remap to maintain proper alignment across all remote edits.

* **Tests**
  * Added comprehensive test suite for remote selection mapping behavior to verify that caret and selection positions are correctly maintained during collaborative editing sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->