### PR TITLE
refactor(playground, packages/awareness): migrate text diff to findChangedSpan

### DIFF
--- a/apps/playground/biome.json
+++ b/apps/playground/biome.json
@@ -35,6 +35,31 @@
           "level": "warn"
         }
       },
+      "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "@/lib/text-diff": {
+                "importNames": [
+                  "findInsertPosition",
+                  "findDeletePosition",
+                  "findDifferingRange"
+                ],
+                "message": "Use findChangedSpan for text diffs; the special-case diff helpers are deprecated."
+              },
+              "@softmaple/awareness/mapping": {
+                "importNames": [
+                  "findInsertPosition",
+                  "findDeletePosition",
+                  "findDifferingRange"
+                ],
+                "message": "Use findChangedSpan for text diffs; the special-case diff helpers are deprecated."
+              }
+            }
+          }
+        }
+      },
       "suspicious": {
         "noExplicitAny": {
           "level": "error"

--- a/apps/playground/src/lib/text-diff.ts
+++ b/apps/playground/src/lib/text-diff.ts
@@ -6,8 +6,4 @@
  * `@/lib/text-diff` imports working.
  */
 
-export {
-  findDeletePosition,
-  findDifferingRange,
-  findInsertPosition,
-} from "@softmaple/awareness/mapping";
+export { findChangedSpan } from "@softmaple/awareness/mapping";

--- a/apps/playground/src/routes/demo/awareness-collab.tsx
+++ b/apps/playground/src/routes/demo/awareness-collab.tsx
@@ -17,11 +17,6 @@ import {
   EditorSurface,
 } from "@/components/awareness-collab/EditorSurface";
 import { TrainerPicker } from "@/components/awareness-collab/TrainerPicker";
-import {
-  findDeletePosition,
-  findDifferingRange,
-  findInsertPosition,
-} from "@/lib/text-diff";
 import { getTrainer } from "@/modules/awareness-collab/trainers";
 import { useAwarenessAdapter } from "@/modules/awareness-collab/use-awareness-adapter";
 
@@ -314,23 +309,15 @@ function CollabSession({
       const oldText = replica.getText();
       if (newText === oldText) return;
 
-      if (newText.length > oldText.length) {
-        const insertPos = findInsertPosition(oldText, newText);
-        const insertedText = newText.slice(
-          insertPos,
-          insertPos + (newText.length - oldText.length),
-        );
-        replica.insert(insertPos, insertedText);
-      } else if (newText.length < oldText.length) {
-        const deletePos = findDeletePosition(oldText, newText);
-        const deleteCount = oldText.length - newText.length;
-        replica.delete(deletePos, deleteCount);
-      } else {
-        const { start, end } = findDifferingRange(oldText, newText);
-        const deleteCount = end - start + 1;
-        const replacementText = newText.slice(start, end + 1);
-        replica.delete(start, deleteCount);
-        replica.insert(start, replacementText);
+      const { prefix, suffix } = findChangedSpan(oldText, newText);
+      const deletedLength = oldText.length - prefix - suffix;
+      const insertedText = newText.slice(prefix, newText.length - suffix);
+
+      if (deletedLength > 0) {
+        replica.delete(prefix, deletedLength);
+      }
+      if (insertedText.length > 0) {
+        replica.insert(prefix, insertedText);
       }
 
       setText(replica.getText());

--- a/apps/playground/src/test/collaborative-editor.test.ts
+++ b/apps/playground/src/test/collaborative-editor.test.ts
@@ -1,11 +1,6 @@
 import { POSITION_OPERATION_TYPE } from "@softmaple/awareness/mapping";
 import { EgWalkerReplica } from "@softmaple/eg-walker";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  findDeletePosition,
-  findDifferingRange,
-  findInsertPosition,
-} from "../lib/text-diff";
 import { computeLocalEdit } from "../modules/collaborative-editor/use-collaborative-editor";
 
 interface MockEgWalkerReplica {
@@ -35,6 +30,15 @@ vi.mock("@softmaple/eg-walker", () => {
 describe("Collaborative Editor Integration", () => {
   let api: MockEgWalkerReplica;
 
+  const applyLocalEdit = (
+    oldText: string,
+    newText: string,
+  ): ReturnType<typeof computeLocalEdit> => {
+    const edit = computeLocalEdit(oldText, newText);
+    edit?.apply(api as unknown as EgWalkerReplica);
+    return edit;
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     // @ts-expect-error - EgWalkerReplica is mocked as MockEgWalkerReplica
@@ -45,42 +49,45 @@ describe("Collaborative Editor Integration", () => {
     it("should call insert with correct position for text at the beginning", () => {
       const oldText = "world";
       const newText = "hello world";
-      const position = findInsertPosition(oldText, newText);
-      const insertedText = newText.slice(
-        position,
-        position + (newText.length - oldText.length),
-      );
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.insert(position, insertedText);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 0,
+          length: 6,
+        },
+      ]);
       expect(vi.mocked(api.insert)).toHaveBeenCalledWith(0, "hello ");
     });
 
     it("should call insert with correct position for text in the middle", () => {
       const oldText = "hello world";
       const newText = "hello beautiful world";
-      const position = findInsertPosition(oldText, newText);
-      const insertedText = newText.slice(
-        position,
-        position + (newText.length - oldText.length),
-      );
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.insert(position, insertedText);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 6,
+          length: 10,
+        },
+      ]);
       expect(vi.mocked(api.insert)).toHaveBeenCalledWith(6, "beautiful ");
     });
 
     it("should call insert with correct position for text at the end", () => {
       const oldText = "hello";
       const newText = "hello world";
-      const position = findInsertPosition(oldText, newText);
-      const insertedText = newText.slice(
-        position,
-        position + (newText.length - oldText.length),
-      );
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.insert(position, insertedText);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 5,
+          length: 6,
+        },
+      ]);
       expect(vi.mocked(api.insert)).toHaveBeenCalledWith(5, " world");
     });
   });
@@ -89,33 +96,45 @@ describe("Collaborative Editor Integration", () => {
     it("should call delete with correct position and count for deletion at the beginning", () => {
       const oldText = "hello world";
       const newText = "world";
-      const position = findDeletePosition(oldText, newText);
-      const deleteCount = oldText.length - newText.length;
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.delete(position, deleteCount);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 0,
+          length: 6,
+        },
+      ]);
       expect(vi.mocked(api.delete)).toHaveBeenCalledWith(0, 6);
     });
 
     it("should call delete with correct position and count for deletion in the middle", () => {
       const oldText = "hello beautiful world";
       const newText = "hello world";
-      const position = findDeletePosition(oldText, newText);
-      const deleteCount = oldText.length - newText.length;
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.delete(position, deleteCount);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 6,
+          length: 10,
+        },
+      ]);
       expect(vi.mocked(api.delete)).toHaveBeenCalledWith(6, 10);
     });
 
     it("should call delete with correct position and count for deletion at the end", () => {
       const oldText = "hello world";
       const newText = "hello";
-      const position = findDeletePosition(oldText, newText);
-      const deleteCount = oldText.length - newText.length;
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.delete(position, deleteCount);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 5,
+          length: 6,
+        },
+      ]);
       expect(vi.mocked(api.delete)).toHaveBeenCalledWith(5, 6);
     });
   });
@@ -170,13 +189,20 @@ describe("Collaborative Editor Integration", () => {
     it("should call delete and insert for replacement at the beginning", () => {
       const oldText = "hello world";
       const newText = "HELLO world";
-      const { start, end } = findDifferingRange(oldText, newText);
-      const deleteCount = end - start + 1;
-      const replacementText = newText.slice(start, end + 1);
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.delete(start, deleteCount);
-      api.insert(start, replacementText);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 0,
+          length: 5,
+        },
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 0,
+          length: 5,
+        },
+      ]);
       expect(vi.mocked(api.delete)).toHaveBeenCalledWith(0, 5);
       expect(vi.mocked(api.insert)).toHaveBeenCalledWith(0, "HELLO");
     });
@@ -184,13 +210,20 @@ describe("Collaborative Editor Integration", () => {
     it("should call delete and insert for replacement in the middle", () => {
       const oldText = "hello world";
       const newText = "hello WORLD";
-      const { start, end } = findDifferingRange(oldText, newText);
-      const deleteCount = end - start + 1;
-      const replacementText = newText.slice(start, end + 1);
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.delete(start, deleteCount);
-      api.insert(start, replacementText);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 6,
+          length: 5,
+        },
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 6,
+          length: 5,
+        },
+      ]);
       expect(vi.mocked(api.delete)).toHaveBeenCalledWith(6, 5);
       expect(vi.mocked(api.insert)).toHaveBeenCalledWith(6, "WORLD");
     });
@@ -198,13 +231,20 @@ describe("Collaborative Editor Integration", () => {
     it("should call delete and insert for single character replacement", () => {
       const oldText = "hello";
       const newText = "heLlo";
-      const { start, end } = findDifferingRange(oldText, newText);
-      const deleteCount = end - start + 1;
-      const replacementText = newText.slice(start, end + 1);
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.delete(start, deleteCount);
-      api.insert(start, replacementText);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 2,
+          length: 1,
+        },
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 2,
+          length: 1,
+        },
+      ]);
       expect(vi.mocked(api.delete)).toHaveBeenCalledWith(2, 1);
       expect(vi.mocked(api.insert)).toHaveBeenCalledWith(2, "L");
     });
@@ -212,13 +252,20 @@ describe("Collaborative Editor Integration", () => {
     it("should call delete and insert for complete text replacement", () => {
       const oldText = "abc";
       const newText = "xyz";
-      const { start, end } = findDifferingRange(oldText, newText);
-      const deleteCount = end - start + 1;
-      const replacementText = newText.slice(start, end + 1);
+      const edit = applyLocalEdit(oldText, newText);
 
-      api.delete(start, deleteCount);
-      api.insert(start, replacementText);
-
+      expect(edit?.mappingOperations).toEqual([
+        {
+          type: POSITION_OPERATION_TYPE.Delete,
+          index: 0,
+          length: 3,
+        },
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 0,
+          length: 3,
+        },
+      ]);
       expect(vi.mocked(api.delete)).toHaveBeenCalledWith(0, 3);
       expect(vi.mocked(api.insert)).toHaveBeenCalledWith(0, "xyz");
     });

--- a/apps/playground/src/test/lib/text-diff.test.ts
+++ b/apps/playground/src/test/lib/text-diff.test.ts
@@ -1,124 +1,83 @@
-import { describe, it, expect } from "vitest";
-import {
-  findInsertPosition,
-  findDeletePosition,
-  findDifferingRange,
-} from "../../lib/text-diff";
+import { describe, expect, it } from "vitest";
+import { findChangedSpan } from "../../lib/text-diff";
 
 describe("text-diff utilities", () => {
-  describe("findInsertPosition", () => {
-    it("should find insertion at the beginning", () => {
-      const oldText = "world";
-      const newText = "hello world";
-      expect(findInsertPosition(oldText, newText)).toBe(0);
+  describe("findChangedSpan", () => {
+    it("should identify no-op changes", () => {
+      expect(findChangedSpan("hello", "hello")).toEqual({
+        prefix: 5,
+        suffix: 0,
+      });
     });
 
-    it("should find insertion in the middle", () => {
-      const oldText = "hello world";
-      const newText = "hello beautiful world";
-      expect(findInsertPosition(oldText, newText)).toBe(6);
+    it("should identify insertion at the beginning", () => {
+      expect(findChangedSpan("world", "hello world")).toEqual({
+        prefix: 0,
+        suffix: 5,
+      });
     });
 
-    it("should find insertion at the end", () => {
-      const oldText = "hello";
-      const newText = "hello world";
-      expect(findInsertPosition(oldText, newText)).toBe(5);
+    it("should identify insertion in the middle", () => {
+      expect(findChangedSpan("hello world", "hello beautiful world")).toEqual({
+        prefix: 6,
+        suffix: 5,
+      });
     });
 
-    it("should handle empty old text", () => {
-      const oldText = "";
-      const newText = "hello";
-      expect(findInsertPosition(oldText, newText)).toBe(0);
+    it("should identify insertion at the end", () => {
+      expect(findChangedSpan("hello", "hello world")).toEqual({
+        prefix: 5,
+        suffix: 0,
+      });
     });
 
-    it("should handle single character insertion", () => {
-      const oldText = "hllo";
-      const newText = "hello";
-      expect(findInsertPosition(oldText, newText)).toBe(1);
-    });
-  });
-
-  describe("findDeletePosition", () => {
-    it("should find deletion at the beginning", () => {
-      const oldText = "hello world";
-      const newText = "world";
-      expect(findDeletePosition(oldText, newText)).toBe(0);
+    it("should identify deletion at the beginning", () => {
+      expect(findChangedSpan("hello world", "world")).toEqual({
+        prefix: 0,
+        suffix: 5,
+      });
     });
 
-    it("should find deletion in the middle", () => {
-      const oldText = "hello beautiful world";
-      const newText = "hello world";
-      expect(findDeletePosition(oldText, newText)).toBe(6);
+    it("should identify deletion in the middle", () => {
+      expect(findChangedSpan("hello beautiful world", "hello world")).toEqual({
+        prefix: 6,
+        suffix: 5,
+      });
     });
 
-    it("should find deletion at the end", () => {
-      const oldText = "hello world";
-      const newText = "hello";
-      expect(findDeletePosition(oldText, newText)).toBe(5);
+    it("should identify deletion at the end", () => {
+      expect(findChangedSpan("hello world", "hello")).toEqual({
+        prefix: 5,
+        suffix: 0,
+      });
     });
 
-    it("should handle complete deletion", () => {
-      const oldText = "hello";
-      const newText = "";
-      expect(findDeletePosition(oldText, newText)).toBe(0);
+    it("should identify same-length replacement", () => {
+      expect(findChangedSpan("hello world", "hello WORLD")).toEqual({
+        prefix: 6,
+        suffix: 0,
+      });
     });
 
-    it("should handle single character deletion", () => {
-      const oldText = "hello";
-      const newText = "hllo";
-      expect(findDeletePosition(oldText, newText)).toBe(1);
-    });
-  });
-
-  describe("findDifferingRange", () => {
-    it("should find differing range at the beginning", () => {
-      const oldText = "hello world";
-      const newText = "HELLO world";
-      const result = findDifferingRange(oldText, newText);
-      expect(result).toEqual({ start: 0, end: 4 });
+    it("should identify replacement with net insertion", () => {
+      expect(findChangedSpan("abcXYZdef", "abc12345def")).toEqual({
+        prefix: 3,
+        suffix: 3,
+      });
     });
 
-    it("should find differing range in the middle", () => {
-      const oldText = "hello world";
-      const newText = "hello WORLD";
-      const result = findDifferingRange(oldText, newText);
-      expect(result).toEqual({ start: 6, end: 10 });
+    it("should identify replacement with net deletion", () => {
+      expect(findChangedSpan("abc12345def", "abcXYdef")).toEqual({
+        prefix: 3,
+        suffix: 3,
+      });
     });
 
-    it("should find differing range at the end", () => {
-      const oldText = "hello world";
-      const newText = "hello worlD";
-      const result = findDifferingRange(oldText, newText);
-      expect(result).toEqual({ start: 10, end: 10 });
-    });
-
-    it("should find differing range for complete replacement", () => {
-      const oldText = "abc";
-      const newText = "xyz";
-      const result = findDifferingRange(oldText, newText);
-      expect(result).toEqual({ start: 0, end: 2 });
-    });
-
-    it("should find differing range for single character", () => {
-      const oldText = "hello";
-      const newText = "heLlo";
-      const result = findDifferingRange(oldText, newText);
-      expect(result).toEqual({ start: 2, end: 2 });
-    });
-
-    it("should handle multiple differing ranges by finding outermost bounds", () => {
-      const oldText = "abcde";
-      const newText = "xbcdz";
-      const result = findDifferingRange(oldText, newText);
-      expect(result).toEqual({ start: 0, end: 4 });
-    });
-
-    it("should handle identical strings", () => {
-      const oldText = "hello";
-      const newText = "hello";
-      const result = findDifferingRange(oldText, newText);
-      // When strings are identical, start > end
-      expect(result.start).toBeGreaterThan(result.end);
+    it("should handle complete replacement", () => {
+      expect(findChangedSpan("abc", "xyz")).toEqual({
+        prefix: 0,
+        suffix: 0,
+      });
     });
   });
 });

--- a/packages/awareness/src/mapping/text-diff.ts
+++ b/packages/awareness/src/mapping/text-diff.ts
@@ -7,6 +7,10 @@
  * `oldText` and `newText` and bail out at the first divergence.
  */
 
+/**
+ * @deprecated Use `findChangedSpan` instead. This helper assumes exactly one
+ * insert and can produce incorrect positions for replacements.
+ */
 export const findInsertPosition = (
   oldText: string,
   newText: string,
@@ -20,6 +24,10 @@ export const findInsertPosition = (
   return oldText.length;
 };
 
+/**
+ * @deprecated Use `findChangedSpan` instead. This helper assumes exactly one
+ * delete and can produce incorrect positions for replacements.
+ */
 export const findDeletePosition = (
   oldText: string,
   newText: string,
@@ -81,6 +89,11 @@ export const findChangedSpan = (
   return { prefix, suffix };
 };
 
+/**
+ * @deprecated Use `findChangedSpan` instead. This helper assumes a
+ * same-length-or-equivalent replacement shape and can produce incorrect
+ * ranges for mixed-length edits.
+ */
 export const findDifferingRange = (
   oldText: string,
   newText: string,


### PR DESCRIPTION
## Summary

- Migrates playground text-diff usage from `findInsertPosition`, `findDeletePosition`, and `findDifferingRange` to the unified `findChangedSpan` prefix/suffix API (awareness collab demo, re-export shim, and tests).
- Deprecates the legacy helpers in `@softmaple/awareness/mapping` with JSDoc guidance.
- Adds Biome `noRestrictedImports` rules in playground to block new imports of the deprecated helpers.

## Test plan

- [x] `pnpm --filter playground test -- src/test/lib/text-diff.test.ts src/test/collaborative-editor.test.ts`
- [ ] `pnpm --filter @softmaple/awareness test -- src/mapping/text-diff.test.ts`
- [ ] Manual: awareness collab demo — insert, delete, and replace edits sync correctly across peers

Closes #748


Made with [Cursor](https://cursor.com)