### PR TITLE
test: P0 validation tests for collaboration foundation

### DIFF
--- a/packages/awareness/src/bindings/textarea/textarea-adapter.test.ts
+++ b/packages/awareness/src/bindings/textarea/textarea-adapter.test.ts
@@ -61,6 +61,30 @@ describe("createTextareaAdapter — local edits", () => {
     adapter.destroy();
   });
 
+  it("emits delete-then-insert when selected text is replaced", () => {
+    // Simulates selecting "ell" in "hello" and typing "xyz" → "hxyzo".
+    // The adapter diffs the before/after value and must emit [delete, insert].
+    const textarea = mountTextarea("hello");
+    const adapter = createTextareaAdapter(textarea);
+    const received: TextareaOperation[][] = [];
+    adapter.observeLocalOperations((ops) => received.push([...ops]));
+
+    fireInput(textarea, "hxyzo");
+
+    expect(received).toEqual([
+      [
+        { type: POSITION_OPERATION_TYPE.Delete, index: 1, length: 3 },
+        {
+          type: POSITION_OPERATION_TYPE.Insert,
+          index: 1,
+          length: 3,
+          text: "xyz",
+        },
+      ],
+    ]);
+    adapter.destroy();
+  });
+
   it("does not emit for no-op input events", () => {
     const textarea = mountTextarea("hello");
     const adapter = createTextareaAdapter(textarea);

--- a/packages/awareness/src/mapping/map-cursor.test.ts
+++ b/packages/awareness/src/mapping/map-cursor.test.ts
@@ -72,3 +72,24 @@ describe("mapCursorThroughOperation: delete", () => {
     expect(mapCursorThroughOperation(10, deleteAt(0, 4))).toBe(6);
   });
 });
+
+describe("mapCursorThroughOperation: boundary — end of document", () => {
+  it("shifts a cursor at the end of the document when an insert occurs before it", () => {
+    // document "hello" (length 5), cursor at 5 (after last char), insert 3 chars at 0
+    expect(mapCursorThroughOperation(5, insertAt(0, 3))).toBe(8);
+  });
+
+  it("shifts a cursor at the very end when the insert lands at the same end position", () => {
+    // Cursor at 5 = insert index 5: right-biased, shifts forward
+    expect(mapCursorThroughOperation(5, insertAt(5, 2))).toBe(7);
+  });
+
+  it("shifts a cursor at the end left when a delete lands before it", () => {
+    // document "hello world" (length 11), cursor at 11, delete [5, 6) → cursor 10
+    expect(mapCursorThroughOperation(11, deleteAt(5, 6))).toBe(5);
+  });
+
+  it("handles a cursor at index 0 in an empty document through a zero-length insert", () => {
+    expect(mapCursorThroughOperation(0, insertAt(0, 0))).toBe(0);
+  });
+});

--- a/packages/awareness/src/mapping/map-cursor.test.ts
+++ b/packages/awareness/src/mapping/map-cursor.test.ts
@@ -85,7 +85,7 @@ describe("mapCursorThroughOperation: boundary — end of document", () => {
   });
 
   it("shifts a cursor at the end left when a delete lands before it", () => {
-    // document "hello world" (length 11), cursor at 11, delete [5, 6) → cursor 10
+    // document "hello world" (length 11), cursor at 11, delete [5, 11) → cursor 5
     expect(mapCursorThroughOperation(11, deleteAt(5, 6))).toBe(5);
   });
 

--- a/packages/awareness/src/mapping/map-selection.test.ts
+++ b/packages/awareness/src/mapping/map-selection.test.ts
@@ -174,4 +174,18 @@ describe("mapSelectionThroughOperation: invariants", () => {
       { from: 3, to: 5 },
     );
   });
+
+  it("handles a collapsed selection at the end of the document through a delete before it", () => {
+    // document length 7, cursor at 7 (end); delete [0, 3) → cursor shifts to 4
+    expect(
+      mapSelectionThroughOperation({ from: 7, to: 7 }, deleteAt(0, 3)),
+    ).toEqual({ from: 4, to: 4 });
+  });
+
+  it("shrinks a selection whose trailing edge is the end of the document when a delete touches it", () => {
+    // selection [3, 7], delete [4, 7) (3 chars from end) → trailing edge collapses to 4
+    expect(
+      mapSelectionThroughOperation({ from: 3, to: 7 }, deleteAt(4, 3)),
+    ).toEqual({ from: 3, to: 4 });
+  });
 });

--- a/packages/eg-walker/src/test/apply-remote-event-result.test.ts
+++ b/packages/eg-walker/src/test/apply-remote-event-result.test.ts
@@ -210,15 +210,13 @@ describe("EgWalkerReplica.applyRemoteEvent — structural result", () => {
     expect(replica.getPendingRemoteCount()).toBe(0);
     expect(replica.getText()).toBe("hello world");
 
-    // Serialise and round-trip through JSON (the wire format).
+    // Serialize and round-trip through JSON (the wire format).
     const serialized = replica.serialize();
     const wire = JSON.parse(JSON.stringify(serialized)) as typeof serialized;
     const restored = EgWalkerReplica.deserialize(wire, "restored");
 
     expect(restored.getText()).toBe("hello world");
-    expect(restored.exportEventGraph().length).toBe(
-      replica.exportEventGraph().length,
-    );
+    expect(restored.exportEventGraph()).toEqual(replica.exportEventGraph());
   });
 
   it("result is exhaustively narrowable via discriminated union", () => {

--- a/packages/eg-walker/src/test/apply-remote-event-result.test.ts
+++ b/packages/eg-walker/src/test/apply-remote-event-result.test.ts
@@ -188,6 +188,39 @@ describe("EgWalkerReplica.applyRemoteEvent — structural result", () => {
     expect(alice.getText()).toBe("AabcB");
   });
 
+  it("serialize/deserialize round-trips correctly after remote buffering and flushing", () => {
+    // Build a two-event causal chain on the author.
+    const author = new EgWalkerReplica("author");
+    author.insert(0, "hello");
+    author.insert(5, " world");
+    const [eventA, eventB] = author.exportEventGraph();
+    expect(eventA).toBeDefined();
+    expect(eventB).toBeDefined();
+
+    // Deliver child before parent so the buffer is exercised.
+    const replica = new EgWalkerReplica("replica");
+    expect(replica.applyRemoteEvent(cloneEvent(eventB!)).status).toBe(
+      APPLY_REMOTE_EVENT_STATUS.Buffered,
+    );
+
+    // Parent arrives: child flushes automatically.
+    expect(replica.applyRemoteEvent(cloneEvent(eventA!)).status).toBe(
+      APPLY_REMOTE_EVENT_STATUS.Integrated,
+    );
+    expect(replica.getPendingRemoteCount()).toBe(0);
+    expect(replica.getText()).toBe("hello world");
+
+    // Serialise and round-trip through JSON (the wire format).
+    const serialized = replica.serialize();
+    const wire = JSON.parse(JSON.stringify(serialized)) as typeof serialized;
+    const restored = EgWalkerReplica.deserialize(wire, "restored");
+
+    expect(restored.getText()).toBe("hello world");
+    expect(restored.exportEventGraph().length).toBe(
+      replica.exportEventGraph().length,
+    );
+  });
+
   it("result is exhaustively narrowable via discriminated union", () => {
     // Compile-time guard: the discriminant must cover all branches.
     const author = new EgWalkerReplica("author");


### PR DESCRIPTION
## Summary

- **awareness/map-cursor**: 4 new boundary tests covering cursor at end-of-document and empty-document edge cases through insert and delete operations
- **awareness/map-selection**: 2 new boundary tests covering collapsed selection at end-of-document and trailing-edge shrink on tail delete
- **awareness/textarea-adapter**: 1 new test verifying that replacing selected text emits `[delete, insert]` at the adapter level (not just in the `computeTextareaOperations` unit)
- **eg-walker/apply-remote-event-result**: 1 new test confirming `serialize()` → JSON round-trip → `deserialize()` is correct after out-of-order delivery (buffer + flush) rather than just in-order delivery

## Motivation

These are the gaps identified in the P0 audit: all four areas had solid coverage for the happy path and common cases, but the boundary conditions and the buffer-then-serialize path were not explicitly pinned. Adding them ensures regressions are caught before abstractions expand.

## Test plan

- [ ] `pnpm --filter @softmaple/awareness test -- --run` — 509 tests pass (was 502)
- [ ] `pnpm --filter @softmaple/eg-walker test -- --run` — 300 tests pass (was 299)
- [ ] No new dependencies introduced between `@softmaple/eg-walker` and `@softmaple/awareness`
- [ ] No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)