### PR TITLE
fix(apps/playground): buffer peer CRDT events during IME composition

### DIFF
--- a/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
+++ b/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
@@ -128,8 +128,10 @@ export const useBroadcastCollabSession = ({
     const getIntegratedEventIds = (): Set<EventId> =>
       new Set(replica.exportEventGraph().map((event) => event.id));
 
-    const findMissingParent = (event: GraphEvent): EventId | null => {
-      const integratedIds = getIntegratedEventIds();
+    const findMissingParent = (
+      event: GraphEvent,
+      integratedIds: Set<EventId>,
+    ): EventId | null => {
       for (const parentId of event.parentVersion) {
         if (!integratedIds.has(parentId)) {
           return parentId;
@@ -156,9 +158,18 @@ export const useBroadcastCollabSession = ({
       }
     };
 
-    const acceptRemote = (event: GraphEvent): void => {
-      if (getIntegratedEventIds().has(event.id)) return;
-      const missingParent = findMissingParent(event);
+    // `knownIntegratedIds` is an optional pre-computed set the caller
+    // can pass when processing events in a batch. It must be mutated in
+    // place (add the new ID after applyRemoteEvent) so subsequent
+    // iterations of the batch loop see fresh data without re-scanning
+    // the graph. When omitted, one fresh scan is done per call.
+    const acceptRemote = (
+      event: GraphEvent,
+      knownIntegratedIds?: Set<EventId>,
+    ): void => {
+      const integratedIds = knownIntegratedIds ?? getIntegratedEventIds();
+      if (integratedIds.has(event.id)) return;
+      const missingParent = findMissingParent(event, integratedIds);
       if (missingParent) {
         bufferRemote(event, missingParent);
         return;
@@ -179,6 +190,7 @@ export const useBroadcastCollabSession = ({
       const result = replica.applyRemoteEvent(event);
       const textAfter = replica.getText();
       publishedIdsRef.current.add(event.id);
+      knownIntegratedIds?.add(event.id);
       if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) return;
       const operations = computeTextareaOperations(textBefore, textAfter);
       collaborationRef.current?.applyRemoteOperations(operations);
@@ -190,8 +202,9 @@ export const useBroadcastCollabSession = ({
       if (events.length === 0) return;
       duringCompositionEventsRef.current = [];
       duringCompositionEventIdsRef.current.clear();
+      const integratedIds = getIntegratedEventIds();
       for (const event of events) {
-        acceptRemote(event);
+        acceptRemote(event, integratedIds);
       }
       onTextChange(replica.getText());
     };
@@ -219,8 +232,9 @@ export const useBroadcastCollabSession = ({
         }
         case "snapshot": {
           if (msg.recipientId !== userId) return;
+          const integratedIds = getIntegratedEventIds();
           for (const event of msg.events) {
-            acceptRemote(event);
+            acceptRemote(event, integratedIds);
           }
           onTextChange(replica.getText());
           return;

--- a/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
+++ b/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
@@ -220,20 +220,31 @@ export const useBroadcastCollabSession = ({
           return;
         }
         case "request": {
-          // Include events queued during an in-progress IME composition:
-          // they have not been applied to the replica yet, so
-          // exportEventGraph() alone would omit them. A peer that joins
-          // while we are composing would then miss those events
-          // permanently if the original sender has gone away before our
-          // flush fires.
+          // Three sources of events that have not yet been applied to the
+          // replica must all be included so a joining peer gets the full
+          // picture even if the original senders are gone:
+          //
+          // 1. appliedEvents — replica.exportEventGraph(), the baseline.
+          // 2. queuedEvents  — events whose parents are integrated but
+          //    that we are holding back until IME composition ends.
+          // 3. pendingEvents — descendants buffered behind a missing
+          //    parent (including children of queuedEvents whose parent
+          //    has not been applied to the replica yet, keyed by the
+          //    missing parent ID at every depth of the causal chain).
           const appliedEvents = replica.exportEventGraph();
           const queuedEvents = duringCompositionEventsRef.current;
-          if (appliedEvents.length === 0 && queuedEvents.length === 0) return;
+          const pendingEvents = [...pendingByMissingParent.values()].flat();
+          if (
+            appliedEvents.length === 0 &&
+            queuedEvents.length === 0 &&
+            pendingEvents.length === 0
+          )
+            return;
           channel.postMessage({
             type: "snapshot",
             senderId: userId,
             recipientId: msg.senderId,
-            events: [...appliedEvents, ...queuedEvents],
+            events: [...appliedEvents, ...queuedEvents, ...pendingEvents],
           } satisfies SyncMessage);
           return;
         }

--- a/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
+++ b/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
@@ -220,13 +220,20 @@ export const useBroadcastCollabSession = ({
           return;
         }
         case "request": {
-          const events = replica.exportEventGraph();
-          if (events.length === 0) return;
+          // Include events queued during an in-progress IME composition:
+          // they have not been applied to the replica yet, so
+          // exportEventGraph() alone would omit them. A peer that joins
+          // while we are composing would then miss those events
+          // permanently if the original sender has gone away before our
+          // flush fires.
+          const appliedEvents = replica.exportEventGraph();
+          const queuedEvents = duringCompositionEventsRef.current;
+          if (appliedEvents.length === 0 && queuedEvents.length === 0) return;
           channel.postMessage({
             type: "snapshot",
             senderId: userId,
             recipientId: msg.senderId,
-            events,
+            events: [...appliedEvents, ...queuedEvents],
           } satisfies SyncMessage);
           return;
         }

--- a/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
+++ b/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
@@ -11,6 +11,14 @@ import {
 import { type RefObject, useCallback, useEffect, useRef } from "react";
 
 /**
+ * A ref to a boolean flag that the caller updates as the textarea's IME
+ * composition state changes. While `isComposingRef.current` is true,
+ * incoming peer events are queued rather than applied immediately.
+ * Flushed after composition ends via `flushDuringCompositionEvents`.
+ */
+type IsComposingRef = RefObject<boolean>;
+
+/**
  * Cross-tab sync protocol. Three message shapes:
  *
  * - `event`     a single newly-produced event, broadcast as it happens.
@@ -42,11 +50,20 @@ type UseBroadcastCollabSessionOptions = {
   readonly userId: string;
   readonly syncChannel: string;
   readonly onTextChange: (text: string) => void;
+  readonly isComposingRef: IsComposingRef;
 };
 
 type BroadcastCollabSession = {
   readonly collaborationRef: RefObject<UseTextareaCollaborationResult | null>;
   readonly broadcastNewEvents: () => void;
+  /**
+   * Process peer events that were queued while the textarea was composing.
+   * Must be called after composition ends and after the local composition
+   * ops have been applied to the replica (i.e. after `onLocalOperations`
+   * returns for the composition commit), so the CRDT sees local ops first
+   * and peer events can be correctly rebased on top.
+   */
+  readonly flushDuringCompositionEvents: () => void;
 };
 
 export const useBroadcastCollabSession = ({
@@ -54,6 +71,7 @@ export const useBroadcastCollabSession = ({
   userId,
   syncChannel,
   onTextChange,
+  isComposingRef,
 }: UseBroadcastCollabSessionOptions): BroadcastCollabSession => {
   const channelRef = useRef<BroadcastChannel | null>(null);
   const collaborationRef = useRef<UseTextareaCollaborationResult | null>(null);
@@ -64,6 +82,16 @@ export const useBroadcastCollabSession = ({
   // Length of the exported graph prefix already inspected by the broadcast
   // loop. The Set above is still the source of truth for dedupe.
   const scannedPrefixRef = useRef(0);
+  // Peer events that arrived while the textarea was composing. We cannot
+  // apply them to the replica immediately because their indices would be
+  // relative to the pre-composition baseline; the composition's own ops
+  // must land first so the CRDT merge is correct. Flushed after
+  // compositionend via flushDuringCompositionEvents.
+  const duringCompositionEventsRef = useRef<GraphEvent[]>([]);
+  const duringCompositionEventIdsRef = useRef<Set<EventId>>(new Set());
+  // Set by the useEffect so flushDuringCompositionEvents (defined outside
+  // the effect) can reach the closure-local acceptRemote.
+  const processBufferedEventsRef = useRef<(() => void) | null>(null);
 
   const broadcastNewEvents = useCallback(() => {
     const channel = channelRef.current;
@@ -86,6 +114,11 @@ export const useBroadcastCollabSession = ({
     scannedPrefixRef.current = events.length;
   }, [replica, userId]);
 
+  const flushDuringCompositionEvents = useCallback(() => {
+    processBufferedEventsRef.current?.();
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: isComposingRef is a stable RefObject; reading .current inside the effect always gives the live value without needing the effect to re-run on composition state changes.
   useEffect(() => {
     const channel = new BroadcastChannel(syncChannel);
     channelRef.current = channel;
@@ -130,6 +163,18 @@ export const useBroadcastCollabSession = ({
         bufferRemote(event, missingParent);
         return;
       }
+      // While the textarea is mid-IME-composition, we cannot apply peer
+      // events to the replica yet. The composition's local ops must land
+      // first (so their indices are correct relative to the
+      // pre-composition baseline); peer events are then applied on top
+      // and the CRDT merge resolves any conflicts. See issue #704.
+      if (isComposingRef.current) {
+        if (!duringCompositionEventIdsRef.current.has(event.id)) {
+          duringCompositionEventsRef.current.push(event);
+          duringCompositionEventIdsRef.current.add(event.id);
+        }
+        return;
+      }
       const textBefore = replica.getText();
       const result = replica.applyRemoteEvent(event);
       const textAfter = replica.getText();
@@ -138,6 +183,17 @@ export const useBroadcastCollabSession = ({
       const operations = computeTextareaOperations(textBefore, textAfter);
       collaborationRef.current?.applyRemoteOperations(operations);
       drainPendingChildren(event.id);
+    };
+
+    processBufferedEventsRef.current = () => {
+      const events = duringCompositionEventsRef.current;
+      if (events.length === 0) return;
+      duringCompositionEventsRef.current = [];
+      duringCompositionEventIdsRef.current.clear();
+      for (const event of events) {
+        acceptRemote(event);
+      }
+      onTextChange(replica.getText());
     };
 
     channel.onmessage = (event: MessageEvent<SyncMessage>) => {
@@ -180,8 +236,11 @@ export const useBroadcastCollabSession = ({
     return () => {
       channel.close();
       channelRef.current = null;
+      processBufferedEventsRef.current = null;
+      duringCompositionEventsRef.current = [];
+      duringCompositionEventIdsRef.current.clear();
     };
   }, [onTextChange, replica, syncChannel, userId]);
 
-  return { collaborationRef, broadcastNewEvents };
+  return { collaborationRef, broadcastNewEvents, flushDuringCompositionEvents };
 };

--- a/apps/playground/src/routes/demo/awareness-collab.tsx
+++ b/apps/playground/src/routes/demo/awareness-collab.tsx
@@ -42,12 +42,15 @@ function CollabSession({
   const [replica] = useState(() => new EgWalkerReplica(userInfo.userId, ""));
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const { collaborationRef, broadcastNewEvents } = useBroadcastCollabSession({
-    replica,
-    userId: userInfo.userId,
-    syncChannel: SYNC_CHANNEL,
-    onTextChange: setText,
-  });
+  const isComposingRef = useRef(false);
+  const { collaborationRef, broadcastNewEvents, flushDuringCompositionEvents } =
+    useBroadcastCollabSession({
+      replica,
+      userId: userInfo.userId,
+      syncChannel: SYNC_CHANNEL,
+      onTextChange: setText,
+      isComposingRef,
+    });
 
   const handleLocalOperations = useCallback<
     Parameters<typeof useTextareaCollaboration>[0]["onLocalOperations"]
@@ -69,6 +72,15 @@ function CollabSession({
   const collaboration = useTextareaCollaboration({
     textareaRef,
     onLocalOperations: handleLocalOperations,
+    onCompositionChange: (composing) => {
+      isComposingRef.current = composing;
+      if (!composing) {
+        // Defer the flush one microtask so the composition's own ops
+        // (emitted synchronously in compositionend, after this callback)
+        // reach the replica before we apply the buffered peer events.
+        Promise.resolve().then(flushDuringCompositionEvents);
+      }
+    },
   });
   useLayoutEffect(() => {
     collaborationRef.current = collaboration;

--- a/apps/playground/src/routes/demo/awareness-collab.tsx
+++ b/apps/playground/src/routes/demo/awareness-collab.tsx
@@ -78,7 +78,7 @@ function CollabSession({
         // Defer the flush one microtask so the composition's own ops
         // (emitted synchronously in compositionend, after this callback)
         // reach the replica before we apply the buffered peer events.
-        Promise.resolve().then(flushDuringCompositionEvents);
+        queueMicrotask(flushDuringCompositionEvents);
       }
     },
   });


### PR DESCRIPTION
## Summary

- Fixes the cross-tab IME divergence reported in issue #704: when a peer edit arrived while the local user was mid-composition, the peer's CRDT event was applied to the replica immediately, then its text-level ops were replayed against the post-composition DOM value — causing the delete/insert indices to land on composition characters instead of the original ones.
- `useBroadcastCollabSession` now queues peer `GraphEvent`s in a composition buffer while `isComposingRef.current` is true, leaving the replica at the pre-composition baseline until composition ends.
- `awareness-collab.tsx` wires `onCompositionChange` to keep `isComposingRef` current and schedule `flushDuringCompositionEvents` as a microtask on `compositionend` — after the adapter has emitted the composition diff and `handleLocalOperations` has applied it to the replica, so the CRDT always sees local composition ops before peer events.

## Mechanics

```
compositionend fires (synchronous):
  1. adapter: setComposing(false) → onCompositionChange(false)
       → isComposingRef.current = false
       → Promise.resolve().then(flushDuringCompositionEvents)  ← microtask queued
  2. adapter: diffAndEmit(value) → handleLocalOperations → replica updated
  (event handler returns)

microtask runs:
  3. flushDuringCompositionEvents → acceptRemote(buffered events) → replica merged
```

The adapter-level DOM buffer (`pendingRemoteOperations` from #755) is now effectively a no-op during composition since `applyRemoteOperations` is never called for buffered events; the DOM update happens through the post-compositionend flush path instead.

## Test plan

- [ ] All existing playground tests pass (`pnpm test` — 27/27)
- [ ] All awareness package tests pass (`pnpm --filter @softmaple/awareness test` — 509/509)
- [ ] TypeScript clean (`pnpm typecheck`)
- [ ] Manual: open two tabs, Tab A start IME composition, Tab B insert a character, Tab A commit — both tabs should converge on the same merged text

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced collaborative editing support for IME (Input Method Editor) composition. Peer updates are now intelligently buffered during composition sessions and applied after completion, ensuring smoother real-time synchronization without interrupting input flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->