### PR TITLE
fix(apps/playground): coalesce peer-event setText calls via queueMicrotask

### DIFF
--- a/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
+++ b/apps/playground/src/modules/awareness-collab/use-broadcast-collab-session.ts
@@ -75,6 +75,10 @@ export const useBroadcastCollabSession = ({
 }: UseBroadcastCollabSessionOptions): BroadcastCollabSession => {
   const channelRef = useRef<BroadcastChannel | null>(null);
   const collaborationRef = useRef<UseTextareaCollaborationResult | null>(null);
+  // True while a microtask is already queued to flush the remote-event
+  // text update. Prevents scheduling multiple `onTextChange` calls when
+  // a peer sends a burst of events in the same JS turn.
+  const remoteFlushScheduledRef = useRef(false);
   // Event IDs we've already published (either broadcast ourselves or received
   // from a peer). Using IDs rather than a graph-length index means applying a
   // remote event never causes us to re-broadcast it on the next local edit.
@@ -216,7 +220,15 @@ export const useBroadcastCollabSession = ({
       switch (msg.type) {
         case "event": {
           acceptRemote(msg.event);
-          onTextChange(replica.getText());
+          if (!remoteFlushScheduledRef.current) {
+            remoteFlushScheduledRef.current = true;
+            queueMicrotask(() => {
+              remoteFlushScheduledRef.current = false;
+              if (channelRef.current) {
+                onTextChange(replica.getText());
+              }
+            });
+          }
           return;
         }
         case "request": {
@@ -271,6 +283,7 @@ export const useBroadcastCollabSession = ({
       processBufferedEventsRef.current = null;
       duringCompositionEventsRef.current = [];
       duringCompositionEventIdsRef.current.clear();
+      remoteFlushScheduledRef.current = false;
     };
   }, [onTextChange, replica, syncChannel, userId]);
 


### PR DESCRIPTION
## Summary

- Adds `remoteFlushScheduledRef` to `useBroadcastCollabSession` to gate React state updates from incoming peer events
- Multiple peer events arriving in the same JS turn (e.g. a paste burst) now schedule exactly one `queueMicrotask` and produce one `onTextChange` call instead of one per event
- `acceptRemote` (CRDT integration + `applyRemoteOperations` DOM patch) still runs synchronously per event — only the React re-render is deferred
- Microtask checks `channelRef.current` before calling `onTextChange` so it's a no-op if the channel closed before it ran (e.g. on unmount)

Closes #705.

## Test plan

- [ ] Open the awareness-collab demo in two tabs; type normally in both — text syncs as before
- [ ] Paste a large block of text in one tab — the other tab receives and applies it without caret desync
- [ ] Rapid typing in one tab while the other is also typing — no render storm, cursors stay stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)