### PR TITLE
test(packages/eg-walker): P1 property tests for concurrent inserts and offline branch merge

### DIFF
--- a/packages/eg-walker/README.md
+++ b/packages/eg-walker/README.md
@@ -64,6 +64,81 @@ pnpm --filter @softmaple/eg-walker build
 pnpm --filter @softmaple/eg-walker lint
 ```
 
+## Validation
+
+### Property / fuzz tests
+
+Property tests live in `src/test/property/` and use
+[fast-check](https://fast-check.dev/) for shrinkable counterexamples.
+They run as part of the normal test suite:
+
+```bash
+# Default — 100 runs per property (suitable for CI).
+pnpm --filter @softmaple/eg-walker test
+
+# Run only property tests.
+pnpm --filter @softmaple/eg-walker test -- --run src/test/property
+
+# Increase runs for a deeper sweep before a release.
+EG_WALKER_PROPERTY_RUNS=500 pnpm --filter @softmaple/eg-walker test
+```
+
+| Property | File |
+| --- | --- |
+| Multi-replica convergence under randomized delivery | `convergence.property.test.ts` |
+| Delivery-order invariance for a fixed event set | `delivery-order-invariance.property.test.ts` |
+| Duplicate event delivery is idempotent | `duplicate-event-idempotency.property.test.ts` |
+| Missing-parent events are buffered then flushed | `missing-parent-buffering.property.test.ts` |
+| JSON serialize / columnar codec round-trip | `serialize-roundtrip.property.test.ts` |
+| UTF-16 surrogate safety | `unicode-surrogate.property.test.ts` |
+| Concurrent same-index inserts converge (YATA tie-breaking) | `concurrent-same-index-inserts.property.test.ts` |
+| Long offline branch merge converges | `long-offline-branch-merge.property.test.ts` |
+
+See [`src/test/property/README.md`](src/test/property/README.md) for how to add new properties.
+
+### Benchmarks
+
+Benchmarks live in `src/bench/` and are separate from the unit-test suite.
+Run them manually — they never fail CI on timing:
+
+```bash
+pnpm --filter @softmaple/eg-walker bench
+```
+
+| Scenario | File | What it stresses |
+| --- | --- | --- |
+| Long linear history (5k sequential inserts) | `long-linear-history.bench.ts` | Section 3.4 non-conflicting-run fast path |
+| Concurrent same-index inserts (200 events) | `concurrent-same-index-inserts.bench.ts` | YATA origin-left tie-breaking |
+| Long offline branch merge (2×1k events) | `long-offline-branch-merge.bench.ts` | Retreat/advance over a stale branch |
+| Delete-heavy workload (2k events, ~70% deletes) | `delete-heavy-workload.bench.ts` | Delete-target-index and placeholder filtering |
+| Checkpoint effectiveness (100 linear + 20 siblings) | `checkpoint-effectiveness.bench.ts` | `CriticalCheckpointStore` partial-replay path |
+
+Each scenario prints one stats line after the benchmark run, for example:
+
+```
+[bench:long-linear-history] events=5000 text=5000 fullReplays=1 partialReplays=0
+  incrementalApplies=4999 retreats=0 advances=0 checkpoints=32
+  sequenceRecords=1 peakSequenceRecords=1
+  checkpointHits=0 checkpointMisses=0 lastReplaySource=incremental
+```
+
+#### Interpreting replay stats
+
+| Field | Meaning |
+| --- | --- |
+| `fullReplays` | Cold-start or recovery replays over the full event graph. Should be 1 for linear workloads. |
+| `partialReplays` | Replays scoped to the divergent suffix using a `CriticalCheckpointStore` anchor. Replaces full replays for concurrent-sibling merges. |
+| `incrementalApplies` | Events applied by advancing the existing engine state with no retreat. The dominant path for sequential editing. |
+| `retreats` / `advances` | Cumulative engine moves. Non-zero for concurrent merges; proportional to the size of the divergent suffix, not the full history. |
+| `checkpoints` | Retained critical-version checkpoints (capped at 32 via LRU). Higher means more reuse opportunities for future merges. |
+| `checkpointHits` | Times `CriticalCheckpointStore.pickFor` found a usable anchor — avoids a full replay. |
+| `checkpointMisses` | Times no retained checkpoint dominated the divergent suffix — forced a full replay. |
+| `sequenceRecords` | Live records in the ranked B-tree at the end of the scenario. Memory proxy. |
+| `peakSequenceRecords` | High-water mark across the replica lifetime; stays visible even after deletes or engine rebuilds. |
+| `lastReplaySource` | `incremental`, `partial`, or `full` — which path handled the last event. |
+
+A healthy concurrent-merge workload shows `partialReplays > 0` and `checkpointHits > 0`, meaning the checkpoint store is being consulted and is avoiding full replays.
+
 ## References
 
 - [Research paper](https://arxiv.org/abs/2409.14252)

--- a/packages/eg-walker/src/test/property/README.md
+++ b/packages/eg-walker/src/test/property/README.md
@@ -37,6 +37,8 @@ up automatically.
 | [`missing-parent-buffering.property.test.ts`](./missing-parent-buffering.property.test.ts) | Events delivered before their parents are buffered and flushed to the canonical text. |
 | [`serialize-roundtrip.property.test.ts`](./serialize-roundtrip.property.test.ts) | JSON `serialize`/`deserialize` and columnar `encodeBinary`/`decodeBinary` preserve text and frontier. |
 | [`unicode-surrogate.property.test.ts`](./unicode-surrogate.property.test.ts) | Surrogate-biased traces stay well-formed UTF-16 and converge under random delivery. |
+| [`concurrent-same-index-inserts.property.test.ts`](./concurrent-same-index-inserts.property.test.ts) | All-concurrent root inserts at the same index converge under any delivery order (YATA tie-breaking). |
+| [`long-offline-branch-merge.property.test.ts`](./long-offline-branch-merge.property.test.ts) | Two replicas that diverge for many steps without syncing converge after full event exchange. |
 
 ## Shared helpers
 

--- a/packages/eg-walker/src/test/property/concurrent-same-index-inserts.property.test.ts
+++ b/packages/eg-walker/src/test/property/concurrent-same-index-inserts.property.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Property: when multiple replicas all insert at the same index with the
+ * same parent version (the "all-concurrent root inserts" worst case for
+ * YATA tie-breaking), every delivery permutation converges to the same
+ * text.
+ *
+ * All events share `parentVersion = new Set()` (empty), so every event is
+ * concurrent with every other event. The YATA origin-left tie-breaking in
+ * `engine/internals/yata-integration.ts` must impose a total deterministic
+ * order to satisfy the convergence property.
+ *
+ * Two tests:
+ *   1. Two independently-shuffled delivery orders produce the same text.
+ *   2. A randomly-shuffled delivery matches the canonical topological replay
+ *      (events sorted by ascending timestamp, then by id).
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { OPERATION_TYPE } from "../../constants/operation-types";
+import { EgWalkerReplica } from "../../core/replica";
+import type { EventId, GraphEvent } from "../../types";
+import { cloneEvent } from "../test-helpers";
+import { fcParams } from "./run-config";
+import { shuffleWithSeed } from "./shuffle";
+import { canonicalReplay } from "./trace-runner";
+
+const BASE_TIMESTAMP = 1_780_000_000_000;
+
+/**
+ * Generates `count` concurrent insert events: all target index 0, all have
+ * an empty parentVersion, unique IDs, and strictly-ascending timestamps.
+ *
+ * Using strictly-ascending timestamps keeps the canonical topological order
+ * stable (earlier timestamp → earlier in the batch replay), so convergence
+ * failures are attributable to the YATA ordering rather than to ambiguous
+ * topological ordering.
+ */
+const concurrentRootInsertsArb = (opts: {
+  readonly minCount?: number;
+  readonly maxCount?: number;
+}): fc.Arbitrary<ReadonlyArray<GraphEvent>> =>
+  fc
+    .array(
+      fc
+        .integer({ min: 0x61, max: 0x7a })
+        .map((cp): string => String.fromCharCode(cp)),
+      {
+        minLength: opts.minCount ?? 2,
+        maxLength: opts.maxCount ?? 8,
+      },
+    )
+    .map((chars) =>
+      chars.map(
+        (ch, i): GraphEvent => ({
+          id: `concurrent-r${i}:0`,
+          parentVersion: new Set<EventId>(),
+          operation: { type: OPERATION_TYPE.INSERT, index: 0, text: ch },
+          timestamp: BASE_TIMESTAMP + i,
+        }),
+      ),
+    );
+
+describe("property: concurrent same-index inserts converge", () => {
+  it("two independently-shuffled delivery orders produce the same text", () => {
+    fc.assert(
+      fc.property(
+        concurrentRootInsertsArb({ minCount: 2, maxCount: 8 }),
+        fc.integer({ min: 0, max: 0x7fff_ffff }),
+        fc.integer({ min: 0, max: 0x7fff_ffff }),
+        (events, seedA, seedB) => {
+          const orderA = shuffleWithSeed(events, seedA);
+          const orderB = shuffleWithSeed(events, seedB);
+
+          const replicaA = new EgWalkerReplica("order-a");
+          for (const event of orderA) {
+            replicaA.applyRemoteEvent(cloneEvent(event));
+          }
+
+          const replicaB = new EgWalkerReplica("order-b");
+          for (const event of orderB) {
+            replicaB.applyRemoteEvent(cloneEvent(event));
+          }
+
+          expect(replicaA.getPendingRemoteCount()).toBe(0);
+          expect(replicaB.getPendingRemoteCount()).toBe(0);
+
+          // Every event was an insert with no deletions, so both replicas
+          // must have text with length equal to the number of events.
+          expect(replicaA.getText().length).toBe(events.length);
+          expect(replicaB.getText().length).toBe(events.length);
+
+          // Convergence: both replicas must agree on the exact same text.
+          expect(replicaA.getText()).toBe(replicaB.getText());
+        },
+      ),
+      fcParams(),
+    );
+  });
+
+  it("any delivery permutation matches the canonical topological replay", () => {
+    fc.assert(
+      fc.property(
+        concurrentRootInsertsArb({ minCount: 2, maxCount: 6 }),
+        fc.integer({ min: 0, max: 0x7fff_ffff }),
+        (events, seed) => {
+          const canonical = canonicalReplay(events);
+
+          const shuffled = shuffleWithSeed(events, seed);
+          const replica = new EgWalkerReplica("delivery");
+          for (const event of shuffled) {
+            replica.applyRemoteEvent(cloneEvent(event));
+          }
+
+          expect(replica.getPendingRemoteCount()).toBe(0);
+          expect(replica.getText().length).toBe(events.length);
+          expect(replica.getText()).toBe(canonical);
+        },
+      ),
+      fcParams(),
+    );
+  });
+});

--- a/packages/eg-walker/src/test/property/concurrent-same-index-inserts.property.test.ts
+++ b/packages/eg-walker/src/test/property/concurrent-same-index-inserts.property.test.ts
@@ -32,31 +32,35 @@ const BASE_TIMESTAMP = 1_780_000_000_000;
  * Generates `count` concurrent insert events: all target index 0, all have
  * an empty parentVersion, unique IDs, and strictly-ascending timestamps.
  *
- * Using strictly-ascending timestamps keeps the canonical topological order
- * stable (earlier timestamp → earlier in the batch replay), so convergence
- * failures are attributable to the YATA ordering rather than to ambiguous
- * topological ordering.
+ * Each event inserts a unique character derived from its index (`'a'` + i),
+ * so any two distinct YATA orderings produce observably different text. If
+ * characters were drawn with replacement (e.g. two events both inserting
+ * `'a'`), a tie-breaking regression could swap their positions without
+ * changing the final string.
+ *
+ * Strictly-ascending timestamps keep the canonical topological order stable
+ * so convergence failures are attributable to YATA, not to ambiguous ordering.
  */
 const concurrentRootInsertsArb = (opts: {
   readonly minCount?: number;
   readonly maxCount?: number;
 }): fc.Arbitrary<ReadonlyArray<GraphEvent>> =>
   fc
-    .array(
-      fc
-        .integer({ min: 0x61, max: 0x7a })
-        .map((cp): string => String.fromCharCode(cp)),
-      {
-        minLength: opts.minCount ?? 2,
-        maxLength: opts.maxCount ?? 8,
-      },
-    )
-    .map((chars) =>
-      chars.map(
-        (ch, i): GraphEvent => ({
+    .integer({
+      min: opts.minCount ?? 2,
+      max: opts.maxCount ?? 8,
+    })
+    .map((count) =>
+      Array.from(
+        { length: count },
+        (_, i): GraphEvent => ({
           id: `concurrent-r${i}:0`,
           parentVersion: new Set<EventId>(),
-          operation: { type: OPERATION_TYPE.INSERT, index: 0, text: ch },
+          operation: {
+            type: OPERATION_TYPE.INSERT,
+            index: 0,
+            text: String.fromCharCode(0x61 + i),
+          },
           timestamp: BASE_TIMESTAMP + i,
         }),
       ),

--- a/packages/eg-walker/src/test/property/long-offline-branch-merge.property.test.ts
+++ b/packages/eg-walker/src/test/property/long-offline-branch-merge.property.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Property: two replicas that edit independently for many steps and then
+ * exchange all events always converge to the same text.
+ *
+ * "Long offline" is modelled by setting `syncEveryN` large enough that no
+ * intermediate sync fires — the trace runner's unconditional final `sync()`
+ * is the only exchange point. Any permutation of the full event set must
+ * converge to the canonical topological-replay text.
+ *
+ * Two assertions per run:
+ *   1. Both live replicas (post-final-sync via the trace runner) agree with
+ *      the canonical text.
+ *   2. A fresh replica that receives the same complete event set in a random
+ *      permutation also converges to the canonical text. This exercises the
+ *      `RemoteEventBuffer` flush path and the partial/full replay selection
+ *      logic under a large causal gap.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { EgWalkerReplica } from "../../core/replica";
+import { cloneEvent } from "../test-helpers";
+import { traceParamsArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+import { shuffleWithSeed } from "./shuffle";
+import { runTrace } from "./trace-runner";
+
+describe("property: long offline branch merge converges", () => {
+  it("two branches that diverge for many steps converge after full event exchange", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 2,
+          minStepsPerReplica: 4,
+          maxStepsPerReplica: 10,
+          // Large syncEveryN forces no intermediate sync: each replica
+          // stays offline for its entire edit sequence. The trace runner's
+          // unconditional final sync() is the only exchange.
+          syncEveryNArb: fc.constant(10_000),
+        }),
+        (params) => {
+          const trace = runTrace(params);
+          fc.pre(trace.appliedEdits > 0);
+
+          // Both live replicas must converge after the final sync.
+          for (const finalText of trace.finalTextPerReplica.values()) {
+            expect(finalText).toBe(trace.canonicalText);
+          }
+        },
+      ),
+      fcParams(),
+    );
+  });
+
+  it("a fresh replica that receives the offline event set in random order converges", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 2,
+          minStepsPerReplica: 4,
+          maxStepsPerReplica: 8,
+          syncEveryNArb: fc.constant(10_000),
+        }),
+        fc.integer({ min: 0, max: 0x7fff_ffff }),
+        (params, seed) => {
+          const trace = runTrace(params);
+          fc.pre(trace.appliedEdits > 0);
+
+          const shuffled = shuffleWithSeed(trace.events, seed);
+          const replica = new EgWalkerReplica(
+            "late-joiner",
+            params.initialText,
+          );
+          for (const event of shuffled) {
+            replica.applyRemoteEvent(cloneEvent(event));
+          }
+
+          expect(replica.getPendingRemoteCount()).toBe(0);
+          expect(replica.getText()).toBe(trace.canonicalText);
+        },
+      ),
+      fcParams(),
+    );
+  });
+});

--- a/packages/eg-walker/src/test/property/long-offline-branch-merge.property.test.ts
+++ b/packages/eg-walker/src/test/property/long-offline-branch-merge.property.test.ts
@@ -45,6 +45,7 @@ describe("property: long offline branch merge converges", () => {
           fc.pre(trace.appliedEdits > 0);
 
           // Both live replicas must converge after the final sync.
+          expect(trace.finalTextPerReplica.size).toBe(2);
           for (const finalText of trace.finalTextPerReplica.values()) {
             expect(finalText).toBe(trace.canonicalText);
           }


### PR DESCRIPTION
## Summary

- Add `concurrent-same-index-inserts.property.test.ts` (property F): asserts that N all-concurrent root inserts at index 0 converge under any delivery permutation, directly exercising YATA origin-left tie-breaking in `engine/internals/yata-integration.ts`
- Add `long-offline-branch-merge.property.test.ts` (property G): asserts that two replicas diverging for many steps without syncing (`syncEveryN=10_000`) converge after full event exchange, including a late-joiner receiving the event set in a random permutation
- Expand `README.md` with a **Validation** section: how to run property tests and benchmarks, tables of all 8 property scenarios and all 5 bench scenarios, field-by-field guide to interpreting replay stats

## Context

The prior P0 work (finding 758) shipped properties A–E plus all 5 bench scenarios. This PR closes the two remaining P1 property slots (F and G) and adds the documentation section requested in the P1 spec.

No public API changes. No new dependencies. Architecture boundaries intact — no `@softmaple/awareness` coupling.

## Test plan

- [ ] `pnpm --filter @softmaple/eg-walker test -- --run` → 304 tests pass (was 300)
- [ ] `pnpm --filter @softmaple/eg-walker typecheck` → clean
- [ ] `pnpm --filter @softmaple/eg-walker lint` → clean
- [ ] `pnpm --filter @softmaple/eg-walker bench` → all 5 scenarios print stats, `checkpoint-effectiveness` reports `criticalCheckpointHits > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced package README with validation guidance on running property and fuzz tests with configurable iteration controls.
  * Added benchmarks documentation with test scenarios and performance metrics interpretation guide.

* **Tests**
  * Added property-based tests for concurrent insert operations and offline branch merge scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->