### PR TITLE
test(packages/eg-walker): add property coverage

### DIFF
--- a/packages/eg-walker/src/test/property/apply-remote-event-result.property.test.ts
+++ b/packages/eg-walker/src/test/property/apply-remote-event-result.property.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Property: when `EgWalkerReplica.applyRemoteEvent` can attribute a single
+ * position operation to an integrated event, that operation must describe
+ * the visible text change from the pre-event document to the post-event
+ * document.
+ *
+ * The public result intentionally reports insert length rather than inserted
+ * text, because awareness consumers remap selections by position. These
+ * assertions therefore check the structural splice contract instead of
+ * reconstructing inserted content.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { OPERATION_TYPE } from "../../constants/operation-types";
+import { EgWalkerReplica } from "../../core/replica";
+import { EventGraph } from "../../graph/event-graph";
+import { APPLY_REMOTE_EVENT_STATUS, type PositionOperation } from "../../types";
+import { cloneEvent } from "../test-helpers";
+import { traceParamsArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+import { runTrace } from "./trace-runner";
+
+describe("property: applyRemoteEvent position operation contract", () => {
+  it("describes the visible splice whenever a single operation is reported", () => {
+    fc.assert(
+      fc.property(
+        traceParamsArb({
+          minReplicas: 2,
+          maxReplicas: 3,
+          minStepsPerReplica: 2,
+          maxStepsPerReplica: 6,
+          deleteWeight: 5,
+        }),
+        (params) => {
+          const trace = runTrace(params);
+          fc.pre(trace.appliedEdits > 0);
+
+          const graph = new EventGraph();
+          for (const event of trace.events.map(cloneEvent)) {
+            graph.addEvent(event);
+          }
+
+          const replica = new EgWalkerReplica("contract", params.initialText);
+          for (const event of graph.getTopologicalOrder()) {
+            const before = replica.getText();
+            const result = replica.applyRemoteEvent(cloneEvent(event));
+            const after = replica.getText();
+
+            expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
+            if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
+              continue;
+            }
+            if (result.operation === null) {
+              continue;
+            }
+            expectPositionOperationToDescribeChange(
+              result.operation,
+              before,
+              after,
+            );
+          }
+
+          expect(replica.getText()).toBe(trace.canonicalText);
+        },
+      ),
+      fcParams(),
+    );
+  });
+});
+
+// Helpers
+
+const expectPositionOperationToDescribeChange = (
+  operation: PositionOperation,
+  before: string,
+  after: string,
+): void => {
+  if (operation.type === OPERATION_TYPE.INSERT) {
+    expect(operation.index).toBeGreaterThanOrEqual(0);
+    expect(operation.index).toBeLessThanOrEqual(before.length);
+    expect(operation.length).toBeGreaterThan(0);
+    expect(after.length).toBe(before.length + operation.length);
+    expect(after.slice(0, operation.index)).toBe(
+      before.slice(0, operation.index),
+    );
+    expect(after.slice(operation.index + operation.length)).toBe(
+      before.slice(operation.index),
+    );
+    return;
+  }
+
+  expect(operation.index).toBeGreaterThanOrEqual(0);
+  expect(operation.index + operation.length).toBeLessThanOrEqual(before.length);
+  expect(operation.length).toBeGreaterThan(0);
+  expect(after).toBe(
+    before.slice(0, operation.index) +
+      before.slice(operation.index + operation.length),
+  );
+};

--- a/packages/eg-walker/src/test/property/apply-remote-event-result.property.test.ts
+++ b/packages/eg-walker/src/test/property/apply-remote-event-result.property.test.ts
@@ -48,8 +48,8 @@ describe("property: applyRemoteEvent position operation contract", () => {
             const result = replica.applyRemoteEvent(cloneEvent(event));
             const after = replica.getText();
 
-            expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
             if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
+              expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
               continue;
             }
             if (result.operation === null) {

--- a/packages/eg-walker/src/test/property/apply-remote-event-result.property.test.ts
+++ b/packages/eg-walker/src/test/property/apply-remote-event-result.property.test.ts
@@ -16,7 +16,12 @@ import { describe, expect, it } from "vitest";
 import { OPERATION_TYPE } from "../../constants/operation-types";
 import { EgWalkerReplica } from "../../core/replica";
 import { EventGraph } from "../../graph/event-graph";
-import { APPLY_REMOTE_EVENT_STATUS, type PositionOperation } from "../../types";
+import {
+  APPLY_REMOTE_EVENT_STATUS,
+  type ApplyRemoteEventResult,
+  type IntegratedApplyRemoteEventResult,
+  type PositionOperation,
+} from "../../types";
 import { cloneEvent } from "../test-helpers";
 import { traceParamsArb } from "./arbitraries";
 import { fcParams } from "./run-config";
@@ -48,10 +53,7 @@ describe("property: applyRemoteEvent position operation contract", () => {
             const result = replica.applyRemoteEvent(cloneEvent(event));
             const after = replica.getText();
 
-            if (result.status !== APPLY_REMOTE_EVENT_STATUS.Integrated) {
-              expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
-              continue;
-            }
+            expectIntegratedResult(result);
             if (result.operation === null) {
               continue;
             }
@@ -71,6 +73,12 @@ describe("property: applyRemoteEvent position operation contract", () => {
 });
 
 // Helpers
+
+function expectIntegratedResult(
+  result: ApplyRemoteEventResult,
+): asserts result is IntegratedApplyRemoteEventResult {
+  expect(result.status).toBe(APPLY_REMOTE_EVENT_STATUS.Integrated);
+}
 
 const expectPositionOperationToDescribeChange = (
   operation: PositionOperation,

--- a/packages/eg-walker/src/test/property/event-graph-diff.property.test.ts
+++ b/packages/eg-walker/src/test/property/event-graph-diff.property.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Property: `EventGraph.diffVersions(left, right)` must agree with the
+ * set difference of the two expanded causal closures.
+ *
+ * This gives the graph layer a direct oracle that is independent of the
+ * replay engine: the optimized merge-base-style diff is checked against
+ * the simpler definition in terms of `expandVersion`.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { EventGraph } from "../../graph/event-graph";
+import type { EventId, GraphEvent } from "../../types";
+import { cloneEvent } from "../test-helpers";
+import { eventDagArb } from "./arbitraries";
+import { fcParams } from "./run-config";
+
+describe("property: event graph version diff", () => {
+  it("matches expanded causal-set differences", () => {
+    fc.assert(
+      fc.property(
+        eventDagArb({ minSize: 1, maxSize: 16 }),
+        fc.array(fc.nat(), { maxLength: 6 }),
+        fc.array(fc.nat(), { maxLength: 6 }),
+        (events, leftPicks, rightPicks) => {
+          const graph = graphFromEvents(events);
+          const left = versionFromPicks(events, leftPicks);
+          const right = versionFromPicks(events, rightPicks);
+
+          const diff = graph.diffVersions(left, right);
+          const expandedLeft = graph.expandVersion(left);
+          const expandedRight = graph.expandVersion(right);
+
+          expect(diff.onlyInLeft).toEqual(
+            difference(expandedLeft, expandedRight),
+          );
+          expect(diff.onlyInRight).toEqual(
+            difference(expandedRight, expandedLeft),
+          );
+        },
+      ),
+      fcParams(),
+    );
+  });
+
+  it("frontier expansion covers the whole graph", () => {
+    fc.assert(
+      fc.property(eventDagArb({ minSize: 1, maxSize: 16 }), (events) => {
+        const graph = graphFromEvents(events);
+
+        expect(graph.expandVersion(graph.getFrontier()).size).toBe(
+          events.length,
+        );
+      }),
+      fcParams(),
+    );
+  });
+});
+
+// Helpers
+
+const graphFromEvents = (events: ReadonlyArray<GraphEvent>): EventGraph => {
+  const graph = new EventGraph();
+  for (const event of events.map(cloneEvent)) {
+    graph.addEvent(event);
+  }
+  return graph;
+};
+
+const versionFromPicks = (
+  events: ReadonlyArray<GraphEvent>,
+  picks: ReadonlyArray<number>,
+): Set<EventId> =>
+  new Set(
+    picks.map((pick) => {
+      const index = pick % events.length;
+      return events[index]!.id;
+    }),
+  );
+
+const difference = <T>(left: ReadonlySet<T>, right: ReadonlySet<T>): Set<T> => {
+  const result = new Set<T>();
+  for (const item of left) {
+    if (!right.has(item)) {
+      result.add(item);
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
## Summary

- Add a property test that checks `EventGraph.diffVersions` against the simpler causal-closure set-difference definition.
- Add a property test for `EgWalkerReplica.applyRemoteEvent` so any reported single position operation must describe the visible text splice.

## Why

These tests add coverage that is less dependent on the replay engine as its own oracle, and they protect the public operation contract used by editor and awareness integration code.

## Validation

- `pnpm --filter @softmaple/eg-walker test`
- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker lint` (passes with two existing warnings in unrelated test files)
- `pnpm exec prettier --check packages/eg-walker/src/test/property/apply-remote-event-result.property.test.ts packages/eg-walker/src/test/property/event-graph-diff.property.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added property-based tests to validate replica event integration and event graph versioning logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softmaple/softmaple/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->