### PR TITLE
[codex] Document collaboration architecture boundaries

### DIFF
--- a/docs/design/adr/collaboration-architecture-boundaries.md
+++ b/docs/design/adr/collaboration-architecture-boundaries.md
@@ -1,0 +1,209 @@
+---
+title: ADR - Collaboration Architecture Boundaries
+description: Decision record for separating document collaboration, awareness, providers, and future integrations.
+---
+
+# ADR: Collaboration Architecture Boundaries
+
+Status: accepted.
+
+## Context
+
+Softmaple has two current collaboration packages:
+
+- `@softmaple/eg-walker`
+- `@softmaple/awareness`
+
+There is no `@softmaple/presence` package.
+
+Document collaboration and awareness are both part of a collaborative
+product experience, but they have different data lifetimes, correctness
+requirements, and failure modes.
+
+Persistent document data must converge. It is saved, replayed,
+serialized, merged, and audited.
+
+Awareness is ephemeral. It describes what users and sessions are doing
+right now: cursor state, selection state, viewport state, user
+metadata, and online/offline state. It can be approximate and
+eventually consistent without corrupting the document.
+
+## Decision
+
+Softmaple separates persistent document collaboration from ephemeral
+awareness.
+
+`@softmaple/eg-walker` owns persistent collaborative document data:
+document and operation models, merge/conflict resolution,
+transactions, state/version vectors, update encoding/decoding, stable
+anchors or relative positions where applicable, and collaborative data
+structures.
+
+`@softmaple/awareness` owns ephemeral user/session awareness:
+user awareness, cursor state, selection state, viewport state, user
+metadata, online/offline state, and realtime session awareness.
+
+Providers are transport. They may carry eg-walker document updates and
+awareness updates, but they must not own document merge logic,
+awareness merge logic, or editor-specific logic.
+
+Editor bindings and adapters are deferred. Do not create adapter
+packages or define shared adapter APIs until concrete product and
+surface requirements make the right boundary clear.
+
+## Dependency rules
+
+- `@softmaple/eg-walker` must not depend on
+  `@softmaple/awareness`.
+- `@softmaple/awareness` must not depend on
+  `@softmaple/eg-walker`.
+- Providers should remain transport-focused.
+- Future integrations may bridge packages, but they are out of scope
+  now.
+
+## Rationale
+
+### Document collaboration and awareness are separate concerns
+
+Document collaboration answers: "What is the durable document state
+after all accepted edits converge?"
+
+Awareness answers: "Who is here, where are they looking or editing,
+and what session state should peers see right now?"
+
+Coupling these concerns would make document convergence depend on
+low-stakes session state, and would make awareness require a document
+engine even in surfaces where no eg-walker document exists.
+
+### eg-walker focuses on persistent document data
+
+eg-walker is responsible for durable collaboration semantics. Its
+state can be serialized, replayed, diffed, merged, and tested for
+convergence.
+
+It should not own awareness, cursor broadcasting, selection
+broadcasting, user metadata, online status, transport implementation,
+or editor-specific APIs. Those concerns do not change document merge
+correctness.
+
+Key principle: eg-walker synchronizes documents, not people.
+
+### awareness focuses on ephemeral session state
+
+Awareness state is useful because it is live and low-latency, not
+because it is durable. A stale cursor or missing online indicator is a
+session-quality issue; it must not corrupt the document or block
+document convergence.
+
+Awareness should work for rich text editors, code editors,
+whiteboards, canvas apps, React Flow, spreadsheets, and multiplayer
+UI. That requires it to remain independent from eg-walker.
+
+Key principle: awareness synchronizes people/session state, not
+documents.
+
+### awareness should not depend on eg-walker
+
+Awareness should be usable without any document engine. A multiplayer
+canvas, dashboard, spreadsheet selection layer, or whiteboard may need
+cursor and user state without using eg-walker.
+
+If awareness imported eg-walker, every awareness consumer would inherit
+document-engine assumptions, bundle cost, and versioning constraints
+that are irrelevant to many surfaces.
+
+### eg-walker should not depend on awareness
+
+eg-walker must be runnable in isolation: in tests, on a server, in a
+worker, or inside another host that supplies its own awareness layer.
+
+If eg-walker imported awareness, document convergence would become
+entangled with session state and UI-adjacent concepts. That would make
+the core CRDT harder to reason about and less reusable.
+
+### Adapter and editor-binding design is deferred
+
+Adapters and editor bindings are easy to over-design before the real
+surface requirements are known. Lexical, ProseMirror, Slate,
+CodeMirror, Monaco, whiteboards, and canvas tools each expose
+different document models and selection semantics.
+
+The current architecture therefore documents dependency direction and
+package responsibilities, but does not introduce adapter packages,
+shared adapter APIs, or speculative abstractions.
+
+Possible future integrations may include `eg-walker-prosemirror`,
+`eg-walker-lexical`, `eg-walker-slate`, `eg-walker-codemirror`,
+`eg-walker-monaco`, and `awareness-eg-walker`. These are examples of
+future directions, not commitments.
+
+## Relationship to common collaboration architectures
+
+This boundary resembles common collaboration systems:
+
+- Yjs separates document updates from its awareness protocol.
+- Liveblocks distinguishes storage/document state from live presence
+  and room events.
+- Automerge focuses on durable document state; user/session awareness
+  is supplied by surrounding application or networking layers.
+- Fluid separates shared distributed data structures from service and
+  audience/session concepts.
+- Figma-style collaboration treats document/object state and live
+  collaborator awareness as related but distinct realtime streams.
+
+Softmaple follows the same broad pattern: durable state and live
+session state can share transport, but they should not share ownership.
+
+## Consequences
+
+Benefits:
+
+- eg-walker remains a focused document-convergence package.
+- awareness remains reusable across many collaborative surfaces.
+- Providers can transport multiple update types without owning their
+  semantics.
+- Future integrations can bridge packages when requirements justify
+  the boundary.
+
+Tradeoffs:
+
+- Hosts must compose document updates and awareness updates explicitly.
+- Future editor bindings need their own decision records before they
+  become package-level APIs.
+- Some naming in existing UI APIs may still use "presence" for
+  component or type names, but the Softmaple package boundary is
+  `@softmaple/awareness`.
+
+## Roadmap
+
+Current scope:
+
+- Maintain `@softmaple/eg-walker` for persistent collaborative
+  document data.
+- Maintain `@softmaple/awareness` for ephemeral user/session state.
+- Keep providers transport-focused.
+- Enforce no dependency between eg-walker and awareness.
+
+Future scope:
+
+- Evaluate editor bindings only after real requirements are known.
+- Evaluate bridge integrations only when a host needs reusable
+  composition between document updates and awareness updates.
+- Add new ADRs before committing to adapter packages or shared
+  adapter APIs.
+
+Out of scope now:
+
+- Creating adapter packages.
+- Defining editor-binding APIs.
+- Introducing a `@softmaple/presence` package.
+- Moving document merge logic into providers.
+- Moving awareness merge logic into providers.
+
+## Related docs
+
+- [Architecture Overview](../architecture-overview.md)
+- [Package Responsibilities](../package-responsibilities.md)
+- [Collaboration Architecture Layers](../collaboration-layers.md)
+- [Collaboration Models](../collaboration-models.md)
+- [Awareness Design](../awareness-and-presence.md)

--- a/docs/design/adr/collaboration-architecture-boundaries.md
+++ b/docs/design/adr/collaboration-architecture-boundaries.md
@@ -43,6 +43,10 @@ structures.
 user awareness, cursor state, selection state, viewport state, user
 metadata, online/offline state, and realtime session awareness.
 
+The package is named `@softmaple/awareness`. "Presence" remains valid
+for concepts and API names that describe online users, cursors,
+selections, and collaborator activity.
+
 Providers are transport. They may carry eg-walker document updates and
 awareness updates, but they must not own document merge logic,
 awareness merge logic, or editor-specific logic.
@@ -99,8 +103,8 @@ Awareness should work for rich text editors, code editors,
 whiteboards, canvas apps, React Flow, spreadsheets, and multiplayer
 UI. That requires it to remain independent from eg-walker.
 
-Key principle: awareness synchronizes people/session state, not
-documents.
+Key principle: `@softmaple/awareness` synchronizes people/session
+state, including presence, not documents.
 
 ### awareness should not depend on eg-walker
 
@@ -170,9 +174,9 @@ Tradeoffs:
 - Hosts must compose document updates and awareness updates explicitly.
 - Future editor bindings need their own decision records before they
   become package-level APIs.
-- Some naming in existing UI APIs may still use "presence" for
-  component or type names, but the Softmaple package boundary is
-  `@softmaple/awareness`.
+- The Softmaple package boundary is `@softmaple/awareness`, but
+  presence remains valid for user-facing concepts, component names,
+  type names, and wire protocol names.
 
 ## Roadmap
 

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -18,6 +18,10 @@ The current collaboration packages are:
 There is no `@softmaple/presence` package. Softmaple uses
 `@softmaple/awareness` for user/session awareness.
 
+This naming rule applies to the package name. "Presence" remains valid
+for user-facing state, UI component names, type names, and wire events
+that describe who is online and where collaborators are working.
+
 ## Boundaries at a glance
 
 ```text
@@ -40,8 +44,8 @@ There is no `@softmaple/presence` package. Softmaple uses
 
 `@softmaple/eg-walker` synchronizes documents, not people.
 
-`@softmaple/awareness` synchronizes people/session state, not
-documents.
+`@softmaple/awareness` synchronizes people/session state, including
+presence, not documents.
 
 Providers transport messages. They may carry both eg-walker document
 updates and awareness updates, but they must not own document merge
@@ -49,11 +53,11 @@ logic, awareness merge logic, or editor-specific behavior.
 
 ## Package roles
 
-| Package                | Owns                                   | Does not own                                                                                                                        |
-| ---------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `@softmaple/eg-walker` | Persistent collaborative document data | Awareness, user metadata, online state, cursor broadcasting, selection broadcasting, transport implementation, editor-specific APIs |
-| `@softmaple/awareness` | Ephemeral user/session awareness state | Persistent document convergence, eg-walker merge rules, editor-specific document APIs                                               |
-| Providers              | Message transport                      | Document merge logic, awareness merge logic, editor-specific logic                                                                  |
+| Package                | Owns                                                | Does not own                                                                                                                        |
+| ---------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `@softmaple/eg-walker` | Persistent collaborative document data              | Awareness, user metadata, online state, cursor broadcasting, selection broadcasting, transport implementation, editor-specific APIs |
+| `@softmaple/awareness` | Ephemeral user/session awareness and presence state | Persistent document convergence, eg-walker merge rules, editor-specific document APIs                                               |
+| Providers              | Message transport                                   | Document merge logic, awareness merge logic, editor-specific logic                                                                  |
 
 See [Package Responsibilities](./package-responsibilities.md) for the
 full responsibility matrix.
@@ -106,8 +110,8 @@ Current architecture scope:
 
 - Keep `@softmaple/eg-walker` focused on persistent collaborative
   document data.
-- Keep `@softmaple/awareness` focused on ephemeral user/session
-  state.
+- Keep `@softmaple/awareness` focused on ephemeral user/session state,
+  including presence.
 - Keep providers focused on transporting opaque update messages.
 - Document and enforce dependency direction.
 

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -1,0 +1,138 @@
+---
+title: Architecture Overview
+description: Collaboration architecture boundaries for document data, awareness state, providers, and future integrations.
+---
+
+# Architecture Overview
+
+Softmaple's collaboration architecture separates persistent document
+data from ephemeral user/session awareness. These concerns often move
+over the same realtime connection, but they are not the same layer and
+must not own each other's merge rules.
+
+The current collaboration packages are:
+
+- `@softmaple/eg-walker`
+- `@softmaple/awareness`
+
+There is no `@softmaple/presence` package. Softmaple uses
+`@softmaple/awareness` for user/session awareness.
+
+## Boundaries at a glance
+
+```text
+                 transport only
+        +-------------------------------+
+        |            Provider           |
+        |  WebSocket / WebRTC / storage |
+        +---------------+---------------+
+                        |
+          carries opaque messages for:
+                        |
+      +-----------------+-----------------+
+      |                                   |
++-----v------------------+      +---------v-------------+
+| @softmaple/eg-walker   |      | @softmaple/awareness  |
+| persistent document    |      | ephemeral awareness   |
+| data                   |      | state                 |
++------------------------+      +-----------------------+
+```
+
+`@softmaple/eg-walker` synchronizes documents, not people.
+
+`@softmaple/awareness` synchronizes people/session state, not
+documents.
+
+Providers transport messages. They may carry both eg-walker document
+updates and awareness updates, but they must not own document merge
+logic, awareness merge logic, or editor-specific behavior.
+
+## Package roles
+
+| Package                | Owns                                   | Does not own                                                                                                                        |
+| ---------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `@softmaple/eg-walker` | Persistent collaborative document data | Awareness, user metadata, online state, cursor broadcasting, selection broadcasting, transport implementation, editor-specific APIs |
+| `@softmaple/awareness` | Ephemeral user/session awareness state | Persistent document convergence, eg-walker merge rules, editor-specific document APIs                                               |
+| Providers              | Message transport                      | Document merge logic, awareness merge logic, editor-specific logic                                                                  |
+
+See [Package Responsibilities](./package-responsibilities.md) for the
+full responsibility matrix.
+
+## Dependency direction
+
+The two core collaboration packages are siblings:
+
+```text
+@softmaple/eg-walker      @softmaple/awareness
+         |                         |
+         | no imports either way   |
+         +-----------x-------------+
+```
+
+Required rules:
+
+- `@softmaple/eg-walker` must not depend on
+  `@softmaple/awareness`.
+- `@softmaple/awareness` must not depend on
+  `@softmaple/eg-walker`.
+- Providers should remain transport-focused.
+- Future integrations may bridge packages, but they are out of scope
+  now.
+
+The host application or a future integration is where document updates
+and awareness state may be composed:
+
+```text
+                      future scope
+                  +----------------+
+                  | integration /  |
+                  | editor binding |
+                  +-------+--------+
+                          |
+           +--------------+--------------+
+           |                             |
++----------v-------------+   +-----------v------------+
+| @softmaple/eg-walker   |   | @softmaple/awareness   |
++------------------------+   +------------------------+
+```
+
+This direction keeps both core packages reusable for rich text
+editors, code editors, whiteboards, canvas apps, React Flow,
+spreadsheets, and multiplayer UI.
+
+## Current scope
+
+Current architecture scope:
+
+- Keep `@softmaple/eg-walker` focused on persistent collaborative
+  document data.
+- Keep `@softmaple/awareness` focused on ephemeral user/session
+  state.
+- Keep providers focused on transporting opaque update messages.
+- Document and enforce dependency direction.
+
+Current docs:
+
+- [Collaboration Architecture Layers](./collaboration-layers.md)
+- [Collaboration Models](./collaboration-models.md)
+- [Awareness Design](./awareness-and-presence.md)
+- [Package Responsibilities](./package-responsibilities.md)
+- [ADR: Collaboration Architecture Boundaries](./adr/collaboration-architecture-boundaries.md)
+
+## Future scope
+
+Editor bindings and adapters are deferred until concrete requirements
+are clear. Do not create adapter packages or shared adapter APIs as
+part of the current architecture.
+
+Possible future integrations may include:
+
+- `eg-walker-prosemirror`
+- `eg-walker-lexical`
+- `eg-walker-slate`
+- `eg-walker-codemirror`
+- `eg-walker-monaco`
+- `awareness-eg-walker`
+
+These names are examples of possible future integration directions,
+not package commitments.

--- a/docs/design/awareness-and-presence.md
+++ b/docs/design/awareness-and-presence.md
@@ -1,10 +1,14 @@
-# Awareness & Presence Design Document
+# Awareness Design
 
 ## 1. Overview
 
-This document describes the design of **Awareness & Presence** in a real-time collaborative editor.
+This document describes the design of **awareness** in a real-time
+collaborative experience. In Softmaple, awareness is the package-level
+term for ephemeral user/session state. There is no
+`@softmaple/presence` package.
 
-**Awareness & Presence** answers four fundamental user questions with minimal cognitive load:
+Awareness answers four fundamental user questions with minimal
+cognitive load:
 
 1. **Who** is currently in the room?
 2. **Where** are they in the document?
@@ -18,24 +22,27 @@ The system is designed to be **low-noise, non-blocking, and progressively disclo
 ## 2. Design Principles
 
 ### 2.1 Low Interruption by Default
+
 - Awareness information should be **visible but ignorable**
 - No blocking modals, no toast spam
 - Strong signals only appear on hover, focus, or potential conflict
 
 ### 2.2 Approximation Over Precision
-- Presence is **probabilistic**, not authoritative
+
+- Awareness is **probabilistic**, not authoritative
 - "Someone is editing here" is sufficient
 - Exact keystrokes or real-time character updates are unnecessary
 
 ### 2.3 Layered Awareness
+
 Information is presented in layers from coarse to fine:
 
-| Layer | Question Answered |
-|---|---|
-| Global | Who is online? |
-| Document | Who is in this document? |
-| Section | Who is editing this part? |
-| Action | What just happened? |
+| Layer    | Question Answered         |
+| -------- | ------------------------- |
+| Global   | Who is online?            |
+| Document | Who is in this document?  |
+| Section  | Who is editing this part? |
+| Action   | What just happened?       |
 
 ---
 
@@ -51,9 +58,9 @@ The following are explicitly out of scope for the first iteration:
 
 ---
 
-## 4. Presence Model
+## 4. Awareness State Model
 
-### 4.1 User Presence State
+### 4.1 User Awareness State
 
 ```ts
 type PresenceStatus = "active" | "idle" | "offline";
@@ -86,22 +93,26 @@ interface PresenceUser {
 
 ### 4.2 Status Rules
 
-| Status | Definition |
-|---|---|
-| `active` | User performed an action in last N seconds |
-| `idle` | Connected but no recent activity |
-| `offline` | Disconnected or heartbeat expired |
+| Status    | Definition                                 |
+| --------- | ------------------------------------------ |
+| `active`  | User performed an action in last N seconds |
+| `idle`    | Connected but no recent activity           |
+| `offline` | Disconnected or heartbeat expired          |
 
 ---
 
 ## 5. UI Components
 
-### 5.1 Presence Bar (Global Awareness)
+### 5.1 Awareness Bar (Global Awareness)
 
 **Purpose**  
 Shows who is currently in the room.
 
+The current UI component name is `PresenceBar`; the architectural
+package term remains awareness.
+
 **Behavior**
+
 - Displays up to N avatars
 - Overflow shown as `+X`
 - Tooltip reveals name and status
@@ -115,6 +126,7 @@ Shows who is currently in the room.
 Indicates where another user is editing.
 
 **Behavior**
+
 - Colored caret
 - Username label appears on movement
 - Label fades out after 2-3 seconds
@@ -128,6 +140,7 @@ Indicates where another user is editing.
 Shows which block or range is being edited by others.
 
 **Behavior**
+
 - Semi-transparent background highlight
 - Same color as user
 - Optional border
@@ -141,6 +154,7 @@ Shows which block or range is being edited by others.
 Communicates recent activity without distraction.
 
 **Examples**
+
 - "Adam is editing this paragraph"
 - "2 people editing here"
 
@@ -159,7 +173,7 @@ Communicates recent activity without distraction.
 
 - Cursor updates throttled (50-100ms)
 - Off-screen cursors not rendered
-- Presence is eventually consistent
+- Awareness is eventually consistent
 
 ---
 
@@ -174,14 +188,17 @@ Communicates recent activity without distraction.
 ## 9. Progressive Rollout Plan
 
 ### Phase 1
-- Presence bar
+
+- Awareness bar (`PresenceBar`)
 - Online count
 
 ### Phase 2
+
 - Live cursors
 - Selection highlights
 
 ### Phase 3
+
 - Minimap / scrollbar indicators
 
 ---
@@ -194,8 +211,20 @@ Communicates recent activity without distraction.
 
 ---
 
-## 11. Summary
+## 11. Architecture Boundary
 
-Awareness & Presence should create **calm confidence**, not excitement.
+Awareness state is ephemeral session state. It must not own persistent
+document merge logic and must remain independent from
+`@softmaple/eg-walker`.
+
+Related docs:
+
+- [Architecture Overview](./architecture-overview.md)
+- [Package Responsibilities](./package-responsibilities.md)
+- [ADR: Collaboration Architecture Boundaries](./adr/collaboration-architecture-boundaries.md)
+
+## 12. Summary
+
+Awareness should create **calm confidence**, not excitement.
 
 > "I know who's here, and I'm not surprised by their actions."

--- a/docs/design/awareness-and-presence.md
+++ b/docs/design/awareness-and-presence.md
@@ -1,14 +1,17 @@
-# Awareness Design
+# Awareness & Presence Design
 
 ## 1. Overview
 
-This document describes the design of **awareness** in a real-time
-collaborative experience. In Softmaple, awareness is the package-level
-term for ephemeral user/session state. There is no
-`@softmaple/presence` package.
+This document describes the design of **awareness and presence** in a
+real-time collaborative experience. In Softmaple, the package name is
+`@softmaple/awareness`; there is no `@softmaple/presence` package.
 
-Awareness answers four fundamental user questions with minimal
-cognitive load:
+Presence remains the right term for user-facing concepts like who is
+online, live cursors, selection highlights, and existing API names such
+as `PresenceUser` or `PresenceBar`.
+
+Awareness and presence answer four fundamental user questions with
+minimal cognitive load:
 
 1. **Who** is currently in the room?
 2. **Where** are they in the document?
@@ -29,7 +32,7 @@ The system is designed to be **low-noise, non-blocking, and progressively disclo
 
 ### 2.2 Approximation Over Precision
 
-- Awareness is **probabilistic**, not authoritative
+- Presence is **probabilistic**, not authoritative
 - "Someone is editing here" is sufficient
 - Exact keystrokes or real-time character updates are unnecessary
 
@@ -58,9 +61,9 @@ The following are explicitly out of scope for the first iteration:
 
 ---
 
-## 4. Awareness State Model
+## 4. Presence Model
 
-### 4.1 User Awareness State
+### 4.1 User Presence State
 
 ```ts
 type PresenceStatus = "active" | "idle" | "offline";
@@ -103,13 +106,13 @@ interface PresenceUser {
 
 ## 5. UI Components
 
-### 5.1 Awareness Bar (Global Awareness)
+### 5.1 Presence Bar (Global Awareness)
 
 **Purpose**  
 Shows who is currently in the room.
 
-The current UI component name is `PresenceBar`; the architectural
-package term remains awareness.
+The current UI component name is `PresenceBar`. The package that
+exports it is `@softmaple/awareness`.
 
 **Behavior**
 
@@ -173,7 +176,7 @@ Communicates recent activity without distraction.
 
 - Cursor updates throttled (50-100ms)
 - Off-screen cursors not rendered
-- Awareness is eventually consistent
+- Presence is eventually consistent
 
 ---
 
@@ -189,7 +192,7 @@ Communicates recent activity without distraction.
 
 ### Phase 1
 
-- Awareness bar (`PresenceBar`)
+- Presence bar
 - Online count
 
 ### Phase 2
@@ -213,8 +216,8 @@ Communicates recent activity without distraction.
 
 ## 11. Architecture Boundary
 
-Awareness state is ephemeral session state. It must not own persistent
-document merge logic and must remain independent from
+Awareness/presence state is ephemeral session state. It must not own
+persistent document merge logic and must remain independent from
 `@softmaple/eg-walker`.
 
 Related docs:
@@ -225,6 +228,7 @@ Related docs:
 
 ## 12. Summary
 
-Awareness should create **calm confidence**, not excitement.
+Awareness and presence should create **calm confidence**, not
+excitement.
 
 > "I know who's here, and I'm not surprised by their actions."

--- a/docs/design/collaboration-layers.md
+++ b/docs/design/collaboration-layers.md
@@ -69,8 +69,8 @@ The CRDT runtime. Implements the Eg-walker paper directly.
 
 `@softmaple/eg-walker` **MUST NOT**:
 
-- Depend on `@softmaple/awareness` (no awareness, no cursors, no
-  transport adapters).
+- Depend on `@softmaple/awareness` (no presence/awareness state, no
+  cursors, no transport adapters).
 - Depend on any editor framework — `lexical`, `prosemirror-*`,
   `slate` / `slate-*`, or equivalent.
 - Expose anything but index-based operations on its public API. No
@@ -79,18 +79,18 @@ The CRDT runtime. Implements the Eg-walker paper directly.
 ### Rationale
 
 eg-walker is the convergence guarantee for the whole product. Keeping
-it free of editor and awareness concerns lets us reuse it under any
-editor we choose, run it in a worker or on the server, and reason
-about it in isolation when debugging divergence.
+it free of editor and presence/awareness concerns lets us reuse it
+under any editor we choose, run it in a worker or on the server, and
+reason about it in isolation when debugging divergence.
 
 ## Layer 2: `@softmaple/awareness`
 
-The ephemeral user/session awareness layer. Editor-class-agnostic and
-independent from eg-walker.
+The ephemeral user/session presence and awareness layer.
+Editor-class-agnostic and independent from eg-walker.
 
 ### Responsibilities
 
-- **User awareness** — who is online, who is in a realtime session,
+- **Presence state** — who is online, who is in a realtime session,
   status (`active` / `idle` / `offline`), and last-seen timestamps.
 - **Cursor state** — where collaborators are pointing or editing.
 - **Selection state** — the ranges collaborators are focused on.
@@ -98,9 +98,9 @@ independent from eg-walker.
   when a host chooses to publish it.
 - **User metadata** — names, avatars, colors, roles, and other
   session-safe metadata.
-- **Realtime session awareness** — state that helps people understand
-  each other during collaboration, without becoming durable document
-  data.
+- **Realtime session awareness / presence** — state that helps people
+  understand each other during collaboration, without becoming durable
+  document data.
 
 ### Forbidden
 
@@ -120,8 +120,8 @@ gate document convergence and must never assume a particular editor.
 This keeps the package useful for rich text editors, code editors,
 whiteboards, canvas apps, React Flow, spreadsheets, and multiplayer UI.
 
-Key principle: awareness synchronizes people/session state, not
-documents.
+Key principle: `@softmaple/awareness` synchronizes people/session
+state, including presence, not documents.
 
 ## Layer 3: Providers
 

--- a/docs/design/collaboration-layers.md
+++ b/docs/design/collaboration-layers.md
@@ -1,13 +1,16 @@
 ---
 title: Collaboration Architecture Layers
-description: Layering boundaries between @softmaple/eg-walker, @softmaple/awareness, and consumer apps.
+description: Enforced layering boundaries between @softmaple/eg-walker, @softmaple/awareness, providers, and consumer apps.
 ---
 
 # Collaboration Architecture Layers
 
-This document is the **source of truth** for how Softmaple's real-time
-collaboration code is layered. It defines what each layer owns, what it
-must not depend on, and how the layers compose inside `apps/*`.
+This document describes the mechanically enforced layering rules for
+Softmaple's real-time collaboration code. For the product-level
+architecture boundary, start with
+[`architecture-overview.md`](./architecture-overview.md), then see
+[`package-responsibilities.md`](./package-responsibilities.md) and the
+[ADR](./adr/collaboration-architecture-boundaries.md).
 
 The split is enforced by an ESLint `no-restricted-imports` rule in
 `@softmaple/eslint-config` (see [Enforcement](#enforcement) below).
@@ -23,11 +26,17 @@ The split is enforced by an ESLint `no-restricted-imports` rule in
     - index-based operations only
 
 @softmaple/awareness
-    - presence state
-    - cursor/selection mapping (issue B1)
-    - transport adapters
-    - rendering helpers
-    - surface bindings (issue B2, deferred)
+    - user/session awareness state
+    - cursor state
+    - selection state
+    - viewport state
+    - user metadata
+    - online/offline state
+
+providers
+    - transport only
+    - may carry eg-walker document updates
+    - may carry awareness updates
 
 apps/*
     - concrete editor integrations
@@ -60,7 +69,7 @@ The CRDT runtime. Implements the Eg-walker paper directly.
 
 `@softmaple/eg-walker` **MUST NOT**:
 
-- Depend on `@softmaple/awareness` (no presence, no cursors, no
+- Depend on `@softmaple/awareness` (no awareness, no cursors, no
   transport adapters).
 - Depend on any editor framework — `lexical`, `prosemirror-*`,
   `slate` / `slate-*`, or equivalent.
@@ -70,55 +79,77 @@ The CRDT runtime. Implements the Eg-walker paper directly.
 ### Rationale
 
 eg-walker is the convergence guarantee for the whole product. Keeping
-it free of editor and presence concerns lets us reuse it under any
+it free of editor and awareness concerns lets us reuse it under any
 editor we choose, run it in a worker or on the server, and reason
 about it in isolation when debugging divergence.
 
 ## Layer 2: `@softmaple/awareness`
 
-The presence and cursor layer. Editor-class-agnostic.
+The ephemeral user/session awareness layer. Editor-class-agnostic and
+independent from eg-walker.
 
 ### Responsibilities
 
-- **Presence state** — who is online, who is in this document, status
-  (`active` / `idle` / `offline`), last-seen timestamps.
-- **Cursor and selection mapping** — translates abstract cursor /
-  selection positions to and from a transport-friendly representation
-  (issue B1).
-- **Transport adapters** — pluggable backends (broadcast channel,
-  WebSocket, no-op) under `adapters/`.
-- **Rendering helpers** — primitives (`PresenceBar`, `LiveCursor`,
-  `SelectionHighlight`, `ActivityIndicator`) and React hooks for the
-  app shell to compose presence UI.
-- **Surface bindings** — concrete glue from a surface's selection
-  model to the awareness cursor model is **deferred** (issue B2). When
-  it arrives it will live in a sub-path of `@softmaple/awareness`
-  (e.g. `@softmaple/awareness/bindings/<surface>`) and is the only
-  place inside this package allowed to know about an editor or canvas
-  framework. The term "surface" (rather than "editor") is intentional;
-  see [`surface-bindings.md`](./surface-bindings.md) for the role
-  definition and naming rationale.
+- **User awareness** — who is online, who is in a realtime session,
+  status (`active` / `idle` / `offline`), and last-seen timestamps.
+- **Cursor state** — where collaborators are pointing or editing.
+- **Selection state** — the ranges collaborators are focused on.
+- **Viewport state** — the visible area or focus area for a session
+  when a host chooses to publish it.
+- **User metadata** — names, avatars, colors, roles, and other
+  session-safe metadata.
+- **Realtime session awareness** — state that helps people understand
+  each other during collaboration, without becoming durable document
+  data.
 
 ### Forbidden
 
 `@softmaple/awareness` **MUST NOT**:
 
-- Depend on `@softmaple/eg-walker`. Presence and convergence are
+- Depend on `@softmaple/eg-walker`. Awareness and convergence are
   independent concerns; awareness must work even without a CRDT
   document attached.
 - Depend on any editor framework — `lexical`, `prosemirror-*`, or
-  `slate` / `slate-*` — outside the deferred `bindings/<surface>`
-  sub-path that does not yet exist.
+  `slate` / `slate-*`.
 
 ### Rationale
 
 Awareness is approximate by design (see
 [`awareness-and-presence`](./awareness-and-presence)). It must never
 gate document convergence and must never assume a particular editor.
-This keeps the package safe to load in a worker, on the server (for
-SSR-friendly presence snapshots), or alongside a non-Lexical editor.
+This keeps the package useful for rich text editors, code editors,
+whiteboards, canvas apps, React Flow, spreadsheets, and multiplayer UI.
 
-## Layer 3: `apps/*`
+Key principle: awareness synchronizes people/session state, not
+documents.
+
+## Layer 3: Providers
+
+The transport layer.
+
+### Responsibilities
+
+- Move eg-walker document updates between replicas.
+- Move awareness updates between sessions.
+- Handle connection, retry, authentication, routing, and backend
+  protocol details.
+
+### Forbidden
+
+Providers **MUST NOT**:
+
+- Own document merge logic.
+- Own awareness merge logic.
+- Own editor-specific logic.
+
+### Rationale
+
+A provider can carry multiple message types over the same connection,
+but it should treat those messages as transport payloads. Document
+state is interpreted by `@softmaple/eg-walker`; awareness state is
+interpreted by `@softmaple/awareness`.
+
+## Layer 4: `apps/*`
 
 The integration layer. Today that is `apps/web` (Next.js + Lexical)
 and `apps/playground` (CRDT experiments).
@@ -129,7 +160,7 @@ and `apps/playground` (CRDT experiments).
   views, or Slate plugins that translate editor operations to and from
   eg-walker's index-based API.
 - **UI composition** — wiring `@softmaple/awareness` components into
-  the app shell, choosing transport adapters, theming.
+  the app shell, choosing providers, theming.
 - **Identity and auth** — mapping the app's user model onto
   `PresenceUser`.
 - **Routing and persistence** — document IDs, room IDs, hydration from
@@ -190,6 +221,10 @@ implement.
 
 ## Generic position contract
 
+This section records current position-shape conventions used by the
+existing sequence model and awareness mapping helpers. It does not
+define a future editor-binding API.
+
 The collaboration foundation must work for plain text, rich text, block,
 canvas/whiteboard, node-based, and IDE-like editors. To keep the two
 packages editor-class agnostic, positions and ranges flow through the
@@ -214,7 +249,7 @@ following shapes:
   open-ended `[key: string]: unknown` field, and renderer components
   (`LiveCursor`, `SelectionHighlight`) already accept post-resolved
   screen coordinates (`LiveCursorPoint { x, y }`, `HighlightRect { x,
-  y, width, height }`) so a canvas integration never has to round-trip
+y, width, height }`) so a canvas integration never has to round-trip
   through `CursorPosition`.
 
 ### Structural remote-event result (issue [#747](https://github.com/softmaple/softmaple/issues/747))
@@ -263,12 +298,14 @@ inferred integration from a text side effect:
 ```ts
 const before = remoteReplica.getText();
 remoteReplica.applyRemoteEvent(event);
-if (remoteReplica.getText() !== before) { /* assume integrated */ }
+if (remoteReplica.getText() !== before) {
+  /* assume integrated */
+}
 ```
 
 That works in practice but is brittle:
 
-- It is *behavioral*, not *structural*. Any future change that lets an
+- It is _behavioral_, not _structural_. Any future change that lets an
   integrated event produce a zero-width visible change (a delete that
   fully overlaps already-deleted characters, an empty insert sliding
   through a coalescing path, IME compositions in #704) would silently

--- a/docs/design/collaboration-models.md
+++ b/docs/design/collaboration-models.md
@@ -7,13 +7,14 @@ description: The three collaboration models Softmaple supports (sequence, block,
 
 This document defines the **collaboration models** Softmaple supports
 and the per-engine contract each model implies. It is a companion to
-[`collaboration-layers.md`](./collaboration-layers.md) (the legal
-layering contract) and [`surface-bindings.md`](./surface-bindings.md)
-(the surface-side glue).
+[`architecture-overview.md`](./architecture-overview.md),
+[`collaboration-layers.md`](./collaboration-layers.md), and
+[`surface-bindings.md`](./surface-bindings.md) (future integration
+scope).
 
 A "collaboration model" is a tuple of three things:
 
-1. **State shape** — what the convergent document *is*.
+1. **State shape** — what the convergent document _is_.
 2. **Op shape** — what local edits and remote events look like.
 3. **Position shape** — how cursors and selections are addressed.
 
@@ -96,9 +97,9 @@ interface BlockTree {
 
 interface Block {
   readonly id: BlockId;
-  readonly type: string;           // "paragraph", "heading", "list-item", …
+  readonly type: string; // "paragraph", "heading", "list-item", …
   readonly children: readonly BlockId[];
-  readonly text?: string;          // for leaf blocks with text
+  readonly text?: string; // for leaf blocks with text
   readonly attrs?: Readonly<Record<string, unknown>>;
 }
 ```
@@ -161,12 +162,12 @@ type ObjectId = string;
 
 interface ObjectScene {
   readonly objects: ReadonlyMap<ObjectId, SceneObject>;
-  readonly zOrder: readonly ObjectId[];   // optional, fractional-indexed in practice
+  readonly zOrder: readonly ObjectId[]; // optional, fractional-indexed in practice
 }
 
 interface SceneObject {
   readonly id: ObjectId;
-  readonly type: string;          // "rect", "ellipse", "arrow", "image", …
+  readonly type: string; // "rect", "ellipse", "arrow", "image", …
   readonly attrs: Readonly<Record<string, unknown>>;
 }
 ```
@@ -188,7 +189,7 @@ fundamentally different from sequence convergence:
 - "Conflict" is two writers setting the same attribute, resolved by
   timestamp + tiebreaker, not by tombstoning a character.
 - Reordering is sometimes a fractional index, occasionally a
-  sequence-CRDT — at the *attribute* level, not the document level.
+  sequence-CRDT — at the _attribute_ level, not the document level.
 
 **Do not force this model through the sequence engine.** A canvas
 demo that hand-rolls convergence on top of `@softmaple/awareness` + a
@@ -217,13 +218,13 @@ Every collaboration engine — present or future — must satisfy this
 informal contract. Each engine spells the types in its own package;
 they are not shared.
 
-| Method | Purpose |
-|---|---|
-| `apply(localOp)` | Translate a local intent into an event, advance state |
-| `applyRemoteEvent(event)` | Integrate, buffer, or dedupe a remote event |
-| `state()` | Read current convergent state |
-| `events()` | Iterate the event graph for sync / replication |
-| `subscribe(listener)` | Notify on integrated changes |
+| Method                    | Purpose                                               |
+| ------------------------- | ----------------------------------------------------- |
+| `apply(localOp)`          | Translate a local intent into an event, advance state |
+| `applyRemoteEvent(event)` | Integrate, buffer, or dedupe a remote event           |
+| `state()`                 | Read current convergent state                         |
+| `events()`                | Iterate the event graph for sync / replication        |
+| `subscribe(listener)`     | Notify on integrated changes                          |
 
 What an engine **must not** do, regardless of model:
 
@@ -240,7 +241,7 @@ the same template.
 
 ## Cross-model reuse
 
-Some plumbing genuinely *is* shared across models (event ID
+Some plumbing genuinely _is_ shared across models (event ID
 generation, columnar codec for the DAG, topological order). Today
 this lives inside `@softmaple/eg-walker/graph`. If and when a second
 engine ships and ends up with a near-identical graph layer, extract a
@@ -249,16 +250,18 @@ expensive than duplication for two consumers.
 
 ## Roadmap
 
-See [`collaboration-layers.md`](./collaboration-layers.md) for the
-hard rules and the project-wide roadmap. In short:
+See [`architecture-overview.md`](./architecture-overview.md) and the
+[ADR](./adr/collaboration-architecture-boundaries.md) for the hard
+rules and the project-wide roadmap. In short:
 
 - **Now** — sequence model only (`@softmaple/eg-walker`).
-- **Next** — surface bindings against the sequence model for
-  textarea, CodeMirror, and a lowered Lexical demo.
-- **Later** — block engine package, when a host demands real
-  block-aware convergence.
-- **Later still** — object engine package, after a canvas demo
-  proves the ops shape on raw awareness + transport.
+- **Now** — `@softmaple/awareness` remains independent from
+  `@softmaple/eg-walker`.
+- **Now** — providers remain transport-focused.
+- **Future** — editor integrations only after concrete requirements
+  are clear.
+- **Future** — block or object engine packages only when a host
+  demands real block-aware or object-aware convergence.
 
 ## When to update this doc
 

--- a/docs/design/package-responsibilities.md
+++ b/docs/design/package-responsibilities.md
@@ -44,18 +44,18 @@ Purpose: persistent collaborative document data.
 
 Purpose: ephemeral user/session state.
 
-`@softmaple/awareness` synchronizes people/session state, not
-documents.
+`@softmaple/awareness` synchronizes people/session state, including
+presence, not documents.
 
 ### Responsibilities
 
-- User awareness
+- User awareness / presence
 - Cursor state
 - Selection state
 - Viewport state
 - User metadata
 - Online/offline state
-- Realtime session awareness
+- Realtime session awareness / presence
 
 ### Reuse targets
 

--- a/docs/design/package-responsibilities.md
+++ b/docs/design/package-responsibilities.md
@@ -1,0 +1,154 @@
+---
+title: Package Responsibilities
+description: Responsibility and dependency rules for Softmaple collaboration packages.
+---
+
+# Package Responsibilities
+
+This page defines the responsibilities, non-goals, and dependency
+rules for Softmaple's collaboration packages.
+
+## `@softmaple/eg-walker`
+
+Purpose: persistent collaborative document data.
+
+`@softmaple/eg-walker` synchronizes documents, not people.
+
+### Responsibilities
+
+- Document model
+- Operation model
+- Merge/conflict resolution
+- Transactions
+- State vectors / version vectors
+- Update encoding / decoding
+- Stable anchors / relative positions, if applicable
+- Collaborative data structures
+
+### Non-goals
+
+- Awareness
+- Cursor broadcasting
+- Selection broadcasting
+- User metadata
+- Online status
+- Transport implementation
+- Editor-specific APIs
+
+### Dependency rule
+
+`@softmaple/eg-walker` must not depend on
+`@softmaple/awareness`.
+
+## `@softmaple/awareness`
+
+Purpose: ephemeral user/session state.
+
+`@softmaple/awareness` synchronizes people/session state, not
+documents.
+
+### Responsibilities
+
+- User awareness
+- Cursor state
+- Selection state
+- Viewport state
+- User metadata
+- Online/offline state
+- Realtime session awareness
+
+### Reuse targets
+
+Awareness must remain independent from `@softmaple/eg-walker` so it
+can be reused by:
+
+- Rich text editors
+- Code editors
+- Whiteboards
+- Canvas apps
+- React Flow
+- Spreadsheets
+- Multiplayer UI
+
+### Non-goals
+
+- Persistent document merge logic
+- eg-walker event graph ownership
+- eg-walker version-vector ownership
+- Editor-specific document APIs
+- Requiring a collaborative document engine to be present
+
+### Dependency rule
+
+`@softmaple/awareness` must not depend on
+`@softmaple/eg-walker`.
+
+## Providers
+
+Purpose: transport.
+
+Provider packages may transport:
+
+- Eg-walker document updates
+- Awareness updates
+
+Providers must not own:
+
+- Document merge logic
+- Awareness merge logic
+- Editor-specific logic
+
+Transport code may use WebSocket, WebRTC, BroadcastChannel, storage
+sync, or another backend. The transport choice does not change the
+responsibility split: providers move messages; the packages that own
+state decide how those messages are interpreted.
+
+## Future integrations
+
+Future integrations may bridge `@softmaple/eg-walker` and
+`@softmaple/awareness`, or bind either package to an editor surface.
+That design is deferred.
+
+Examples of possible future integrations include
+`eg-walker-prosemirror`, `eg-walker-lexical`, `eg-walker-slate`,
+`eg-walker-codemirror`, `eg-walker-monaco`, and
+`awareness-eg-walker`.
+
+These are possible directions only. They should not be treated as
+current packages or API commitments.
+
+## Dependency diagrams
+
+Allowed current relationships:
+
+```text
+Provider
+  | transports
+  +--> eg-walker document updates
+  +--> awareness updates
+
+@softmaple/eg-walker       @softmaple/awareness
+        no dependency in either direction
+```
+
+Forbidden current relationships:
+
+```text
+@softmaple/eg-walker  ----imports---->  @softmaple/awareness
+@softmaple/awareness  ----imports---->  @softmaple/eg-walker
+Provider              ----owns------->  merge/conflict logic
+Provider              ----owns------->  editor-specific logic
+```
+
+Future-only relationship:
+
+```text
+Integration / editor binding
+  +--> @softmaple/eg-walker
+  +--> @softmaple/awareness
+
+Status: deferred until real requirements are clear.
+```
+
+See [ADR: Collaboration Architecture Boundaries](./adr/collaboration-architecture-boundaries.md)
+for the decision record.

--- a/docs/design/surface-bindings.md
+++ b/docs/design/surface-bindings.md
@@ -1,191 +1,95 @@
 ---
-title: Surface Bindings
-description: What a surface binding is, how it differs from a transport adapter, and when a binding graduates from apps/* to its own package.
+title: Future Surface Integrations
+description: Future-scope notes for editor and surface integrations without defining adapter APIs.
 ---
 
-# Surface Bindings
+# Future Surface Integrations
 
-A **surface binding** is the glue between a concrete user-facing
-surface (textarea, CodeMirror, Lexical, ProseMirror, Slate, canvas
-tool, …) and Softmaple's collaboration primitives. Bindings are the
-*only* place in the stack allowed to know about a specific surface
-framework.
+Surface integrations are future scope. This page records the boundary
+around that future work; it does not define adapter APIs, create
+package names, or commit Softmaple to any editor-binding abstraction.
 
-This doc defines:
+For the current architecture boundary, see
+[`architecture-overview.md`](./architecture-overview.md),
+[`package-responsibilities.md`](./package-responsibilities.md), and
+the [ADR](./adr/collaboration-architecture-boundaries.md).
 
-- What a binding owns (and what it does **not** own).
-- Why we use "surface" rather than "editor".
-- The split between **surface bindings** and **transport adapters**.
-- The promotion rule: when a binding moves from `apps/*` into its own
-  package.
+## Current decision
 
-For the legal layering contract, see
-[`collaboration-layers.md`](./collaboration-layers.md). For the
-per-binding TypeScript shape, see
-[`../../packages/awareness/docs/surface-binding-contract.md`](../../packages/awareness/docs/surface-binding-contract.md).
+Do not create adapter packages or shared editor-binding APIs now.
 
-## Why "surface", not "editor"
+The current packages remain:
 
-The term "editor adapter" was previously used. It is too narrow:
+- `@softmaple/eg-walker`
+- `@softmaple/awareness`
 
-- A `<canvas>` whiteboard is not an "editor" in the textarea sense,
-  but it is a collaborative surface.
-- A Jupyter cell, a form field, a code-review thread, and a comment
-  box are all collaborative surfaces with different bindings.
-- "Surface" matches the user-facing artefact regardless of model
-  (sequence / block / object — see
-  [`collaboration-models.md`](./collaboration-models.md)).
+There is no `@softmaple/presence` package.
 
-The rename is mechanical; the role is unchanged from the original
-"Editor Adapter Contract".
+## What future integrations may bridge
 
-## What a surface binding owns
+A future integration may compose:
 
-A binding is a **two-way translator** between a surface and Softmaple
-primitives. For one surface instance, it:
+- A concrete editor or collaborative surface
+- `@softmaple/eg-walker` document updates
+- `@softmaple/awareness` user/session awareness
+- A provider that transports updates
 
-1. **Local ops → engine ops.** Observe the surface's native change
-   events; produce engine-shaped ops (`insert(index, text)` /
-   `delete(index, length)` for sequence; future block / object ops
-   for the other models).
-2. **Engine ops → surface mutations.** Apply remote events to the
-   surface so the user sees the convergent state.
-3. **Surface selection → awareness position.** Read the native
-   selection; produce a `CursorPosition` / `SelectionRange` (or an
-   opaque blob for canvas) for `@softmaple/awareness`.
-4. **Awareness position → surface selection.** Restore a saved
-   selection back into the surface after a remote op shifts content.
-5. **Lifecycle.** Subscribe on mount, unsubscribe on unmount.
-
-That is all a binding does. It is logical, not visual.
-
-## What a surface binding does **not** own
-
-A binding **MUST NOT** include any of:
-
-- **CRDT internals.** The engine resolves conflicts; the binding
-  applies the result.
-- **Event graph persistence.** That belongs in the engine package.
-- **Network transport.** WebSocket / WebRTC / BroadcastChannel are
-  the job of a transport adapter (see below).
-- **User identity.** The binding does not care who is typing, only
-  what was typed.
-- **Visual cursor rendering.** Remote cursors are rendered by
-  `@softmaple/awareness` components (`LiveCursor`,
-  `SelectionHighlight`), not by the binding.
-- **Surface-specific UI components.** No React components, no CSS.
-  The binding is logical glue, not a widget.
-
-If a "binding" starts growing any of these, it is two things stuck
-together. Split it.
-
-## Bindings vs transport adapters
-
-"Adapter" today refers to two different things in this codebase. We
-keep them separate by giving them separate names:
-
-| Concern | Name | Direction | Lives in (today) |
-|---|---|---|---|
-| Surface ↔ engine, surface ↔ awareness | **Surface binding** | Surface ↔ Softmaple | `apps/*`, promoted to `@softmaple/binding-<surface>` later |
-| Replica ↔ replica wire transport | **Transport adapter** | Softmaple ↔ network | `@softmaple/awareness/adapters` |
-| Presence state → pixels | **Presence renderer** | Awareness → DOM | `@softmaple/awareness` components |
-
-A binding talks to **one engine** (the engine for its model) and to
-awareness independently. A transport adapter knows nothing about any
-surface and nothing about model internals; it moves opaque messages.
-
-## Naming convention
-
-- **Surface bindings**: package name `@softmaple/binding-<surface>`,
-  examples: `@softmaple/binding-textarea`,
-  `@softmaple/binding-codemirror`, `@softmaple/binding-lexical`,
-  `@softmaple/binding-tldraw`.
-- **Transport adapters**: factory function
-  `create<Transport>Adapter`, already established
-  (`createWebSocketAdapter`, `createBroadcastChannelAdapter`,
-  `createNoopAdapter`).
-
-When awareness's deferred `bindings/<surface>` subpath ships (issue
-B2), it will follow the same surface-named convention.
-
-## The promotion rule
-
-A binding starts life in `apps/playground/src/surface-bindings/`
-(staging area). It is promoted to a standalone
-`@softmaple/binding-<surface>` package **only when** at least one of:
-
-1. A second host (a second `apps/*` directory, or an external
-   consumer) needs the same binding.
-2. The binding's public surface has held stable across at least two
-   refactors of the surface library it targets.
-3. The binding's selection-mapping logic is reused by another
-   binding via composition.
-
-Until that bar is met, a binding stays in `apps/*`. This is
-deliberate: an in-app binding is cheap to refactor; a published
-package binding accrues a versioning contract. Promote on evidence,
-not on aspiration.
-
-When promotion happens, the move is mechanical:
+That bridge belongs outside the two core packages until repeated
+requirements show that a reusable package boundary is justified.
 
 ```text
-apps/playground/src/surface-bindings/codemirror/
-    -> packages/binding-codemirror/src/
+future integration / editor binding
+  +--> concrete surface
+  +--> @softmaple/eg-walker
+  +--> @softmaple/awareness
+  +--> provider transport
 ```
 
-The binding's `import` from the engine (`@softmaple/eg-walker`) and
-from awareness (`@softmaple/awareness`) does not change.
+## What future integrations must not move
 
-## Per-model binding rules
+Future integrations must not move these responsibilities:
 
-A binding is tied to one collaboration model (see
-[`collaboration-models.md`](./collaboration-models.md)). The
-allowable bindings per model:
+- Document merge logic stays with the document engine.
+- Awareness merge logic stays with `@softmaple/awareness`.
+- Transport stays with providers.
+- Editor-specific logic stays in the host or future integration.
 
-- **Sequence model** — `@softmaple/eg-walker`:
-  textarea, CodeMirror, Monaco, lowered Lexical / ProseMirror /
-  Slate.
-- **Block model** — *no engine yet*; once one exists, native
-  Lexical / ProseMirror / Slate bindings bind here, not to the
-  sequence engine.
-- **Object model** — *no engine yet*; canvas / whiteboard bindings
-  will bind here, never to the sequence engine via a shim.
+## Possible future directions
 
-A binding never spans models. If a single host renders two surfaces
-with different models (e.g. a Lexical block surface beside a tldraw
-canvas), it instantiates two bindings against two engines.
+Possible future integrations may include:
 
-## Replaceability invariant
+- `eg-walker-prosemirror`
+- `eg-walker-lexical`
+- `eg-walker-slate`
+- `eg-walker-codemirror`
+- `eg-walker-monaco`
+- `awareness-eg-walker`
 
-Any binding can be swapped for another binding against the same
-engine without changes elsewhere. This is the practical test of the
-layering rules in [`collaboration-layers.md`](./collaboration-layers.md):
+These are examples only. They should be introduced only when real
+requirements are clear enough to justify a package and API.
 
-- If swapping a textarea binding for a CodeMirror binding requires
-  changes inside `@softmaple/eg-walker`, the engine has leaked
-  surface concerns.
-- If it requires changes inside `@softmaple/awareness`, awareness has
-  leaked engine concerns.
-- If it requires changes only inside the host's binding wiring, the
-  layering is healthy.
+## Roadmap boundary
 
-## When to update this doc
+Current scope:
 
-Update this page whenever any of the following change:
+- Keep `@softmaple/eg-walker` focused on persistent document data.
+- Keep `@softmaple/awareness` focused on ephemeral user/session
+  awareness.
+- Keep providers transport-focused.
+- Keep editor-specific composition in applications.
 
-- A new surface binding is staged in `apps/playground` (add it to
-  the staging-area inventory below if we start one).
-- A binding is promoted to its own package (add the package to the
-  naming-convention list).
-- The promotion rule itself changes.
+Future scope:
 
-## Current bindings (snapshot)
+- Evaluate reusable editor bindings after concrete integration
+  requirements are known.
+- Evaluate a bridge between awareness and eg-walker only if multiple
+  hosts need the same composition.
+- Add a new ADR before introducing adapter packages or shared
+  adapter APIs.
 
-| Surface | Model | Lives in | Status |
-|---|---|---|---|
-| `<textarea>` | sequence | `apps/playground/src/modules/collaborative-editor/` | in-app |
-| (future) CodeMirror | sequence | `apps/playground/src/surface-bindings/` | not yet started |
-| (future) Lexical | sequence (lowered) → block | `apps/web/` | partial, in-app |
+Out of scope now:
 
-This table is illustrative and will drift. The authoritative source
-is the directory layout.
+- New packages for editor bindings.
+- Shared adapter APIs.
+- Speculative abstractions for all editors or surfaces.
+- A `@softmaple/presence` package.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,8 +40,13 @@
       {
         "group": "Design Documents",
         "pages": [
+          "design/architecture-overview",
+          "design/package-responsibilities",
           "design/awareness-and-presence",
-          "design/collaboration-layers"
+          "design/collaboration-layers",
+          "design/collaboration-models",
+          "design/surface-bindings",
+          "design/adr/collaboration-architecture-boundaries"
         ]
       },
       {

--- a/packages/awareness/README.md
+++ b/packages/awareness/README.md
@@ -1,25 +1,28 @@
 # @softmaple/awareness
 
-Awareness primitives and UI components for realtime collaboration.
+Awareness and presence primitives for realtime collaboration.
 
 ## Overview
 
-This package provides awareness primitives and UI components designed
-for low-interruption, non-blocking collaborative experiences.
+This package provides awareness and presence primitives designed for
+low-interruption, non-blocking collaborative experiences.
 
 Based on the design principles outlined in
 [docs/design/awareness-and-presence.md](../../docs/design/awareness-and-presence.md).
 
 ## Collaboration boundary
 
-`@softmaple/awareness` owns ephemeral user/session state. It
-synchronizes people/session state, not documents.
+`@softmaple/awareness` owns ephemeral user/session state, including
+presence. It synchronizes people/session state, not documents.
 
 It must remain independent from `@softmaple/eg-walker` so awareness
 can be reused by rich text editors, code editors, whiteboards, canvas
 apps, React Flow, spreadsheets, and multiplayer UI.
 
 There is no `@softmaple/presence` package.
+
+"Presence" remains valid for user-facing concepts and existing API
+names such as `PresenceUser`, `PresenceProvider`, and `PresenceBar`.
 
 See the public docs for the full boundary:
 
@@ -93,7 +96,7 @@ export function App() {
 
 ## Adapters
 
-The package includes transport helpers for awareness updates:
+The package includes transport helpers for awareness/presence updates:
 
 - **createWebSocketAdapter**: Standard WebSocket implementation
 - **createBroadcastChannelAdapter**: Local BroadcastChannel for same-origin tabs

--- a/packages/awareness/README.md
+++ b/packages/awareness/README.md
@@ -1,13 +1,31 @@
 # @softmaple/awareness
 
-Awareness and presence UI components for real-time collaboration.
+Awareness primitives and UI components for realtime collaboration.
 
 ## Overview
 
-This package provides transport-agnostic awareness and presence UI components designed for low-interruption, non-blocking collaborative experiences.
+This package provides awareness primitives and UI components designed
+for low-interruption, non-blocking collaborative experiences.
 
-Based on the design principles outlined in [docs/design/awareness-and-presence.md](../../docs/design/awareness-and-presence.md)
-and the [Surface Binding Contract](docs/surface-binding-contract.md).
+Based on the design principles outlined in
+[docs/design/awareness-and-presence.md](../../docs/design/awareness-and-presence.md).
+
+## Collaboration boundary
+
+`@softmaple/awareness` owns ephemeral user/session state. It
+synchronizes people/session state, not documents.
+
+It must remain independent from `@softmaple/eg-walker` so awareness
+can be reused by rich text editors, code editors, whiteboards, canvas
+apps, React Flow, spreadsheets, and multiplayer UI.
+
+There is no `@softmaple/presence` package.
+
+See the public docs for the full boundary:
+
+- [Architecture Overview](../../docs/design/architecture-overview.md)
+- [Package Responsibilities](../../docs/design/package-responsibilities.md)
+- [ADR: Collaboration Architecture Boundaries](../../docs/design/adr/collaboration-architecture-boundaries.md)
 
 ## Features
 
@@ -75,7 +93,7 @@ export function App() {
 
 ## Adapters
 
-The package supports multiple transport adapters:
+The package includes transport helpers for awareness updates:
 
 - **createWebSocketAdapter**: Standard WebSocket implementation
 - **createBroadcastChannelAdapter**: Local BroadcastChannel for same-origin tabs
@@ -88,6 +106,9 @@ The package supports multiple transport adapters:
 The adapter contract is transport-agnostic, so additional providers such as
 Supabase Realtime or Liveblocks can be implemented without changing the React
 components.
+
+These helpers are transport-focused. They do not own persistent
+document merge logic, awareness merge logic, or editor-specific logic.
 
 ## WebSocket server contract
 
@@ -106,13 +127,13 @@ components.
 
 Payload shapes per message type:
 
-| Type | Payload |
-| --- | --- |
-| `join` | `{ user: PresenceUser }` |
-| `leave` | `{ userId: string }` |
-| `presence_update` | `{ userId: string, updates: Partial<Omit<PresenceUser, "userId">> }` |
-| `presence_sync` / `presence_sync_response` | `{ users: PresenceUser[] }` |
-| `error` | `{ code: string, message: string }` |
+| Type                                       | Payload                                                              |
+| ------------------------------------------ | -------------------------------------------------------------------- |
+| `join`                                     | `{ user: PresenceUser }`                                             |
+| `leave`                                    | `{ userId: string }`                                                 |
+| `presence_update`                          | `{ userId: string, updates: Partial<Omit<PresenceUser, "userId">> }` |
+| `presence_sync` / `presence_sync_response` | `{ users: PresenceUser[] }`                                          |
+| `error`                                    | `{ code: string, message: string }`                                  |
 
 Every inbound payload is validated by a runtime type guard
 (`src/adapters/websocket/validation.ts`). Malformed frames are dropped and

--- a/packages/eg-walker/README.md
+++ b/packages/eg-walker/README.md
@@ -14,6 +14,21 @@ The package is organized around the paper's runtime model:
 
 No CRDT metadata is persisted or exposed through the public API.
 
+## Collaboration boundary
+
+`@softmaple/eg-walker` owns persistent collaborative document data.
+It synchronizes documents, not people.
+
+It must not depend on `@softmaple/awareness`, own awareness state,
+broadcast cursors or selections, own user metadata or online status,
+implement transport, or expose editor-specific APIs.
+
+See the public docs for the full boundary:
+
+- [Architecture Overview](../../docs/design/architecture-overview.md)
+- [Package Responsibilities](../../docs/design/package-responsibilities.md)
+- [ADR: Collaboration Architecture Boundaries](../../docs/design/adr/collaboration-architecture-boundaries.md)
+
 ## Usage
 
 ```typescript
@@ -83,18 +98,18 @@ pnpm --filter @softmaple/eg-walker test -- --run src/test/property
 EG_WALKER_PROPERTY_RUNS=500 pnpm --filter @softmaple/eg-walker test
 ```
 
-| Property | File |
-| --- | --- |
-| Multi-replica convergence under randomized delivery | `convergence.property.test.ts` |
-| Delivery-order invariance for a fixed event set | `delivery-order-invariance.property.test.ts` |
-| Duplicate event delivery is idempotent | `duplicate-event-idempotency.property.test.ts` |
-| Missing-parent events are buffered then flushed | `missing-parent-buffering.property.test.ts` |
-| JSON serialize / columnar codec round-trip | `serialize-roundtrip.property.test.ts` |
-| UTF-16 surrogate safety | `unicode-surrogate.property.test.ts` |
+| Property                                                   | File                                             |
+| ---------------------------------------------------------- | ------------------------------------------------ |
+| Multi-replica convergence under randomized delivery        | `convergence.property.test.ts`                   |
+| Delivery-order invariance for a fixed event set            | `delivery-order-invariance.property.test.ts`     |
+| Duplicate event delivery is idempotent                     | `duplicate-event-idempotency.property.test.ts`   |
+| Missing-parent events are buffered then flushed            | `missing-parent-buffering.property.test.ts`      |
+| JSON serialize / columnar codec round-trip                 | `serialize-roundtrip.property.test.ts`           |
+| UTF-16 surrogate safety                                    | `unicode-surrogate.property.test.ts`             |
 | Concurrent same-index inserts converge (YATA tie-breaking) | `concurrent-same-index-inserts.property.test.ts` |
-| Long offline branch merge converges | `long-offline-branch-merge.property.test.ts` |
-| `applyRemoteEvent` position operation splice contract | `apply-remote-event-result.property.test.ts` |
-| Event graph `diffVersions` matches causal-set differences | `event-graph-diff.property.test.ts` |
+| Long offline branch merge converges                        | `long-offline-branch-merge.property.test.ts`     |
+| `applyRemoteEvent` position operation splice contract      | `apply-remote-event-result.property.test.ts`     |
+| Event graph `diffVersions` matches causal-set differences  | `event-graph-diff.property.test.ts`              |
 
 See [`src/test/property/README.md`](src/test/property/README.md) for how to add new properties.
 
@@ -107,13 +122,13 @@ Run them manually — they never fail CI on timing:
 pnpm --filter @softmaple/eg-walker bench
 ```
 
-| Scenario | File | What it stresses |
-| --- | --- | --- |
-| Long linear history (5k sequential inserts) | `long-linear-history.bench.ts` | Section 3.4 non-conflicting-run fast path |
-| Concurrent same-index inserts (200 events) | `concurrent-same-index-inserts.bench.ts` | YATA origin-left tie-breaking |
-| Long offline branch merge (2×1k events) | `long-offline-branch-merge.bench.ts` | Retreat/advance over a stale branch |
-| Delete-heavy workload (2k events, ~70% deletes) | `delete-heavy-workload.bench.ts` | Delete-target-index and placeholder filtering |
-| Checkpoint effectiveness (100 linear + 20 siblings) | `checkpoint-effectiveness.bench.ts` | `CriticalCheckpointStore` partial-replay path |
+| Scenario                                            | File                                     | What it stresses                              |
+| --------------------------------------------------- | ---------------------------------------- | --------------------------------------------- |
+| Long linear history (5k sequential inserts)         | `long-linear-history.bench.ts`           | Section 3.4 non-conflicting-run fast path     |
+| Concurrent same-index inserts (200 events)          | `concurrent-same-index-inserts.bench.ts` | YATA origin-left tie-breaking                 |
+| Long offline branch merge (2×1k events)             | `long-offline-branch-merge.bench.ts`     | Retreat/advance over a stale branch           |
+| Delete-heavy workload (2k events, ~70% deletes)     | `delete-heavy-workload.bench.ts`         | Delete-target-index and placeholder filtering |
+| Checkpoint effectiveness (100 linear + 20 siblings) | `checkpoint-effectiveness.bench.ts`      | `CriticalCheckpointStore` partial-replay path |
 
 Each scenario prints one stats line after the benchmark run, for example:
 
@@ -126,18 +141,18 @@ Each scenario prints one stats line after the benchmark run, for example:
 
 #### Interpreting replay stats
 
-| Field | Meaning |
-| --- | --- |
-| `fullReplays` | Cold-start or recovery replays over the full event graph. Should be 1 for linear workloads. |
-| `partialReplays` | Replays scoped to the divergent suffix using a `CriticalCheckpointStore` anchor. Replaces full replays for concurrent-sibling merges. |
-| `incrementalApplies` | Events applied by advancing the existing engine state with no retreat. The dominant path for sequential editing. |
-| `retreats` / `advances` | Cumulative engine moves. Non-zero for concurrent merges; proportional to the size of the divergent suffix, not the full history. |
-| `checkpoints` | Retained critical-version checkpoints (capped at 32 via LRU). Higher means more reuse opportunities for future merges. |
-| `checkpointHits` | Times `CriticalCheckpointStore.pickFor` found a usable anchor — avoids a full replay. |
-| `checkpointMisses` | Times no retained checkpoint dominated the divergent suffix — forced a full replay. |
-| `sequenceRecords` | Live records in the ranked B-tree at the end of the scenario. Memory proxy. |
-| `peakSequenceRecords` | High-water mark across the replica lifetime; stays visible even after deletes or engine rebuilds. |
-| `lastReplaySource` | `incremental`, `partial`, or `full` — which path handled the last event. |
+| Field                   | Meaning                                                                                                                               |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `fullReplays`           | Cold-start or recovery replays over the full event graph. Should be 1 for linear workloads.                                           |
+| `partialReplays`        | Replays scoped to the divergent suffix using a `CriticalCheckpointStore` anchor. Replaces full replays for concurrent-sibling merges. |
+| `incrementalApplies`    | Events applied by advancing the existing engine state with no retreat. The dominant path for sequential editing.                      |
+| `retreats` / `advances` | Cumulative engine moves. Non-zero for concurrent merges; proportional to the size of the divergent suffix, not the full history.      |
+| `checkpoints`           | Retained critical-version checkpoints (capped at 32 via LRU). Higher means more reuse opportunities for future merges.                |
+| `checkpointHits`        | Times `CriticalCheckpointStore.pickFor` found a usable anchor — avoids a full replay.                                                 |
+| `checkpointMisses`      | Times no retained checkpoint dominated the divergent suffix — forced a full replay.                                                   |
+| `sequenceRecords`       | Live records in the ranked B-tree at the end of the scenario. Memory proxy.                                                           |
+| `peakSequenceRecords`   | High-water mark across the replica lifetime; stays visible even after deletes or engine rebuilds.                                     |
+| `lastReplaySource`      | `incremental`, `partial`, or `full` — which path handled the last event.                                                              |
 
 A healthy concurrent-merge workload shows `partialReplays > 0` and `checkpointHits > 0`, meaning the checkpoint store is being consulted and is avoiding full replays.
 


### PR DESCRIPTION
## Summary

- Add a collaboration architecture overview for eg-walker, awareness, providers, and future integrations.
- Add package responsibility documentation and dependency-direction diagrams.
- Add an ADR documenting why document collaboration and awareness/presence remain separate concerns from persistent document data.
- Update existing design docs, docs navigation, and package READMEs to cross-link the boundary docs.
- Clarify terminology: the package name is `@softmaple/awareness`, there is no `@softmaple/presence` package, and `presence` remains valid for user-facing concepts, component names, type names, and wire events.

## Impact

This is documentation-only. It does not add packages, move files, change dependencies, change exports, or introduce adapter abstractions.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8')); console.log('docs.json ok')"`
- `pnpm exec prettier --check docs/docs.json docs/design/architecture-overview.md docs/design/package-responsibilities.md docs/design/adr/collaboration-architecture-boundaries.md docs/design/collaboration-layers.md docs/design/collaboration-models.md docs/design/surface-bindings.md docs/design/awareness-and-presence.md packages/eg-walker/README.md packages/awareness/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture design documentation with detailed boundary definitions and clear responsibility assignments between core collaboration framework components.
  * Added comprehensive package responsibility guides clarifying ownership boundaries, explicitly distinguishing document persistence management from ephemeral user session and presence state management.
  * Reorganized reference materials and enhanced package documentation with clearer structural layouts for improved navigation, clarity, and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->