### PR TITLE
perf(packages/eg-walker): improve eg-walker paper benchmark sequential hot paths

### DIFF
--- a/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
+++ b/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
@@ -42,9 +42,10 @@ export class CriticalCheckpointStore {
     if (frontier.size !== 1) {
       return;
     }
-    if (!this.analyzer.isCritical(graph, frontier)) {
-      return;
-    }
+    // A finite DAG with exactly one frontier has every event causally before
+    // that frontier. The singleton frontier is therefore critical by
+    // definition, so avoid the analyzer's full ancestor expansion on the
+    // sequential hot path.
     const last = this.checkpoints[this.checkpoints.length - 1];
     if (last && versionsEqual(last.version, frontier)) {
       return;

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -511,11 +511,13 @@ export class EgWalkerReplica {
     if (!engineVersion || engineVersion.size === 0) {
       return true;
     }
-    let directlyCovered = true;
-    for (const id of engineVersion) {
-      if (!event.parentVersion.has(id)) {
-        directlyCovered = false;
-        break;
+    let directlyCovered = engineVersion.size <= event.parentVersion.size;
+    if (directlyCovered) {
+      for (const id of engineVersion) {
+        if (!event.parentVersion.has(id)) {
+          directlyCovered = false;
+          break;
+        }
       }
     }
     if (directlyCovered) {

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -511,6 +511,17 @@ export class EgWalkerReplica {
     if (!engineVersion || engineVersion.size === 0) {
       return true;
     }
+    let directlyCovered = true;
+    for (const id of engineVersion) {
+      if (!event.parentVersion.has(id)) {
+        directlyCovered = false;
+        break;
+      }
+    }
+    if (directlyCovered) {
+      return true;
+    }
+
     const parentExpansion = this.eventGraph.expandVersion(event.parentVersion);
     for (const id of engineVersion) {
       if (!parentExpansion.has(id)) {


### PR DESCRIPTION
## Summary

- Skip full parent ancestry expansion when a remote event directly covers the engine frontier.
- Treat singleton frontiers as critical checkpoints without running full critical-version analysis.

## Root Cause

The S1 paper benchmark is a linear trace, but two replica-level guards still expanded the full event history per event:

- `canIncrementallyAdvance` expanded each event's parent version before allowing incremental apply.
- `maybeAdvanceCheckpoint` ran critical-version analysis for every singleton frontier.

That made the sequential hot path behave close to O(N^2) despite all events applying incrementally.

## Validation

- `pnpm --filter @softmaple/eg-walker test -- src/test/replica-replay-paths.test.ts src/test/replay-stats.test.ts src/test/apply-remote-event-result.test.ts src/test/critical-version-perf.test.ts`
- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker paper-bench -- --datasets S1 --runs 1`

Full S1 paper benchmark after the fix:

```text
applyMs=9015.01 totalMs=9101.74 events=166296 incrementalApplies=166295 fullReplays=1 partialReplays=0 retreats=0 advances=0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Skip an expensive validation step when processing single-event frontiers, reducing overhead on the hot path.
  * Add an early fast-path check to detect fully covered incoming events, avoiding unnecessary expansion and speeding incremental advancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->