### PR TITLE
perf(packages/eg-walker): optimize partial replay suffix ordering

### DIFF
--- a/packages/eg-walker/src/engine/partial-replay.ts
+++ b/packages/eg-walker/src/engine/partial-replay.ts
@@ -86,7 +86,7 @@ const getBranchPreservingReplayOrder = (
   for (const eventId of replayEventIds) {
     const event = graph.getEvent(eventId);
     if (!event) {
-      continue;
+      throw new Error(`Missing replay event in graph: ${eventId}`);
     }
 
     let parentCount = 0;

--- a/packages/eg-walker/src/engine/partial-replay.ts
+++ b/packages/eg-walker/src/engine/partial-replay.ts
@@ -1,5 +1,6 @@
 import { EgWalkerEngine, type GeneratedDocument } from "./eg-walker-engine";
 import type { EventGraph } from "../graph/event-graph";
+import { compareEventIds } from "../graph/event-id";
 import type { EventId, Version } from "../types";
 
 export interface ReplayCheckpoint {
@@ -40,17 +41,8 @@ export class PartialReplayManager {
       checkpoint.version,
       targetVersion,
     );
-    // We only need a hash-set membership view of every event in the
-    // graph; building it from {@link EventGraph.getAllEvents} skips a
-    // Kahn pass over events we discard anyway. `getAllEvents` returns
-    // every event the graph holds (i.e. the same set as
-    // {@link EventGraph.getTopologicalOrder}); the order is irrelevant
-    // here because `replayedEventIds` already encodes the replay order.
-    const eventById = new Map(
-      graph.getAllEvents().map((event) => [event.id, event]),
-    );
     const events = replayedEventIds
-      .map((eventId) => eventById.get(eventId))
+      .map((eventId) => graph.getEvent(eventId))
       .filter(
         (event): event is NonNullable<typeof event> => event !== undefined,
       );
@@ -76,12 +68,84 @@ export class PartialReplayManager {
     // Section 3.4: walk the divergent suffix in branch-preserving order so
     // each event lands on a parent version matching the engine's current
     // version where possible, keeping the replay on the non-conflicting-run
-    // fast path and minimising retreat/advance churn. The columnar codec
-    // keeps using {@link EventGraph.getTopologicalOrder} (Kahn) for byte
-    // stability of persisted graphs.
-    return graph
-      .getBranchPreservingTopologicalOrder()
-      .map((event) => event.id)
-      .filter((eventId) => onlyInRight.has(eventId));
+    // fast path and minimising retreat/advance churn. Only the divergent
+    // suffix is replayed, so compute the branch-preserving order on that
+    // suffix instead of sorting the whole graph on every partial replay.
+    return getBranchPreservingReplayOrder(graph, onlyInRight);
   }
 }
+
+const getBranchPreservingReplayOrder = (
+  graph: EventGraph,
+  replayEventIds: ReadonlySet<EventId>,
+): ReadonlyArray<EventId> => {
+  const remainingParents = new Map<EventId, number>();
+  const children = new Map<EventId, EventId[]>();
+  const roots: EventId[] = [];
+
+  for (const eventId of replayEventIds) {
+    const event = graph.getEvent(eventId);
+    if (!event) {
+      continue;
+    }
+
+    let parentCount = 0;
+    for (const parentId of event.parentVersion) {
+      if (!replayEventIds.has(parentId)) {
+        continue;
+      }
+      parentCount++;
+      const childIds = children.get(parentId) ?? [];
+      childIds.push(eventId);
+      children.set(parentId, childIds);
+    }
+
+    remainingParents.set(eventId, parentCount);
+    if (parentCount === 0) {
+      roots.push(eventId);
+    }
+  }
+
+  roots.sort(compareEventIds);
+
+  const stack: EventId[] = [];
+  for (let i = roots.length - 1; i >= 0; i--) {
+    stack.push(roots[i]!);
+  }
+
+  const ordered: EventId[] = [];
+  const visited = new Set<EventId>();
+
+  while (stack.length > 0) {
+    const eventId = stack.pop()!;
+    if (visited.has(eventId)) {
+      continue;
+    }
+    visited.add(eventId);
+    ordered.push(eventId);
+
+    const childIds = children.get(eventId);
+    if (!childIds || childIds.length === 0) {
+      continue;
+    }
+
+    const newlyReady: EventId[] = [];
+    for (const childId of childIds) {
+      const remaining = (remainingParents.get(childId) ?? 0) - 1;
+      remainingParents.set(childId, remaining);
+      if (remaining === 0) {
+        newlyReady.push(childId);
+      }
+    }
+    newlyReady.sort(compareEventIds);
+    for (let i = newlyReady.length - 1; i >= 0; i--) {
+      stack.push(newlyReady[i]!);
+    }
+  }
+
+  if (ordered.length !== remainingParents.size) {
+    throw new Error("Cycle detected in partial replay suffix");
+  }
+
+  return ordered;
+};


### PR DESCRIPTION
## Summary

- avoid building a full id-to-event map during partial replay
- compute branch-preserving replay order only for the divergent suffix instead of the whole graph
- keep branch-preserving replay semantics required for convergence

## Validation

- `pnpm --filter @softmaple/eg-walker exec vitest --run`
- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker lint`
  - passes with pre-existing unrelated unused-variable warnings in `src/test/columnar-codec.test.ts` and `src/test/convergence-property.test.ts`

## Notes

Benchmark/documentation work is intentionally excluded from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved partial-replay ordering to be deterministic and branch-preserving, reducing nondeterministic behavior during replay.
  * Replay now computes ordering solely within the divergent suffix, includes stronger cycle detection, and emits clearer errors if replay ordering fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->