### PR TITLE
perf(packages/eg-walker): reduce replay checkpoint overhead

### DIFF
--- a/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
+++ b/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
@@ -5,7 +5,17 @@ import type { EventId } from "../../types";
 
 const MAX_RETAINED_CHECKPOINTS = 32;
 
-export type CriticalCheckpoint = ReplayCheckpoint;
+export interface CriticalCheckpoint extends ReplayCheckpoint {
+  /**
+   * Number of events present when this checkpoint was captured.
+   *
+   * Checkpoints are currently captured only for singleton frontiers, which
+   * means every event up to this count is causally included by the checkpoint.
+   * Later criticality checks can therefore inspect only events added after this
+   * cut point instead of expanding the checkpoint's full ancestor closure.
+   */
+  readonly eventCount: number;
+}
 
 export class CriticalCheckpointStore {
   private checkpoints: ReadonlyArray<CriticalCheckpoint> = [];
@@ -53,6 +63,7 @@ export class CriticalCheckpointStore {
     this.append({
       version: new Set(frontier),
       text: document,
+      eventCount: graph.getEventCount(),
     });
   }
 
@@ -62,13 +73,60 @@ export class CriticalCheckpointStore {
       if (!candidate) {
         continue;
       }
-      if (this.analyzer.isCritical(graph, candidate.version)) {
+      if (this.isStillCritical(graph, candidate)) {
         this.hitCount++;
         return candidate;
       }
     }
     this.missCount++;
     return null;
+  }
+
+  private isStillCritical(
+    graph: EventGraph,
+    candidate: CriticalCheckpoint,
+  ): boolean {
+    if (candidate.version.size !== 1) {
+      return this.analyzer.isCritical(graph, candidate.version);
+    }
+
+    const [frontierId] = candidate.version;
+    if (frontierId === undefined) {
+      return graph.getEventCount() === 0;
+    }
+
+    const outsideCount = graph.getEventCount() - candidate.eventCount;
+    if (outsideCount <= 0) {
+      return true;
+    }
+
+    let descendantsAfterCheckpoint = 0;
+    const visited = new Set<EventId>();
+    const stack = Array.from(graph.getChildren(frontierId));
+
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      if (visited.has(current)) {
+        continue;
+      }
+      visited.add(current);
+
+      const rank = graph.getInsertionRank(current);
+      if (rank !== undefined && rank >= candidate.eventCount) {
+        descendantsAfterCheckpoint++;
+        if (descendantsAfterCheckpoint === outsideCount) {
+          return true;
+        }
+      }
+
+      for (const child of graph.getChildren(current)) {
+        if (!visited.has(child)) {
+          stack.push(child);
+        }
+      }
+    }
+
+    return false;
   }
 
   private append(checkpoint: CriticalCheckpoint): void {

--- a/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
+++ b/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
@@ -91,9 +91,6 @@ export class CriticalCheckpointStore {
     }
 
     const [frontierId] = candidate.version;
-    if (frontierId === undefined) {
-      return graph.getEventCount() === 0;
-    }
 
     const outsideCount = graph.getEventCount() - candidate.eventCount;
     if (outsideCount <= 0) {
@@ -101,26 +98,22 @@ export class CriticalCheckpointStore {
     }
 
     let descendantsAfterCheckpoint = 0;
-    const visited = new Set<EventId>();
-    const stack = Array.from(graph.getChildren(frontierId));
+    // The checkpoint frontier was singleton and childless when captured.
+    // Therefore every reachable descendant must have been inserted after
+    // `candidate.eventCount`; count unique descendants without checking ranks.
+    const stack = Array.from(graph.getChildren(frontierId!));
+    const visited = new Set<EventId>(stack);
 
     while (stack.length > 0) {
       const current = stack.pop()!;
-      if (visited.has(current)) {
-        continue;
-      }
-      visited.add(current);
-
-      const rank = graph.getInsertionRank(current);
-      if (rank !== undefined && rank >= candidate.eventCount) {
-        descendantsAfterCheckpoint++;
-        if (descendantsAfterCheckpoint === outsideCount) {
-          return true;
-        }
+      descendantsAfterCheckpoint++;
+      if (descendantsAfterCheckpoint === outsideCount) {
+        return true;
       }
 
       for (const child of graph.getChildren(current)) {
         if (!visited.has(child)) {
+          visited.add(child);
           stack.push(child);
         }
       }

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -262,7 +262,8 @@ export class EgWalkerEngine {
     this.peakSequenceRecordCount = 0;
     this.placeholderCounter = 0;
 
-    const graphEvents = options.eventGraph?.getTopologicalOrder() ?? events;
+    const graphEvents =
+      options.eventOrder ?? options.eventGraph?.getTopologicalOrder() ?? events;
     graphEvents.forEach((event, index) => {
       this.eventsById.set(event.id, event);
       this.eventOrder.set(event.id, index);

--- a/packages/eg-walker/src/engine/internals/engine-types.ts
+++ b/packages/eg-walker/src/engine/internals/engine-types.ts
@@ -1,5 +1,5 @@
 import type { EventGraph } from "../../graph/event-graph";
-import type { EventId, ExternalOperation } from "../../types";
+import type { EventId, ExternalOperation, GraphEvent } from "../../types";
 
 export const PLACEHOLDER_EVENT_ID = "__placeholder__";
 export const PLACEHOLDER_ID_PREFIX = "__placeholder__:";
@@ -105,6 +105,15 @@ export interface EngineStats {
 export interface GenerateOptions {
   readonly initialVersion?: ReadonlySet<EventId>;
   readonly eventGraph?: EventGraph;
+  /**
+   * Topological rank source for prepare/effect retreat/advance ordering.
+   *
+   * When omitted, the engine uses `eventGraph.getTopologicalOrder()` if a
+   * graph is provided. Partial replay can pass the already-computed divergent
+   * suffix order here so reset does not rebuild full-graph ordering on every
+   * checkpoint replay.
+   */
+  readonly eventOrder?: ReadonlyArray<GraphEvent>;
 }
 
 export interface GeneratedDocument {

--- a/packages/eg-walker/src/engine/partial-replay.ts
+++ b/packages/eg-walker/src/engine/partial-replay.ts
@@ -50,6 +50,7 @@ export class PartialReplayManager {
     const generated = engine.generate(events, checkpoint.text, {
       initialVersion: checkpoint.version,
       eventGraph: graph,
+      eventOrder: events,
     });
 
     return {

--- a/packages/eg-walker/src/graph/event-graph.ts
+++ b/packages/eg-walker/src/graph/event-graph.ts
@@ -147,16 +147,6 @@ export class EventGraph {
   }
 
   /**
-   * Stable insertion rank for an event, assigned by {@link addEvent}.
-   *
-   * Ranks are monotonic and parent ranks are always lower than child ranks,
-   * making them useful as cheap topological cut points for replay heuristics.
-   */
-  getInsertionRank(id: EventId): number | undefined {
-    return this.insertionRank.get(id);
-  }
-
-  /**
    * Store non-CRDT persistence metadata alongside the graph.
    */
   setMetadata(metadata: Record<string, unknown>): void {

--- a/packages/eg-walker/src/graph/event-graph.ts
+++ b/packages/eg-walker/src/graph/event-graph.ts
@@ -137,6 +137,26 @@ export class EventGraph {
   }
 
   /**
+   * Number of events currently stored in the graph.
+   *
+   * Prefer this over `getAllEvents().length` on hot paths because it avoids
+   * materialising a new array.
+   */
+  getEventCount(): number {
+    return this.events.size;
+  }
+
+  /**
+   * Stable insertion rank for an event, assigned by {@link addEvent}.
+   *
+   * Ranks are monotonic and parent ranks are always lower than child ranks,
+   * making them useful as cheap topological cut points for replay heuristics.
+   */
+  getInsertionRank(id: EventId): number | undefined {
+    return this.insertionRank.get(id);
+  }
+
+  /**
    * Store non-CRDT persistence metadata alongside the graph.
    */
   setMetadata(metadata: Record<string, unknown>): void {

--- a/packages/eg-walker/src/test/replay-stats.test.ts
+++ b/packages/eg-walker/src/test/replay-stats.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { OPERATION_TYPE } from "../constants/operation-types";
 import { REPLAY_SOURCE } from "../constants/replay-source";
+import { CriticalCheckpointStore } from "../core/internals/critical-checkpoint-store";
 import { EgWalkerReplica } from "../core/replica";
+import { CriticalVersionAnalyzer } from "../engine/critical-version";
 import { EventGraph } from "../graph/event-graph";
 import type { GraphEvent } from "../types";
 
@@ -171,6 +173,37 @@ describe("EgWalkerReplica replay stats — new diagnostic fields", () => {
       );
       expect(after.criticalCheckpointHits).toBe(before.criticalCheckpointHits);
       expect(after.fullReplays).toBe(before.fullReplays + 1);
+    });
+
+    it("does not treat a fan-in descendant as proof that a checkpoint stayed critical", () => {
+      const graph = new EventGraph();
+      const checkpoints = new CriticalCheckpointStore(
+        new CriticalVersionAnalyzer(),
+      );
+      graph.addEvent({
+        id: "alice:0",
+        parentVersion: new Set(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "A" },
+        timestamp: 1,
+      });
+      checkpoints.maybeAdvance(graph, "A");
+
+      graph.addEvent({
+        id: "bob:0",
+        parentVersion: new Set(),
+        operation: { type: OPERATION_TYPE.INSERT, index: 0, text: "B" },
+        timestamp: 2,
+      });
+      graph.addEvent({
+        id: "merge:0",
+        parentVersion: new Set(["alice:0", "bob:0"]),
+        operation: { type: OPERATION_TYPE.INSERT, index: 2, text: "!" },
+        timestamp: 3,
+      });
+
+      expect(checkpoints.pickFor(graph)).toBeNull();
+      expect(checkpoints.misses).toBe(1);
+      expect(checkpoints.hits).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- Avoid full ancestor expansion when checking retained singleton critical checkpoints by storing the graph event count at checkpoint capture time.
- Let partial replay pass its already-computed divergent suffix order into `EgWalkerEngine.generate`, avoiding repeated full-graph topological-order rebuilds during checkpoint replay.
- Add a regression test for fan-in histories so descendant reachability is not mistaken for a still-critical checkpoint.

## Impact

This reduces bounded concurrent paper-trace replay overhead in `@softmaple/eg-walker`. Local smoke data from `C1,C2 --max-txns 3000` improved from roughly 4.4-4.5s apply time to roughly 1.4-1.5s after the two runtime optimizations.

## Validation

- `pnpm test --run`
- `pnpm typecheck`
- `pnpm lint` (passes with existing unrelated warnings in `src/test/columnar-codec.test.ts` and `src/test/convergence-property.test.ts`)
- `pnpm paper-bench -- --datasets C1,C2 --runs 3 --max-txns 3000`
- `pnpm paper-bench -- --datasets C1,C2 --runs 1 --max-txns 10000`
- `pnpm paper-bench -- --datasets A1 --runs 1`
- `pnpm paper-bench -- --datasets S1,S2,S3 --runs 1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event graph now exposes an event-count query.
  * Replay generation accepts an explicit event-order option for custom processing sequences.

* **Improvements**
  * More accurate selection and tracking of critical checkpoints for complex event relationships.

* **Tests**
  * Added a test validating checkpoint selection behavior in fan-in/merge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->