### PR TITLE
Adopt compact native snapshot runtime state

### DIFF
--- a/packages/eg-walker/src/core/native-snapshot.ts
+++ b/packages/eg-walker/src/core/native-snapshot.ts
@@ -8,8 +8,16 @@ import type {
 import { EventGraph } from "../graph/event-graph";
 import { ColumnarEventGraphCodec } from "../graph/columnar-codec";
 import { BinaryReader, BinaryWriter } from "../graph/internals/binary-io";
-import type { EngineSequenceRecord } from "../engine/sequence-records";
-import type { DeleteTargetRecord } from "../engine/eg-walker-engine";
+import {
+  recordsFromCompactDeleteTargets,
+  type CompactDeleteTargetRecords,
+  type DeleteTargetRecord,
+} from "../engine/eg-walker-engine";
+import {
+  recordsFromCompactRecords,
+  type CompactEngineSequenceRecords,
+  type EngineSequenceRecord,
+} from "../engine/sequence-records";
 import type { CriticalCheckpointSnapshot } from "./internals/critical-checkpoint-store";
 
 export const NATIVE_SNAPSHOT_FORMAT_VERSION = "EGWS1" as const;
@@ -36,16 +44,24 @@ export interface NativeSnapshotHeader {
   readonly eventCount: number;
   readonly nextSequenceNumber: number;
   readonly metadata?: Record<string, unknown>;
-  readonly sequenceRecords: ReadonlyArray<EngineSequenceRecord>;
-  readonly deleteTargets: ReadonlyArray<DeleteTargetRecord>;
   readonly checkpoints: ReadonlyArray<CriticalCheckpointSnapshot>;
+}
+
+export interface NativeSnapshotRuntimeState {
+  readonly sequenceRecords: CompactEngineSequenceRecords;
+  readonly deleteTargets: CompactDeleteTargetRecords;
 }
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 const MAGIC_BYTES = encoder.encode(NATIVE_SNAPSHOT_FORMAT_VERSION);
+const RUNTIME_STATE_FORMAT_VERSION = 1;
 const columnarCodec = new ColumnarEventGraphCodec();
 const decodedGraphSourceCache = new WeakMap<NativeSnapshot, () => EventGraph>();
+const decodedRuntimeStateCache = new WeakMap<
+  NativeSnapshot,
+  NativeSnapshotRuntimeState
+>();
 
 export class NativeSnapshotCodec {
   encode(snapshot: NativeSnapshot): Uint8Array {
@@ -55,6 +71,7 @@ export class NativeSnapshotCodec {
     const body = new BinaryWriter();
     body.writeBytes(encoder.encode(JSON.stringify(header)));
     body.writeBytes(columnarCodec.encodeBinary(graph));
+    body.writeBytes(encodeRuntimeState(validated));
 
     const payload = body.toUint8Array();
     const out = new Uint8Array(MAGIC_BYTES.byteLength + payload.byteLength);
@@ -89,15 +106,29 @@ const decodeLengthPrefixedNativeSnapshotBody = (
 ): NativeSnapshot | null => {
   try {
     const reader = new BinaryReader(body);
-    const header = validateNativeSnapshotHeader(
+    const headerPayload = validateNativeSnapshotHeaderPayload(
       JSON.parse(
         decoder.decode(reader.readBytes(reader.readVarint())),
       ) as unknown,
     );
     const graphBytes = reader.readBytes(reader.readVarint());
+    const runtimeState = reader.hasRemaining()
+      ? decodeRuntimeState(reader.readBytes(reader.readVarint()))
+      : undefined;
     const graphSource = createMemoizedGraphSource(graphBytes);
-    const snapshot = createSnapshotWithLazyEventGraph(header, graphSource);
+    const snapshot = createSnapshotWithLazySections(
+      headerPayload.header,
+      graphSource,
+      runtimeState,
+      {
+        sequenceRecords: headerPayload.sequenceRecords,
+        deleteTargets: headerPayload.deleteTargets,
+      },
+    );
     decodedGraphSourceCache.set(snapshot, graphSource);
+    if (runtimeState) {
+      decodedRuntimeStateCache.set(snapshot, runtimeState);
+    }
     return snapshot;
   } catch (error) {
     if (body[0] === 0x7b) {
@@ -117,6 +148,16 @@ export const consumeDecodedNativeSnapshotGraphSource = (
   return graphSource;
 };
 
+export const consumeDecodedNativeSnapshotRuntimeState = (
+  snapshot: NativeSnapshot,
+): NativeSnapshotRuntimeState | undefined => {
+  const runtimeState = decodedRuntimeStateCache.get(snapshot);
+  if (runtimeState) {
+    decodedRuntimeStateCache.delete(snapshot);
+  }
+  return runtimeState;
+};
+
 export const validateNativeSnapshotHeaderOnly = (
   value: unknown,
 ): NativeSnapshotHeader => validateNativeSnapshotHeader(value);
@@ -128,13 +169,32 @@ export const validateGraphMatchesSnapshot = (
   validateGraphMatchesHeader(graph, snapshot);
 };
 
-const createSnapshotWithLazyEventGraph = (
+const createSnapshotWithLazySections = (
   header: NativeSnapshotHeader,
   graphSource: () => EventGraph,
+  runtimeState: NativeSnapshotRuntimeState | undefined,
+  legacyRuntimeState: {
+    readonly sequenceRecords: ReadonlyArray<EngineSequenceRecord>;
+    readonly deleteTargets: ReadonlyArray<DeleteTargetRecord>;
+  },
 ): NativeSnapshot => {
   let eventGraph: SerializedGraphOutput | null = null;
+  let sequenceRecords: ReadonlyArray<EngineSequenceRecord> | null = null;
+  let deleteTargets: ReadonlyArray<DeleteTargetRecord> | null = null;
   return {
     ...header,
+    get sequenceRecords(): ReadonlyArray<EngineSequenceRecord> {
+      sequenceRecords ??= runtimeState
+        ? recordsFromCompactRecords(runtimeState.sequenceRecords)
+        : legacyRuntimeState.sequenceRecords;
+      return sequenceRecords;
+    },
+    get deleteTargets(): ReadonlyArray<DeleteTargetRecord> {
+      deleteTargets ??= runtimeState
+        ? recordsFromCompactDeleteTargets(runtimeState.deleteTargets)
+        : legacyRuntimeState.deleteTargets;
+      return deleteTargets;
+    },
     get eventGraph(): SerializedGraphOutput {
       eventGraph ??= graphSource().serialize();
       return eventGraph;
@@ -148,6 +208,280 @@ const createMemoizedGraphSource = (bytes: Uint8Array): (() => EventGraph) => {
     graph ??= columnarCodec.decodeBinary(bytes);
     return graph;
   };
+};
+
+const encodeRuntimeState = (snapshot: NativeSnapshot): Uint8Array => {
+  const sequenceRecords = snapshot.sequenceRecords;
+  const deleteTargets = snapshot.deleteTargets;
+  const idRefs = createStringTableRefBuilder<EventId>();
+  const replicaRefs = createStringTableRefBuilder<string>();
+
+  for (const record of sequenceRecords) {
+    idRefs.ref(record.id);
+    idRefs.ref(record.eventId);
+    if (record.originLeft !== null) {
+      idRefs.ref(record.originLeft);
+    }
+    if (record.originRight !== null) {
+      idRefs.ref(record.originRight);
+    }
+    if (record.run !== null) {
+      replicaRefs.ref(record.run.replicaId);
+    }
+  }
+  for (const record of deleteTargets) {
+    idRefs.ref(record.deleteEventId);
+    for (const targetId of record.targetIds) {
+      idRefs.ref(targetId);
+    }
+  }
+
+  const { bytes: contentBytes, offsets: contentOffsets } =
+    encodeContentBlob(sequenceRecords);
+  const targetOffsets = createTargetOffsets(deleteTargets);
+  const targetCount = targetOffsets[targetOffsets.length - 1] ?? 0;
+  const targetRefAt = createTargetRefReader(deleteTargets, targetOffsets);
+
+  const writer = new BinaryWriter();
+  writer.writeVarint(RUNTIME_STATE_FORMAT_VERSION);
+  writer.writeStringArray(idRefs.values);
+  writer.writeStringArray(replicaRefs.values);
+  writer.writeVarint(sequenceRecords.length);
+  writer.writeMappedVarintArray(sequenceRecords.length, (index) =>
+    idRefs.ref(sequenceRecords[index]!.id),
+  );
+  writer.writeMappedVarintArray(sequenceRecords.length, (index) =>
+    idRefs.ref(sequenceRecords[index]!.eventId),
+  );
+  writer.writeMappedVarintArray(sequenceRecords.length, (index) => {
+    const originLeft = sequenceRecords[index]!.originLeft;
+    return originLeft === null ? 0 : idRefs.ref(originLeft);
+  });
+  writer.writeMappedVarintArray(sequenceRecords.length, (index) => {
+    const originRight = sequenceRecords[index]!.originRight;
+    return originRight === null ? 0 : idRefs.ref(originRight);
+  });
+  writer.writeMappedVarintArray(contentOffsets.length, (index) =>
+    Number(contentOffsets[index] ?? 0),
+  );
+  writer.writeBytes(contentBytes);
+  writer.writeBytes(
+    Uint8Array.from(sequenceRecords, (record) => (record.everDeleted ? 1 : 0)),
+  );
+  writer.writeMappedVarintArray(
+    sequenceRecords.length,
+    (index) => sequenceRecords[index]!.prepareState,
+  );
+  writer.writeMappedVarintArray(sequenceRecords.length, (index) => {
+    const run = sequenceRecords[index]!.run;
+    return run === null ? 0 : replicaRefs.ref(run.replicaId);
+  });
+  writer.writeMappedVarintArray(
+    sequenceRecords.length,
+    (index) => sequenceRecords[index]!.run?.startSequence ?? 0,
+  );
+  writer.writeVarint(deleteTargets.length);
+  writer.writeMappedVarintArray(deleteTargets.length, (index) =>
+    idRefs.ref(deleteTargets[index]!.deleteEventId),
+  );
+  writer.writeMappedVarintArray(targetOffsets.length, (index) =>
+    Number(targetOffsets[index] ?? 0),
+  );
+  writer.writeMappedVarintArray(targetCount, (index) =>
+    idRefs.ref(targetRefAt(index)),
+  );
+
+  return writer.toUint8Array();
+};
+
+const decodeRuntimeState = (bytes: Uint8Array): NativeSnapshotRuntimeState => {
+  const reader = new BinaryReader(bytes);
+  const version = reader.readVarint();
+  if (version !== RUNTIME_STATE_FORMAT_VERSION) {
+    throw new Error(`Unsupported native runtime state version: ${version}`);
+  }
+  const idTable = reader.readStringArray();
+  const replicaTable = reader.readStringArray();
+  const sequenceCount = reader.readVarint();
+  const sequenceRecords = {
+    count: sequenceCount,
+    idTable,
+    replicaTable,
+    idRefs: expectColumnLength(
+      reader.readVarintUint32Array(),
+      sequenceCount,
+      "compact sequence idRefs",
+    ),
+    eventIdRefs: expectColumnLength(
+      reader.readVarintUint32Array(),
+      sequenceCount,
+      "compact sequence eventIdRefs",
+    ),
+    originLeftRefs: expectColumnLength(
+      reader.readVarintUint32Array(),
+      sequenceCount,
+      "compact sequence originLeftRefs",
+    ),
+    originRightRefs: expectColumnLength(
+      reader.readVarintUint32Array(),
+      sequenceCount,
+      "compact sequence originRightRefs",
+    ),
+    contentOffsets: expectColumnLength(
+      reader.readVarintUint32Array(),
+      sequenceCount + 1,
+      "compact sequence contentOffsets",
+    ),
+    contentBytes: reader.readBytes(reader.readVarint()),
+    everDeleted: expectByteColumnLength(
+      reader.readBytes(reader.readVarint()),
+      sequenceCount,
+      "compact sequence everDeleted",
+    ),
+    prepareStates: expectColumnLength(
+      reader.readVarintUint32Array(),
+      sequenceCount,
+      "compact sequence prepareStates",
+    ),
+    runReplicaRefs: expectColumnLength(
+      reader.readVarintUint32Array(),
+      sequenceCount,
+      "compact sequence runReplicaRefs",
+    ),
+    runStartSequences: expectColumnLength(
+      reader.readVarintUint32Array(),
+      sequenceCount,
+      "compact sequence runStartSequences",
+    ),
+  };
+  const deleteCount = reader.readVarint();
+  const deleteEventRefs = expectColumnLength(
+    reader.readVarintUint32Array(),
+    deleteCount,
+    "compact delete target deleteEventRefs",
+  );
+  const targetOffsets = expectColumnLength(
+    reader.readVarintUint32Array(),
+    deleteCount + 1,
+    "compact delete target targetOffsets",
+  );
+  const targetCount = targetOffsets[targetOffsets.length - 1] ?? 0;
+  const targetRefs = expectColumnLength(
+    reader.readVarintUint32Array(),
+    targetCount,
+    "compact delete target targetRefs",
+  );
+
+  return {
+    sequenceRecords,
+    deleteTargets: {
+      idTable,
+      deleteEventRefs,
+      targetOffsets,
+      targetRefs,
+    },
+  };
+};
+
+const createStringTableRefBuilder = <T extends string>(): {
+  readonly values: T[];
+  readonly ref: (value: T) => number;
+} => {
+  const values: T[] = [];
+  const indexes = new Map<T, number>();
+  return {
+    values,
+    ref: (value: T): number => {
+      const existing = indexes.get(value);
+      if (existing !== undefined) {
+        return existing + 1;
+      }
+      const index = values.length;
+      indexes.set(value, index);
+      values.push(value);
+      return index + 1;
+    },
+  };
+};
+
+const encodeContentBlob = (
+  records: ReadonlyArray<EngineSequenceRecord>,
+): { readonly bytes: Uint8Array; readonly offsets: Uint32Array } => {
+  const parts = records.map((record) => encoder.encode(record.content));
+  const offsets = new Uint32Array(records.length + 1);
+  let byteLength = 0;
+  for (let index = 0; index < parts.length; index++) {
+    offsets[index] = byteLength;
+    byteLength += parts[index]!.byteLength;
+  }
+  offsets[parts.length] = byteLength;
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const part of parts) {
+    bytes.set(part, offset);
+    offset += part.byteLength;
+  }
+  return { bytes, offsets };
+};
+
+const createTargetOffsets = (
+  records: ReadonlyArray<DeleteTargetRecord>,
+): Uint32Array => {
+  const offsets = new Uint32Array(records.length + 1);
+  let targetCount = 0;
+  for (let index = 0; index < records.length; index++) {
+    offsets[index] = targetCount;
+    targetCount += records[index]!.targetIds.length;
+  }
+  offsets[records.length] = targetCount;
+  return offsets;
+};
+
+const createTargetRefReader = (
+  records: ReadonlyArray<DeleteTargetRecord>,
+  offsets: Uint32Array,
+): ((targetIndex: number) => EventId) => {
+  let recordIndex = 0;
+  return (targetIndex: number): EventId => {
+    while (
+      recordIndex + 1 < offsets.length &&
+      (offsets[recordIndex + 1] ?? 0) <= targetIndex
+    ) {
+      recordIndex++;
+    }
+    const localIndex = targetIndex - (offsets[recordIndex] ?? 0);
+    const value = records[recordIndex]?.targetIds[localIndex];
+    if (value === undefined) {
+      throw new Error(`Invalid delete target index ${targetIndex}`);
+    }
+    return value;
+  };
+};
+
+const expectColumnLength = (
+  values: Uint32Array,
+  expected: number,
+  label: string,
+): Uint32Array => {
+  if (values.length !== expected) {
+    throw new Error(
+      `Invalid ${label}: expected ${expected} values, received ${values.length}`,
+    );
+  }
+  return values;
+};
+
+const expectByteColumnLength = (
+  values: Uint8Array,
+  expected: number,
+  label: string,
+): Uint8Array => {
+  if (values.length !== expected) {
+    throw new Error(
+      `Invalid ${label}: expected ${expected} values, received ${values.length}`,
+    );
+  }
+  return values;
 };
 
 const validateGraphMatchesHeader = (
@@ -178,13 +512,32 @@ const headerFromSnapshot = (
   eventCount: snapshot.eventCount,
   nextSequenceNumber: snapshot.nextSequenceNumber,
   metadata: snapshot.metadata,
-  sequenceRecords: snapshot.sequenceRecords,
-  deleteTargets: snapshot.deleteTargets,
   checkpoints: snapshot.checkpoints,
 });
 
-const validateNativeSnapshotHeader = (value: unknown): NativeSnapshotHeader => {
+const validateNativeSnapshotHeaderPayload = (
+  value: unknown,
+): {
+  readonly header: NativeSnapshotHeader;
+  readonly sequenceRecords: ReadonlyArray<EngineSequenceRecord>;
+  readonly deleteTargets: ReadonlyArray<DeleteTargetRecord>;
+} => {
   const snapshot = expectRecord(value, "native snapshot header");
+  return {
+    header: validateNativeSnapshotHeaderRecord(snapshot),
+    sequenceRecords: expectSequenceRecords(snapshot.sequenceRecords),
+    deleteTargets: expectDeleteTargets(snapshot.deleteTargets),
+  };
+};
+
+const validateNativeSnapshotHeader = (value: unknown): NativeSnapshotHeader =>
+  validateNativeSnapshotHeaderRecord(
+    expectRecord(value, "native snapshot header"),
+  );
+
+const validateNativeSnapshotHeaderRecord = (
+  snapshot: Record<string, unknown>,
+): NativeSnapshotHeader => {
   const formatVersion = snapshot.formatVersion;
   if (formatVersion !== NATIVE_SNAPSHOT_FORMAT_VERSION) {
     throw new Error(
@@ -215,8 +568,6 @@ const validateNativeSnapshotHeader = (value: unknown): NativeSnapshotHeader => {
       snapshot.metadata === undefined
         ? undefined
         : expectRecord(snapshot.metadata, "native snapshot metadata"),
-    sequenceRecords: expectSequenceRecords(snapshot.sequenceRecords),
-    deleteTargets: expectDeleteTargets(snapshot.deleteTargets),
     checkpoints: expectCheckpoints(snapshot.checkpoints),
   };
 };

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -45,6 +45,7 @@ import {
 import { RemoteEventBuffer } from "./internals/remote-event-buffer";
 import {
   consumeDecodedNativeSnapshotGraphSource,
+  consumeDecodedNativeSnapshotRuntimeState,
   NATIVE_SNAPSHOT_FORMAT_VERSION,
   type NativeSnapshot,
   validateGraphMatchesSnapshot,
@@ -278,12 +279,17 @@ export class EgWalkerReplica {
     replicaId: string = "native-snapshot-replica",
   ): EgWalkerReplica {
     const graphSource = consumeDecodedNativeSnapshotGraphSource(snapshot);
+    const runtimeState = consumeDecodedNativeSnapshotRuntimeState(snapshot);
     let lazyEventGraph: LazyEventGraphSource | undefined;
     let graph: EventGraph | undefined;
+    let sequenceRecords: ReadonlyArray<EngineSequenceRecord> = [];
+    let deleteTargets: ReadonlyArray<DeleteTargetRecord> = [];
     const validated =
       graphSource === undefined
         ? (() => {
             const fullSnapshot = validateNativeSnapshot(snapshot);
+            sequenceRecords = fullSnapshot.sequenceRecords;
+            deleteTargets = fullSnapshot.deleteTargets;
             graph = EventGraph.deserialize(fullSnapshot.eventGraph);
             validateGraphMatchesSnapshot(graph, fullSnapshot);
             return fullSnapshot;
@@ -303,6 +309,10 @@ export class EgWalkerReplica {
             };
             return header;
           })();
+    if (graphSource !== undefined && runtimeState === undefined) {
+      sequenceRecords = snapshot.sequenceRecords;
+      deleteTargets = snapshot.deleteTargets;
+    }
     const snapshotFrontier = new Set(validated.currentVersion);
 
     if (graph) {
@@ -315,7 +325,12 @@ export class EgWalkerReplica {
     }
 
     let restoredEngine: EgWalkerEngine | undefined;
-    if (validated.sequenceRecords.length > 0) {
+    const hasCompactSequenceRecords =
+      runtimeState !== undefined && runtimeState.sequenceRecords.count > 0;
+    const hasSequenceRecords = hasCompactSequenceRecords
+      ? true
+      : sequenceRecords.length > 0;
+    if (hasSequenceRecords) {
       graph ??= lazyEventGraph?.();
       lazyEventGraph = undefined;
       if (!graph) {
@@ -325,8 +340,10 @@ export class EgWalkerReplica {
         graph,
         currentVersion: snapshotFrontier,
         text: validated.text,
-        sequenceRecords: validated.sequenceRecords,
-        deleteTargets: validated.deleteTargets,
+        sequenceRecords,
+        compactSequenceRecords: runtimeState?.sequenceRecords,
+        deleteTargets,
+        compactDeleteTargets: runtimeState?.deleteTargets,
       });
     }
 
@@ -337,7 +354,7 @@ export class EgWalkerReplica {
       nextSequenceNumber: validated.nextSequenceNumber,
       lazyEventGraph,
       deferLocalReplay: restoredEngine === undefined,
-      restoredSequenceRecords: validated.sequenceRecords,
+      restoredSequenceRecords: sequenceRecords,
       restoredEngine,
       restoredCheckpoints: validated.checkpoints,
     });

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -5,6 +5,8 @@ import type { EventId, ExternalOperation, GraphEvent } from "../types";
 import { IndexedSequence } from "./indexed-sequence";
 import {
   DeleteTargetIndex,
+  iterateCompactDeleteTargets,
+  type CompactDeleteTargetRecords,
   type DeleteTargetRecord,
 } from "./internals/delete-target-index";
 import {
@@ -29,7 +31,9 @@ import { PendingInsertBuffer } from "./internals/pending-insert-buffer";
 import { RecordSplitter } from "./internals/record-splitter";
 import {
   itemsFromRecords,
+  itemsFromCompactRecords,
   recordsFromItems,
+  type CompactEngineSequenceRecords,
   type EngineSequenceRecord,
 } from "./internals/sequence-records";
 import { spliceText } from "./internals/text-utils";
@@ -40,14 +44,20 @@ export type {
   GenerateOptions,
   IncrementalApplyResult,
 } from "./internals/engine-types";
-export type { DeleteTargetRecord } from "./internals/delete-target-index";
+export {
+  recordsFromCompactDeleteTargets,
+  type CompactDeleteTargetRecords,
+  type DeleteTargetRecord,
+} from "./internals/delete-target-index";
 
 export interface EngineSnapshotState {
   readonly graph: EventGraph;
   readonly currentVersion: ReadonlySet<EventId>;
   readonly text: string;
-  readonly sequenceRecords: ReadonlyArray<EngineSequenceRecord>;
-  readonly deleteTargets: ReadonlyArray<DeleteTargetRecord>;
+  readonly sequenceRecords?: ReadonlyArray<EngineSequenceRecord>;
+  readonly compactSequenceRecords?: CompactEngineSequenceRecords;
+  readonly deleteTargets?: ReadonlyArray<DeleteTargetRecord>;
+  readonly compactDeleteTargets?: CompactDeleteTargetRecords;
 }
 
 /**
@@ -193,7 +203,9 @@ export class EgWalkerEngine {
   }
 
   private restoreSnapshotState(state: EngineSnapshotState): void {
-    const items = itemsFromRecords(state.sequenceRecords);
+    const items = state.compactSequenceRecords
+      ? itemsFromCompactRecords(state.compactSequenceRecords)
+      : itemsFromRecords(state.sequenceRecords ?? []);
 
     this.eventsById.clear();
     this.eventOrder.clear();
@@ -224,7 +236,10 @@ export class EgWalkerEngine {
       this.trackEventItems(item);
     }
 
-    for (const target of state.deleteTargets) {
+    const deleteTargets = state.compactDeleteTargets
+      ? iterateCompactDeleteTargets(state.compactDeleteTargets)
+      : (state.deleteTargets ?? []);
+    for (const target of deleteTargets) {
       this.deleteTargets.record(target.deleteEventId, target.targetIds);
     }
   }

--- a/packages/eg-walker/src/engine/internals/delete-target-index.ts
+++ b/packages/eg-walker/src/engine/internals/delete-target-index.ts
@@ -5,6 +5,59 @@ export interface DeleteTargetRecord {
   readonly targetIds: ReadonlyArray<EventId>;
 }
 
+export interface CompactDeleteTargetRecords {
+  readonly idTable: ReadonlyArray<EventId>;
+  readonly deleteEventRefs: Uint32Array;
+  readonly targetOffsets: Uint32Array;
+  readonly targetRefs: Uint32Array;
+}
+
+export const recordsFromCompactDeleteTargets = (
+  records: CompactDeleteTargetRecords,
+): DeleteTargetRecord[] =>
+  Array.from({ length: records.deleteEventRefs.length }, (_, index) => {
+    const start = records.targetOffsets[index] ?? 0;
+    const end = records.targetOffsets[index + 1] ?? start;
+    return {
+      deleteEventId: readIdRef(
+        records.idTable,
+        records.deleteEventRefs[index] ?? 0,
+      ),
+      targetIds: Array.from(records.targetRefs.slice(start, end), (ref) =>
+        readIdRef(records.idTable, ref),
+      ),
+    };
+  });
+
+export function* iterateCompactDeleteTargets(
+  records: CompactDeleteTargetRecords,
+): IterableIterator<DeleteTargetRecord> {
+  for (let index = 0; index < records.deleteEventRefs.length; index++) {
+    const start = records.targetOffsets[index] ?? 0;
+    const end = records.targetOffsets[index + 1] ?? start;
+    yield {
+      deleteEventId: readIdRef(
+        records.idTable,
+        records.deleteEventRefs[index] ?? 0,
+      ),
+      targetIds: Array.from(records.targetRefs.slice(start, end), (ref) =>
+        readIdRef(records.idTable, ref),
+      ),
+    };
+  }
+}
+
+const readIdRef = (
+  table: ReadonlyArray<EventId>,
+  oneBasedRef: number,
+): EventId => {
+  const value = table[oneBasedRef - 1];
+  if (value === undefined) {
+    throw new Error(`Invalid compact delete target id ref ${oneBasedRef}`);
+  }
+  return value;
+};
+
 /**
  * Bidirectional index of delete events and the CRDT records they targeted.
  *

--- a/packages/eg-walker/src/engine/internals/sequence-records.ts
+++ b/packages/eg-walker/src/engine/internals/sequence-records.ts
@@ -2,6 +2,8 @@ import type { EventId } from "../../types";
 import { IndexedSequence } from "../indexed-sequence";
 import type { AugmentedCRDTItem, TypedRun } from "./engine-types";
 
+const decoder = new TextDecoder();
+
 export interface EngineSequenceRecord {
   readonly id: EventId;
   readonly eventId: EventId;
@@ -11,6 +13,22 @@ export interface EngineSequenceRecord {
   readonly everDeleted: boolean;
   readonly prepareState: number;
   readonly run: TypedRun | null;
+}
+
+export interface CompactEngineSequenceRecords {
+  readonly count: number;
+  readonly idTable: ReadonlyArray<EventId>;
+  readonly replicaTable: ReadonlyArray<string>;
+  readonly idRefs: Uint32Array;
+  readonly eventIdRefs: Uint32Array;
+  readonly originLeftRefs: Uint32Array;
+  readonly originRightRefs: Uint32Array;
+  readonly contentOffsets: Uint32Array;
+  readonly contentBytes: Uint8Array;
+  readonly everDeleted: Uint8Array;
+  readonly prepareStates: Uint32Array;
+  readonly runReplicaRefs: Uint32Array;
+  readonly runStartSequences: Uint32Array;
 }
 
 export const recordFromItem = (
@@ -47,6 +65,20 @@ export const itemsFromRecords = (
   records: ReadonlyArray<EngineSequenceRecord>,
 ): AugmentedCRDTItem[] => records.map(itemFromRecord);
 
+export const recordsFromCompactRecords = (
+  records: CompactEngineSequenceRecords,
+): EngineSequenceRecord[] =>
+  Array.from({ length: records.count }, (_, index) =>
+    recordFromCompactRecord(records, index),
+  );
+
+export const itemsFromCompactRecords = (
+  records: CompactEngineSequenceRecords,
+): AugmentedCRDTItem[] =>
+  Array.from({ length: records.count }, (_, index) =>
+    itemFromCompactRecord(records, index),
+  );
+
 export const sequenceFromRecords = (
   records: ReadonlyArray<EngineSequenceRecord>,
 ): IndexedSequence<AugmentedCRDTItem> =>
@@ -61,6 +93,89 @@ const prepareWeight = (item: AugmentedCRDTItem): number =>
 
 const effectWeight = (item: AugmentedCRDTItem): number =>
   item.everDeleted ? 0 : item.content.length;
+
+const recordFromCompactRecord = (
+  records: CompactEngineSequenceRecords,
+  index: number,
+): EngineSequenceRecord => ({
+  id: readIdRef(records.idTable, records.idRefs[index] ?? 0),
+  eventId: readIdRef(records.idTable, records.eventIdRefs[index] ?? 0),
+  content: decodeContent(records, index),
+  originLeft: readOptionalIdRef(
+    records.idTable,
+    records.originLeftRefs[index] ?? 0,
+  ),
+  originRight: readOptionalIdRef(
+    records.idTable,
+    records.originRightRefs[index] ?? 0,
+  ),
+  everDeleted: (records.everDeleted[index] ?? 0) === 1,
+  prepareState: records.prepareStates[index] ?? 0,
+  run: readRun(records, index),
+});
+
+const itemFromCompactRecord = (
+  records: CompactEngineSequenceRecords,
+  index: number,
+): AugmentedCRDTItem => ({
+  id: readIdRef(records.idTable, records.idRefs[index] ?? 0),
+  eventId: readIdRef(records.idTable, records.eventIdRefs[index] ?? 0),
+  content: decodeContent(records, index),
+  originLeft: readOptionalIdRef(
+    records.idTable,
+    records.originLeftRefs[index] ?? 0,
+  ),
+  originRight: readOptionalIdRef(
+    records.idTable,
+    records.originRightRefs[index] ?? 0,
+  ),
+  everDeleted: (records.everDeleted[index] ?? 0) === 1,
+  prepareState: records.prepareStates[index] ?? 0,
+  run: readRun(records, index),
+});
+
+const decodeContent = (
+  records: CompactEngineSequenceRecords,
+  index: number,
+): string => {
+  const start = records.contentOffsets[index] ?? 0;
+  const end = records.contentOffsets[index + 1] ?? start;
+  return decoder.decode(records.contentBytes.subarray(start, end));
+};
+
+const readIdRef = (
+  table: ReadonlyArray<EventId>,
+  oneBasedRef: number,
+): EventId => {
+  const value = table[oneBasedRef - 1];
+  if (value === undefined) {
+    throw new Error(`Invalid compact sequence id ref ${oneBasedRef}`);
+  }
+  return value;
+};
+
+const readOptionalIdRef = (
+  table: ReadonlyArray<EventId>,
+  oneBasedRef: number,
+): EventId | null => (oneBasedRef === 0 ? null : readIdRef(table, oneBasedRef));
+
+const readRun = (
+  records: CompactEngineSequenceRecords,
+  index: number,
+): TypedRun | null => {
+  const replicaRef = records.runReplicaRefs[index] ?? 0;
+  if (replicaRef === 0) {
+    return null;
+  }
+  const replicaId = records.replicaTable[replicaRef - 1];
+  if (replicaId === undefined) {
+    throw new Error(`Invalid compact sequence replica ref ${replicaRef}`);
+  }
+  return {
+    replicaId,
+    startSequence: records.runStartSequences[index] ?? 0,
+  };
+};
 
 const cloneRun = (run: TypedRun | null): TypedRun | null =>
   run === null

--- a/packages/eg-walker/src/engine/sequence-records.ts
+++ b/packages/eg-walker/src/engine/sequence-records.ts
@@ -1,8 +1,10 @@
 export {
   itemFromRecord,
   itemsFromRecords,
+  recordsFromCompactRecords,
   recordFromItem,
   recordsFromItems,
   sequenceFromRecords,
+  type CompactEngineSequenceRecords,
   type EngineSequenceRecord,
 } from "./internals/sequence-records";

--- a/packages/eg-walker/src/graph/internals/binary-io.ts
+++ b/packages/eg-walker/src/graph/internals/binary-io.ts
@@ -49,6 +49,16 @@ export class BinaryWriter {
     }
   }
 
+  writeMappedVarintArray(
+    length: number,
+    valueAt: (index: number) => number,
+  ): void {
+    this.writeVarint(length);
+    for (let index = 0; index < length; index++) {
+      this.writeVarint(valueAt(index));
+    }
+  }
+
   writeZigZagVarint(value: number): void {
     if (!Number.isSafeInteger(value)) {
       throw new Error(`Cannot encode invalid zigzag varint value ${value}`);
@@ -152,6 +162,15 @@ export class BinaryReader {
     return Array.from({ length }, () => this.readVarint());
   }
 
+  readVarintUint32Array(): Uint32Array {
+    const length = this.readVarint();
+    const values = new Uint32Array(length);
+    for (let index = 0; index < length; index++) {
+      values[index] = this.readVarint();
+    }
+    return values;
+  }
+
   readZigZagVarint(): number {
     return zigzagDecode(this.readVarint());
   }
@@ -184,5 +203,9 @@ export class BinaryReader {
     const result = this.bytes.slice(this.offset, this.offset + length);
     this.offset += length;
     return result;
+  }
+
+  hasRemaining(): boolean {
+    return this.offset < this.bytes.length;
   }
 }

--- a/packages/eg-walker/src/test/native-snapshot.test.ts
+++ b/packages/eg-walker/src/test/native-snapshot.test.ts
@@ -9,7 +9,7 @@ import { REPLAY_SOURCE } from "../constants/replay-source";
 import { sequenceFromRecords } from "../engine/sequence-records";
 import { EventGraph } from "../graph/event-graph";
 import { ColumnarEventGraphCodec } from "../graph/columnar-codec";
-import { BinaryWriter } from "../graph/internals/binary-io";
+import { BinaryReader, BinaryWriter } from "../graph/internals/binary-io";
 
 describe("EgWalkerReplica native snapshots", () => {
   it("should restore readable document state without replaying history", () => {
@@ -240,6 +240,38 @@ describe("EgWalkerReplica native snapshots", () => {
     expect(sequence.effectIndexBeforePosition(sequence.length)).toBe(2);
   });
 
+  it("should keep runtime records out of the JSON header", () => {
+    // Arrange
+    const replica = new EgWalkerReplica("alice", "");
+    replica.insert(0, "A");
+    replica.insert(1, "B");
+    const codec = new NativeSnapshotCodec();
+
+    // Act
+    const bytes = codec.encode(replica.createNativeSnapshot());
+    const reader = new BinaryReader(bytes.subarray(5));
+    const header = JSON.parse(
+      new TextDecoder().decode(reader.readBytes(reader.readVarint())),
+    ) as Record<string, unknown>;
+    const decoded = codec.decode(bytes);
+
+    // Assert
+    expect(header.sequenceRecords).toBeUndefined();
+    expect(header.deleteTargets).toBeUndefined();
+    expect(decoded.sequenceRecords).toEqual([
+      {
+        id: "alice:0:0",
+        eventId: "alice:0",
+        content: "AB",
+        originLeft: null,
+        originRight: null,
+        everDeleted: false,
+        prepareState: 1,
+        run: { replicaId: "alice", startSequence: 0 },
+      },
+    ]);
+  });
+
   it("should persist delete targets for restored engine resume state", () => {
     // Arrange
     const replica = new EgWalkerReplica("alice", "");
@@ -316,6 +348,34 @@ describe("EgWalkerReplica native snapshots", () => {
       configurable: true,
       get: () => {
         throw new Error("eventGraph should stay lazy on fast restore");
+      },
+    });
+
+    // Act
+    const restored = EgWalkerReplica.fromNativeSnapshot(decoded, "alice");
+
+    // Assert
+    expect(restored.getText()).toBe("AB");
+    expect(restored.getReplayStats().fullReplays).toBe(0);
+  });
+
+  it("should restore decoded snapshots without materializing public runtime record arrays", () => {
+    // Arrange
+    const replica = new EgWalkerReplica("alice", "");
+    replica.insert(0, "A");
+    replica.insert(1, "B");
+    const codec = new NativeSnapshotCodec();
+    const decoded = codec.decode(codec.encode(replica.createNativeSnapshot()));
+    Object.defineProperty(decoded, "sequenceRecords", {
+      configurable: true,
+      get: () => {
+        throw new Error("sequenceRecords should stay compact on fast restore");
+      },
+    });
+    Object.defineProperty(decoded, "deleteTargets", {
+      configurable: true,
+      get: () => {
+        throw new Error("deleteTargets should stay compact on fast restore");
       },
     });
 


### PR DESCRIPTION
## Summary

- Move native snapshot runtime sequence/delete-target data out of the JSON header into a binary runtime-state section.
- Decode runtime state into compact column arrays and keep public `sequenceRecords` / `deleteTargets` as lazy compatibility getters.
- Teach snapshot restore and engine adoption to consume compact runtime state without first materializing public runtime record arrays.

## Validation

- `pnpm --filter @softmaple/eg-walker test src/test/native-snapshot.test.ts --run`
- `pnpm --filter @softmaple/eg-walker test --run`
- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker lint` (passes with two pre-existing unrelated warnings in `columnar-codec.test.ts` and `convergence-property.test.ts`)

## Scope

This PR intentionally excludes the plan document, paper benchmark files, and `packages/eg-walker/package.json` changes that remain uncommitted in the local worktree.