### PR TITLE
perf(packages/eg-walker): adopt compact native snapshot runtime state

### DIFF
--- a/packages/eg-walker/src/core/native-snapshot.ts
+++ b/packages/eg-walker/src/core/native-snapshot.ts
@@ -8,8 +8,16 @@ import type {
 import { EventGraph } from "../graph/event-graph";
 import { ColumnarEventGraphCodec } from "../graph/columnar-codec";
 import { BinaryReader, BinaryWriter } from "../graph/internals/binary-io";
-import type { EngineSequenceRecord } from "../engine/sequence-records";
-import type { DeleteTargetRecord } from "../engine/eg-walker-engine";
+import {
+  recordsFromCompactDeleteTargets,
+  type CompactDeleteTargetRecords,
+  type DeleteTargetRecord,
+} from "../engine/eg-walker-engine";
+import {
+  recordsFromCompactRecords,
+  type CompactEngineSequenceRecords,
+  type EngineSequenceRecord,
+} from "../engine/sequence-records";
 import type { CriticalCheckpointSnapshot } from "./internals/critical-checkpoint-store";
 
 export const NATIVE_SNAPSHOT_FORMAT_VERSION = "EGWS1" as const;
@@ -36,20 +44,22 @@ export interface NativeSnapshotHeader {
   readonly eventCount: number;
   readonly nextSequenceNumber: number;
   readonly metadata?: Record<string, unknown>;
-  readonly sequenceRecords: ReadonlyArray<EngineSequenceRecord>;
-  readonly deleteTargets: ReadonlyArray<DeleteTargetRecord>;
   readonly checkpoints: ReadonlyArray<CriticalCheckpointSnapshot>;
 }
 
-type NativeSnapshotWireHeader = Omit<
-  NativeSnapshotHeader,
-  "sequenceRecords" | "deleteTargets"
-> &
-  Partial<Pick<NativeSnapshotHeader, "sequenceRecords" | "deleteTargets">>;
+type NativeSnapshotWireHeader = NativeSnapshotHeader & {
+  readonly sequenceRecords?: ReadonlyArray<EngineSequenceRecord>;
+  readonly deleteTargets?: ReadonlyArray<DeleteTargetRecord>;
+};
 
 interface NativeRuntimeState {
   readonly sequenceRecords: ReadonlyArray<EngineSequenceRecord>;
   readonly deleteTargets: ReadonlyArray<DeleteTargetRecord>;
+}
+
+export interface NativeSnapshotRuntimeState {
+  readonly sequenceRecords: CompactEngineSequenceRecords;
+  readonly deleteTargets: CompactDeleteTargetRecords;
 }
 
 const encoder = new TextEncoder();
@@ -57,6 +67,10 @@ const decoder = new TextDecoder();
 const MAGIC_BYTES = encoder.encode(NATIVE_SNAPSHOT_FORMAT_VERSION);
 const columnarCodec = new ColumnarEventGraphCodec();
 const decodedGraphSourceCache = new WeakMap<NativeSnapshot, () => EventGraph>();
+const decodedRuntimeStateCache = new WeakMap<
+  NativeSnapshot,
+  NativeSnapshotRuntimeState
+>();
 
 export class NativeSnapshotCodec {
   encode(snapshot: NativeSnapshot): Uint8Array {
@@ -106,32 +120,37 @@ const decodeLengthPrefixedNativeSnapshotBody = (
 ): NativeSnapshot | null => {
   try {
     const reader = new BinaryReader(body);
-    const header = validateNativeSnapshotHeader(
+    const headerPayload = validateNativeSnapshotHeaderPayload(
       JSON.parse(
         decoder.decode(reader.readBytes(reader.readVarint())),
       ) as unknown,
     );
     const graphBytes = reader.readBytes(reader.readVarint());
-    const runtimeState =
+    const compactRuntimeState =
       reader.remainingByteLength === 0
-        ? {
-            sequenceRecords: header.sequenceRecords,
-            deleteTargets: header.deleteTargets,
-          }
+        ? undefined
         : decodeRuntimeState(reader.readBytes(reader.readVarint()));
+    const legacyRuntimeState =
+      compactRuntimeState === undefined
+        ? {
+            sequenceRecords: headerPayload.sequenceRecords,
+            deleteTargets: headerPayload.deleteTargets,
+          }
+        : { sequenceRecords: [], deleteTargets: [] };
     if (reader.remainingByteLength !== 0) {
       throw new Error("Invalid native snapshot: unexpected trailing bytes");
     }
     const graphSource = createMemoizedGraphSource(graphBytes);
-    const snapshot = createSnapshotWithLazyEventGraph(
-      {
-        ...header,
-        sequenceRecords: runtimeState.sequenceRecords,
-        deleteTargets: runtimeState.deleteTargets,
-      },
+    const snapshot = createSnapshotWithLazySections(
+      headerPayload.header,
       graphSource,
+      compactRuntimeState,
+      legacyRuntimeState,
     );
     decodedGraphSourceCache.set(snapshot, graphSource);
+    if (compactRuntimeState) {
+      decodedRuntimeStateCache.set(snapshot, compactRuntimeState);
+    }
     return snapshot;
   } catch (error) {
     if (body[0] === 0x7b) {
@@ -151,6 +170,16 @@ export const consumeDecodedNativeSnapshotGraphSource = (
   return graphSource;
 };
 
+export const consumeDecodedNativeSnapshotRuntimeState = (
+  snapshot: NativeSnapshot,
+): NativeSnapshotRuntimeState | undefined => {
+  const runtimeState = decodedRuntimeStateCache.get(snapshot);
+  if (runtimeState) {
+    decodedRuntimeStateCache.delete(snapshot);
+  }
+  return runtimeState;
+};
+
 export const validateNativeSnapshotHeaderOnly = (
   value: unknown,
 ): NativeSnapshotHeader => validateNativeSnapshotHeader(value);
@@ -162,13 +191,29 @@ export const validateGraphMatchesSnapshot = (
   validateGraphMatchesHeader(graph, snapshot);
 };
 
-const createSnapshotWithLazyEventGraph = (
+const createSnapshotWithLazySections = (
   header: NativeSnapshotHeader,
   graphSource: () => EventGraph,
+  runtimeState: NativeSnapshotRuntimeState | undefined,
+  legacyRuntimeState: NativeRuntimeState,
 ): NativeSnapshot => {
   let eventGraph: SerializedGraphOutput | null = null;
+  let sequenceRecords: ReadonlyArray<EngineSequenceRecord> | null = null;
+  let deleteTargets: ReadonlyArray<DeleteTargetRecord> | null = null;
   return {
     ...header,
+    get sequenceRecords(): ReadonlyArray<EngineSequenceRecord> {
+      sequenceRecords ??= runtimeState
+        ? recordsFromCompactRecords(runtimeState.sequenceRecords)
+        : legacyRuntimeState.sequenceRecords;
+      return sequenceRecords;
+    },
+    get deleteTargets(): ReadonlyArray<DeleteTargetRecord> {
+      deleteTargets ??= runtimeState
+        ? recordsFromCompactDeleteTargets(runtimeState.deleteTargets)
+        : legacyRuntimeState.deleteTargets;
+      return deleteTargets;
+    },
     get eventGraph(): SerializedGraphOutput {
       eventGraph ??= graphSource().serialize();
       return eventGraph;
@@ -228,7 +273,7 @@ const encodeRuntimeState = (state: NativeRuntimeState): Uint8Array => {
   return writer.toUint8Array();
 };
 
-const decodeRuntimeState = (bytes: Uint8Array): NativeRuntimeState => {
+const decodeRuntimeState = (bytes: Uint8Array): NativeSnapshotRuntimeState => {
   const reader = new BinaryReader(bytes);
   const idTable = reader.readStringArray();
   const replicaTable = reader.readStringArray();
@@ -338,77 +383,65 @@ const readSequenceRecords = (
   reader: BinaryReader,
   idTable: ReadonlyArray<string>,
   replicaTable: ReadonlyArray<string>,
-): EngineSequenceRecord[] => {
+): CompactEngineSequenceRecords => {
   const count = reader.readVarint();
-  const ids = expectColumnLength(reader.readVarintArray(), count, "record ids");
+  const idRefs = expectColumnLength(
+    reader.readVarintUint32Array(),
+    count,
+    "record ids",
+  );
   const eventIds = expectColumnLength(
-    reader.readVarintArray(),
+    reader.readVarintUint32Array(),
     count,
     "record event ids",
   );
   const originLefts = expectColumnLength(
-    reader.readVarintArray(),
+    reader.readVarintUint32Array(),
     count,
     "record originLeft ids",
   );
   const originRights = expectColumnLength(
-    reader.readVarintArray(),
+    reader.readVarintUint32Array(),
     count,
     "record originRight ids",
   );
   const everDeleted = expectColumnLength(
-    reader.readVarintArray(),
+    reader.readVarintUint32Array(),
     count,
     "record deletion flags",
   );
   const prepareStates = expectColumnLength(
-    reader.readVarintArray(),
+    reader.readVarintUint32Array(),
     count,
     "record prepare states",
   );
   const runReplicas = expectColumnLength(
-    reader.readVarintArray(),
+    reader.readVarintUint32Array(),
     count,
     "record run replicas",
   );
   const runStartSequences = expectColumnLength(
-    reader.readVarintArray(),
+    reader.readVarintUint32Array(),
     count,
     "record run start sequences",
   );
-  const contents = readContentBlob(reader, count);
+  const content = readContentBlob(reader, count);
 
-  return Array.from({ length: count }, (_, index) => {
-    const runReplica = runReplicas[index]!;
-    return {
-      id: stringAt(idTable, ids[index]!, "record id"),
-      eventId: stringAt(idTable, eventIds[index]!, "record eventId"),
-      content: contents[index]!,
-      originLeft: optionalStringAt(
-        idTable,
-        originLefts[index]!,
-        "record originLeft",
-      ),
-      originRight: optionalStringAt(
-        idTable,
-        originRights[index]!,
-        "record originRight",
-      ),
-      everDeleted: everDeleted[index] === 1,
-      prepareState: prepareStates[index]!,
-      run:
-        runReplica === 0
-          ? null
-          : {
-              replicaId: stringAt(
-                replicaTable,
-                runReplica - 1,
-                "record run replicaId",
-              ),
-              startSequence: runStartSequences[index]!,
-            },
-    };
-  });
+  return {
+    count,
+    idTable,
+    replicaTable,
+    idRefs,
+    eventIdRefs: eventIds,
+    originLeftRefs: originLefts,
+    originRightRefs: originRights,
+    everDeleted,
+    prepareStates,
+    runReplicaRefs: runReplicas,
+    runStartSequences,
+    contentOffsets: content.offsets,
+    contentBytes: content.bytes,
+  };
 };
 
 const writeContentBlob = (
@@ -433,9 +466,9 @@ const writeContentBlob = (
 const readContentBlob = (
   reader: BinaryReader,
   recordCount: number,
-): string[] => {
+): { readonly offsets: Uint32Array; readonly bytes: Uint8Array } => {
   const offsets = expectColumnLength(
-    reader.readZigZagDeltaArray(),
+    Uint32Array.from(reader.readZigZagDeltaArray()),
     recordCount + 1,
     "record content offsets",
   );
@@ -445,7 +478,7 @@ const readContentBlob = (
     );
   }
   const blob = reader.readBytes(reader.readVarint());
-  return Array.from({ length: recordCount }, (_, index) => {
+  for (let index = 0; index < recordCount; index++) {
     const start = offsets[index]!;
     const end = offsets[index + 1]!;
     if (start > end || end > blob.byteLength) {
@@ -453,8 +486,8 @@ const readContentBlob = (
         "Invalid native snapshot runtime state: content offset out of bounds",
       );
     }
-    return decoder.decode(blob.subarray(start, end));
-  });
+  }
+  return { offsets, bytes: blob };
 };
 
 const writeDeleteTargets = (
@@ -474,18 +507,26 @@ const writeDeleteTargets = (
 const readDeleteTargets = (
   reader: BinaryReader,
   idTable: ReadonlyArray<string>,
-): DeleteTargetRecord[] => {
+): CompactDeleteTargetRecords => {
   const count = reader.readVarint();
-  return Array.from({ length: count }, () => ({
-    deleteEventId: stringAt(
-      idTable,
-      reader.readVarint(),
-      "delete target event id",
-    ),
-    targetIds: reader
-      .readVarintArray()
-      .map((id) => stringAt(idTable, id, "delete target item id")),
-  }));
+  const deleteEventRefs = new Uint32Array(count);
+  const targetOffsets = new Uint32Array(count + 1);
+  const targetRefs: number[] = [];
+  for (let index = 0; index < count; index++) {
+    deleteEventRefs[index] = reader.readVarint();
+    const refs = reader.readVarintUint32Array();
+    targetOffsets[index] = targetRefs.length;
+    for (const ref of refs) {
+      targetRefs.push(ref);
+    }
+  }
+  targetOffsets[count] = targetRefs.length;
+  return {
+    idTable,
+    deleteEventRefs,
+    targetOffsets,
+    targetRefs: Uint32Array.from(targetRefs),
+  };
 };
 
 const idIndex = (table: StringTable, value: string): number => {
@@ -507,30 +548,11 @@ const replicaIndex = (table: StringTable, value: string): number => {
   return index;
 };
 
-const stringAt = (
-  table: ReadonlyArray<string>,
-  index: number,
-  label: string,
-): string => {
-  const value = table[index];
-  if (value === undefined) {
-    throw new Error(`Invalid native snapshot runtime state: missing ${label}`);
-  }
-  return value;
-};
-
-const optionalStringAt = (
-  table: ReadonlyArray<string>,
-  encodedIndex: number,
-  label: string,
-): string | null =>
-  encodedIndex === 0 ? null : stringAt(table, encodedIndex - 1, label);
-
 const expectColumnLength = (
-  values: number[],
+  values: Uint32Array,
   expected: number,
   label: string,
-): number[] => {
+): Uint32Array => {
   if (values.length !== expected) {
     throw new Error(
       `Invalid native snapshot runtime state: ${label} has ${values.length} entries but expected ${expected}`,
@@ -539,8 +561,29 @@ const expectColumnLength = (
   return values;
 };
 
-const validateNativeSnapshotHeader = (value: unknown): NativeSnapshotHeader => {
+const validateNativeSnapshotHeaderPayload = (
+  value: unknown,
+): {
+  readonly header: NativeSnapshotHeader;
+  readonly sequenceRecords: ReadonlyArray<EngineSequenceRecord>;
+  readonly deleteTargets: ReadonlyArray<DeleteTargetRecord>;
+} => {
   const snapshot = expectRecord(value, "native snapshot header");
+  return {
+    header: validateNativeSnapshotHeaderRecord(snapshot),
+    sequenceRecords: expectSequenceRecords(snapshot.sequenceRecords),
+    deleteTargets: expectDeleteTargets(snapshot.deleteTargets),
+  };
+};
+
+const validateNativeSnapshotHeader = (value: unknown): NativeSnapshotHeader =>
+  validateNativeSnapshotHeaderRecord(
+    expectRecord(value, "native snapshot header"),
+  );
+
+const validateNativeSnapshotHeaderRecord = (
+  snapshot: Record<string, unknown>,
+): NativeSnapshotHeader => {
   const formatVersion = snapshot.formatVersion;
   if (formatVersion !== NATIVE_SNAPSHOT_FORMAT_VERSION) {
     throw new Error(
@@ -571,8 +614,6 @@ const validateNativeSnapshotHeader = (value: unknown): NativeSnapshotHeader => {
       snapshot.metadata === undefined
         ? undefined
         : expectRecord(snapshot.metadata, "native snapshot metadata"),
-    sequenceRecords: expectSequenceRecords(snapshot.sequenceRecords),
-    deleteTargets: expectDeleteTargets(snapshot.deleteTargets),
     checkpoints: expectCheckpoints(snapshot.checkpoints),
   };
 };

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -325,11 +325,10 @@ export class EgWalkerReplica {
     }
 
     let restoredEngine: EgWalkerEngine | undefined;
-    const hasCompactSequenceRecords =
-      runtimeState !== undefined && runtimeState.sequenceRecords.count > 0;
-    const hasSequenceRecords = hasCompactSequenceRecords
-      ? true
-      : sequenceRecords.length > 0;
+    const hasSequenceRecords =
+      runtimeState !== undefined
+        ? runtimeState.sequenceRecords.count > 0
+        : sequenceRecords.length > 0;
     if (hasSequenceRecords) {
       graph ??= lazyEventGraph?.();
       lazyEventGraph = undefined;

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -45,6 +45,7 @@ import {
 import { RemoteEventBuffer } from "./internals/remote-event-buffer";
 import {
   consumeDecodedNativeSnapshotGraphSource,
+  consumeDecodedNativeSnapshotRuntimeState,
   NATIVE_SNAPSHOT_FORMAT_VERSION,
   type NativeSnapshot,
   validateGraphMatchesSnapshot,
@@ -278,12 +279,17 @@ export class EgWalkerReplica {
     replicaId: string = "native-snapshot-replica",
   ): EgWalkerReplica {
     const graphSource = consumeDecodedNativeSnapshotGraphSource(snapshot);
+    const runtimeState = consumeDecodedNativeSnapshotRuntimeState(snapshot);
     let lazyEventGraph: LazyEventGraphSource | undefined;
     let graph: EventGraph | undefined;
+    let sequenceRecords: ReadonlyArray<EngineSequenceRecord> = [];
+    let deleteTargets: ReadonlyArray<DeleteTargetRecord> = [];
     const validated =
       graphSource === undefined
         ? (() => {
             const fullSnapshot = validateNativeSnapshot(snapshot);
+            sequenceRecords = fullSnapshot.sequenceRecords;
+            deleteTargets = fullSnapshot.deleteTargets;
             graph = EventGraph.deserialize(fullSnapshot.eventGraph);
             validateGraphMatchesSnapshot(graph, fullSnapshot);
             return fullSnapshot;
@@ -303,6 +309,10 @@ export class EgWalkerReplica {
             };
             return header;
           })();
+    if (graphSource !== undefined && runtimeState === undefined) {
+      sequenceRecords = snapshot.sequenceRecords;
+      deleteTargets = snapshot.deleteTargets;
+    }
     const snapshotFrontier = new Set(validated.currentVersion);
 
     if (graph) {
@@ -315,7 +325,12 @@ export class EgWalkerReplica {
     }
 
     let restoredEngine: EgWalkerEngine | undefined;
-    if (validated.sequenceRecords.length > 0) {
+    const hasCompactSequenceRecords =
+      runtimeState !== undefined && runtimeState.sequenceRecords.count > 0;
+    const hasSequenceRecords = hasCompactSequenceRecords
+      ? true
+      : sequenceRecords.length > 0;
+    if (hasSequenceRecords) {
       graph ??= lazyEventGraph?.();
       lazyEventGraph = undefined;
       if (!graph) {
@@ -325,8 +340,10 @@ export class EgWalkerReplica {
         graph,
         currentVersion: snapshotFrontier,
         text: validated.text,
-        sequenceRecords: validated.sequenceRecords,
-        deleteTargets: validated.deleteTargets,
+        sequenceRecords,
+        compactSequenceRecords: runtimeState?.sequenceRecords,
+        deleteTargets,
+        compactDeleteTargets: runtimeState?.deleteTargets,
       });
     }
 
@@ -337,7 +354,7 @@ export class EgWalkerReplica {
       nextSequenceNumber: validated.nextSequenceNumber,
       lazyEventGraph,
       deferLocalReplay: restoredEngine === undefined,
-      restoredSequenceRecords: validated.sequenceRecords,
+      restoredSequenceRecords: sequenceRecords,
       restoredEngine,
       restoredCheckpoints: validated.checkpoints,
     });

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -5,6 +5,8 @@ import type { EventId, ExternalOperation, GraphEvent } from "../types";
 import { IndexedSequence } from "./indexed-sequence";
 import {
   DeleteTargetIndex,
+  iterateCompactDeleteTargets,
+  type CompactDeleteTargetRecords,
   type DeleteTargetRecord,
 } from "./internals/delete-target-index";
 import {
@@ -28,8 +30,10 @@ import { OriginLeftIndex } from "./internals/origin-left-index";
 import { PendingInsertBuffer } from "./internals/pending-insert-buffer";
 import { RecordSplitter } from "./internals/record-splitter";
 import {
+  itemsFromCompactRecords,
   itemsFromRecords,
   recordsFromItems,
+  type CompactEngineSequenceRecords,
   type EngineSequenceRecord,
 } from "./internals/sequence-records";
 import { spliceText } from "./internals/text-utils";
@@ -40,14 +44,20 @@ export type {
   GenerateOptions,
   IncrementalApplyResult,
 } from "./internals/engine-types";
-export type { DeleteTargetRecord } from "./internals/delete-target-index";
+export {
+  recordsFromCompactDeleteTargets,
+  type CompactDeleteTargetRecords,
+  type DeleteTargetRecord,
+} from "./internals/delete-target-index";
 
 export interface EngineSnapshotState {
   readonly graph: EventGraph;
   readonly currentVersion: ReadonlySet<EventId>;
   readonly text: string;
-  readonly sequenceRecords: ReadonlyArray<EngineSequenceRecord>;
-  readonly deleteTargets: ReadonlyArray<DeleteTargetRecord>;
+  readonly sequenceRecords?: ReadonlyArray<EngineSequenceRecord>;
+  readonly compactSequenceRecords?: CompactEngineSequenceRecords;
+  readonly deleteTargets?: ReadonlyArray<DeleteTargetRecord>;
+  readonly compactDeleteTargets?: CompactDeleteTargetRecords;
 }
 
 /**
@@ -193,7 +203,9 @@ export class EgWalkerEngine {
   }
 
   private restoreSnapshotState(state: EngineSnapshotState): void {
-    const items = itemsFromRecords(state.sequenceRecords);
+    const items = state.compactSequenceRecords
+      ? itemsFromCompactRecords(state.compactSequenceRecords)
+      : itemsFromRecords(state.sequenceRecords ?? []);
 
     this.eventsById.clear();
     this.eventOrder.clear();
@@ -224,7 +236,10 @@ export class EgWalkerEngine {
       this.trackEventItems(item);
     }
 
-    for (const target of state.deleteTargets) {
+    const deleteTargets = state.compactDeleteTargets
+      ? iterateCompactDeleteTargets(state.compactDeleteTargets)
+      : (state.deleteTargets ?? []);
+    for (const target of deleteTargets) {
       this.deleteTargets.record(target.deleteEventId, target.targetIds);
     }
   }

--- a/packages/eg-walker/src/engine/internals/delete-target-index.ts
+++ b/packages/eg-walker/src/engine/internals/delete-target-index.ts
@@ -23,7 +23,7 @@ export const recordsFromCompactDeleteTargets = (
         records.idTable,
         records.deleteEventRefs[index] ?? 0,
       ),
-      targetIds: Array.from(records.targetRefs.slice(start, end), (ref) =>
+      targetIds: Array.from(records.targetRefs.subarray(start, end), (ref) =>
         readIdRef(records.idTable, ref),
       ),
     };

--- a/packages/eg-walker/src/engine/internals/delete-target-index.ts
+++ b/packages/eg-walker/src/engine/internals/delete-target-index.ts
@@ -40,7 +40,7 @@ export function* iterateCompactDeleteTargets(
         records.idTable,
         records.deleteEventRefs[index] ?? 0,
       ),
-      targetIds: Array.from(records.targetRefs.slice(start, end), (ref) =>
+      targetIds: Array.from(records.targetRefs.subarray(start, end), (ref) =>
         readIdRef(records.idTable, ref),
       ),
     };

--- a/packages/eg-walker/src/engine/internals/delete-target-index.ts
+++ b/packages/eg-walker/src/engine/internals/delete-target-index.ts
@@ -5,6 +5,59 @@ export interface DeleteTargetRecord {
   readonly targetIds: ReadonlyArray<EventId>;
 }
 
+export interface CompactDeleteTargetRecords {
+  readonly idTable: ReadonlyArray<EventId>;
+  readonly deleteEventRefs: Uint32Array;
+  readonly targetOffsets: Uint32Array;
+  readonly targetRefs: Uint32Array;
+}
+
+export const recordsFromCompactDeleteTargets = (
+  records: CompactDeleteTargetRecords,
+): DeleteTargetRecord[] =>
+  Array.from({ length: records.deleteEventRefs.length }, (_, index) => {
+    const start = records.targetOffsets[index] ?? 0;
+    const end = records.targetOffsets[index + 1] ?? start;
+    return {
+      deleteEventId: readIdRef(
+        records.idTable,
+        records.deleteEventRefs[index] ?? 0,
+      ),
+      targetIds: Array.from(records.targetRefs.slice(start, end), (ref) =>
+        readIdRef(records.idTable, ref),
+      ),
+    };
+  });
+
+export function* iterateCompactDeleteTargets(
+  records: CompactDeleteTargetRecords,
+): IterableIterator<DeleteTargetRecord> {
+  for (let index = 0; index < records.deleteEventRefs.length; index++) {
+    const start = records.targetOffsets[index] ?? 0;
+    const end = records.targetOffsets[index + 1] ?? start;
+    yield {
+      deleteEventId: readIdRef(
+        records.idTable,
+        records.deleteEventRefs[index] ?? 0,
+      ),
+      targetIds: Array.from(records.targetRefs.slice(start, end), (ref) =>
+        readIdRef(records.idTable, ref),
+      ),
+    };
+  }
+}
+
+const readIdRef = (
+  table: ReadonlyArray<EventId>,
+  zeroBasedRef: number,
+): EventId => {
+  const value = table[zeroBasedRef];
+  if (value === undefined) {
+    throw new Error(`Invalid compact delete target id ref ${zeroBasedRef}`);
+  }
+  return value;
+};
+
 /**
  * Bidirectional index of delete events and the CRDT records they targeted.
  *

--- a/packages/eg-walker/src/engine/internals/sequence-records.ts
+++ b/packages/eg-walker/src/engine/internals/sequence-records.ts
@@ -2,6 +2,8 @@ import type { EventId } from "../../types";
 import { IndexedSequence } from "../indexed-sequence";
 import type { AugmentedCRDTItem, TypedRun } from "./engine-types";
 
+const decoder = new TextDecoder();
+
 export interface EngineSequenceRecord {
   readonly id: EventId;
   readonly eventId: EventId;
@@ -11,6 +13,22 @@ export interface EngineSequenceRecord {
   readonly everDeleted: boolean;
   readonly prepareState: number;
   readonly run: TypedRun | null;
+}
+
+export interface CompactEngineSequenceRecords {
+  readonly count: number;
+  readonly idTable: ReadonlyArray<EventId>;
+  readonly replicaTable: ReadonlyArray<string>;
+  readonly idRefs: Uint32Array;
+  readonly eventIdRefs: Uint32Array;
+  readonly originLeftRefs: Uint32Array;
+  readonly originRightRefs: Uint32Array;
+  readonly everDeleted: Uint32Array;
+  readonly prepareStates: Uint32Array;
+  readonly runReplicaRefs: Uint32Array;
+  readonly runStartSequences: Uint32Array;
+  readonly contentOffsets: Uint32Array;
+  readonly contentBytes: Uint8Array;
 }
 
 export const recordFromItem = (
@@ -47,6 +65,20 @@ export const itemsFromRecords = (
   records: ReadonlyArray<EngineSequenceRecord>,
 ): AugmentedCRDTItem[] => records.map(itemFromRecord);
 
+export const recordsFromCompactRecords = (
+  records: CompactEngineSequenceRecords,
+): EngineSequenceRecord[] =>
+  Array.from({ length: records.count }, (_, index) =>
+    recordFromCompactRecord(records, index),
+  );
+
+export const itemsFromCompactRecords = (
+  records: CompactEngineSequenceRecords,
+): AugmentedCRDTItem[] =>
+  Array.from({ length: records.count }, (_, index) =>
+    itemFromCompactRecord(records, index),
+  );
+
 export const sequenceFromRecords = (
   records: ReadonlyArray<EngineSequenceRecord>,
 ): IndexedSequence<AugmentedCRDTItem> =>
@@ -61,6 +93,90 @@ const prepareWeight = (item: AugmentedCRDTItem): number =>
 
 const effectWeight = (item: AugmentedCRDTItem): number =>
   item.everDeleted ? 0 : item.content.length;
+
+const recordFromCompactRecord = (
+  records: CompactEngineSequenceRecords,
+  index: number,
+): EngineSequenceRecord => ({
+  id: readIdRef(records.idTable, records.idRefs[index] ?? 0),
+  eventId: readIdRef(records.idTable, records.eventIdRefs[index] ?? 0),
+  content: decodeContent(records, index),
+  originLeft: readOptionalIdRef(
+    records.idTable,
+    records.originLeftRefs[index] ?? 0,
+  ),
+  originRight: readOptionalIdRef(
+    records.idTable,
+    records.originRightRefs[index] ?? 0,
+  ),
+  everDeleted: (records.everDeleted[index] ?? 0) === 1,
+  prepareState: records.prepareStates[index] ?? 0,
+  run: readRun(records, index),
+});
+
+const itemFromCompactRecord = (
+  records: CompactEngineSequenceRecords,
+  index: number,
+): AugmentedCRDTItem => ({
+  id: readIdRef(records.idTable, records.idRefs[index] ?? 0),
+  eventId: readIdRef(records.idTable, records.eventIdRefs[index] ?? 0),
+  content: decodeContent(records, index),
+  originLeft: readOptionalIdRef(
+    records.idTable,
+    records.originLeftRefs[index] ?? 0,
+  ),
+  originRight: readOptionalIdRef(
+    records.idTable,
+    records.originRightRefs[index] ?? 0,
+  ),
+  everDeleted: (records.everDeleted[index] ?? 0) === 1,
+  prepareState: records.prepareStates[index] ?? 0,
+  run: readRun(records, index),
+});
+
+const decodeContent = (
+  records: CompactEngineSequenceRecords,
+  index: number,
+): string => {
+  const start = records.contentOffsets[index] ?? 0;
+  const end = records.contentOffsets[index + 1] ?? start;
+  return decoder.decode(records.contentBytes.subarray(start, end));
+};
+
+const readIdRef = (
+  table: ReadonlyArray<EventId>,
+  zeroBasedRef: number,
+): EventId => {
+  const value = table[zeroBasedRef];
+  if (value === undefined) {
+    throw new Error(`Invalid compact sequence id ref ${zeroBasedRef}`);
+  }
+  return value;
+};
+
+const readOptionalIdRef = (
+  table: ReadonlyArray<EventId>,
+  oneBasedRef: number,
+): EventId | null =>
+  oneBasedRef === 0 ? null : readIdRef(table, oneBasedRef - 1);
+
+const readRun = (
+  records: CompactEngineSequenceRecords,
+  index: number,
+): TypedRun | null => {
+  const replicaRef = records.runReplicaRefs[index] ?? 0;
+  if (replicaRef === 0) {
+    return null;
+  }
+  const replicaId = records.replicaTable[replicaRef - 1];
+  if (replicaId === undefined) {
+    throw new Error(`Invalid compact sequence replica ref ${replicaRef}`);
+  }
+  return {
+    replicaId,
+    startSequence: records.runStartSequences[index] ?? 0,
+  };
+};
 
 const cloneRun = (run: TypedRun | null): TypedRun | null =>
   run === null

--- a/packages/eg-walker/src/engine/sequence-records.ts
+++ b/packages/eg-walker/src/engine/sequence-records.ts
@@ -1,8 +1,11 @@
 export {
   itemFromRecord,
+  itemsFromCompactRecords,
   itemsFromRecords,
+  recordsFromCompactRecords,
   recordFromItem,
   recordsFromItems,
   sequenceFromRecords,
+  type CompactEngineSequenceRecords,
   type EngineSequenceRecord,
 } from "./internals/sequence-records";

--- a/packages/eg-walker/src/graph/internals/binary-io.ts
+++ b/packages/eg-walker/src/graph/internals/binary-io.ts
@@ -156,6 +156,15 @@ export class BinaryReader {
     return Array.from({ length }, () => this.readVarint());
   }
 
+  readVarintUint32Array(): Uint32Array {
+    const length = this.readVarint();
+    const values = new Uint32Array(length);
+    for (let index = 0; index < length; index++) {
+      values[index] = this.readVarint();
+    }
+    return values;
+  }
+
   readZigZagVarint(): number {
     return zigzagDecode(this.readVarint());
   }

--- a/packages/eg-walker/src/test/native-snapshot.test.ts
+++ b/packages/eg-walker/src/test/native-snapshot.test.ts
@@ -399,6 +399,34 @@ describe("EgWalkerReplica native snapshots", () => {
     expect(restored.getReplayStats().fullReplays).toBe(0);
   });
 
+  it("should restore decoded snapshots without materializing public runtime record arrays", () => {
+    // Arrange
+    const replica = new EgWalkerReplica("alice", "");
+    replica.insert(0, "A");
+    replica.insert(1, "B");
+    const codec = new NativeSnapshotCodec();
+    const decoded = codec.decode(codec.encode(replica.createNativeSnapshot()));
+    Object.defineProperty(decoded, "sequenceRecords", {
+      configurable: true,
+      get: () => {
+        throw new Error("sequenceRecords should stay compact on fast restore");
+      },
+    });
+    Object.defineProperty(decoded, "deleteTargets", {
+      configurable: true,
+      get: () => {
+        throw new Error("deleteTargets should stay compact on fast restore");
+      },
+    });
+
+    // Act
+    const restored = EgWalkerReplica.fromNativeSnapshot(decoded, "alice");
+
+    // Assert
+    expect(restored.getText()).toBe("AB");
+    expect(restored.getReplayStats().fullReplays).toBe(0);
+  });
+
   it("should reject snapshots whose frontier does not match the event graph", () => {
     // Arrange
     const replica = new EgWalkerReplica("alice", "");


### PR DESCRIPTION
## Summary

- Decode the existing native snapshot runtime-state section into compact sequence/delete-target columns instead of eagerly materializing public runtime record arrays.
- Keep the public sequenceRecords / deleteTargets snapshot shape as lazy compatibility getters.
- Teach EgWalkerReplica.fromNativeSnapshot and EgWalkerEngine.fromSnapshotState to consume compact runtime state directly on the fast restore path.

## Validation

- pnpm --filter @softmaple/eg-walker test src/test/native-snapshot.test.ts --run
- pnpm --filter @softmaple/eg-walker typecheck
- pnpm --filter @softmaple/eg-walker lint (passes with two pre-existing unrelated warnings in columnar-codec.test.ts and convergence-property.test.ts)
- pnpm --filter @softmaple/eg-walker test --run currently fails in src/test/property/serialize-roundtrip.property.test.ts with Decompressed inserted-content size mismatch; this is in the columnar codec property path and is outside this PR's changed files.

## Scope

This replacement PR was created after syncing native-snapshot-plan-1780567446 with git pull --ff-only. It intentionally contains only the core compact-restore changes.