### PR TITLE
fix(packages/eg-walker): compact native snapshot restore state

### DIFF
--- a/packages/eg-walker/src/core/native-snapshot.ts
+++ b/packages/eg-walker/src/core/native-snapshot.ts
@@ -65,6 +65,7 @@ export interface NativeSnapshotRuntimeState {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 const MAGIC_BYTES = encoder.encode(NATIVE_SNAPSHOT_FORMAT_VERSION);
+const RUNTIME_STATE_MAGIC = encoder.encode("EGWR2");
 const columnarCodec = new ColumnarEventGraphCodec();
 const decodedGraphSourceCache = new WeakMap<NativeSnapshot, () => EventGraph>();
 const decodedRuntimeStateCache = new WeakMap<
@@ -270,19 +271,44 @@ const encodeRuntimeState = (state: NativeRuntimeState): Uint8Array => {
   writeSequenceRecords(writer, state.sequenceRecords, idTable, replicaTable);
   writeDeleteTargets(writer, state.deleteTargets, idTable);
 
-  return writer.toUint8Array();
+  const payload = writer.toUint8Array();
+  const out = new Uint8Array(RUNTIME_STATE_MAGIC.byteLength + payload.length);
+  out.set(RUNTIME_STATE_MAGIC, 0);
+  out.set(payload, RUNTIME_STATE_MAGIC.byteLength);
+  return out;
 };
 
 const decodeRuntimeState = (bytes: Uint8Array): NativeSnapshotRuntimeState => {
-  const reader = new BinaryReader(bytes);
+  const isVersionedRuntimeState = hasPrefix(bytes, RUNTIME_STATE_MAGIC);
+  const reader = new BinaryReader(
+    isVersionedRuntimeState
+      ? bytes.subarray(RUNTIME_STATE_MAGIC.byteLength)
+      : bytes,
+  );
   const idTable = reader.readStringArray();
   const replicaTable = reader.readStringArray();
-  const sequenceRecords = readSequenceRecords(reader, idTable, replicaTable);
-  const deleteTargets = readDeleteTargets(reader, idTable);
+  const sequenceRecords = isVersionedRuntimeState
+    ? readDeltaSequenceRecords(reader, idTable, replicaTable)
+    : readLegacySequenceRecords(reader, idTable, replicaTable);
+  const deleteTargets = isVersionedRuntimeState
+    ? readDeltaDeleteTargets(reader, idTable)
+    : readLegacyDeleteTargets(reader, idTable);
   if (reader.remainingByteLength !== 0) {
     throw new Error("Invalid native snapshot runtime state: trailing bytes");
   }
   return { sequenceRecords, deleteTargets };
+};
+
+const hasPrefix = (bytes: Uint8Array, prefix: Uint8Array): boolean => {
+  if (bytes.byteLength < prefix.byteLength) {
+    return false;
+  }
+  for (let index = 0; index < prefix.byteLength; index++) {
+    if (bytes[index] !== prefix[index]) {
+      return false;
+    }
+  }
+  return true;
 };
 
 interface StringTable {
@@ -339,28 +365,28 @@ const writeSequenceRecords = (
   replicaTable: StringTable,
 ): void => {
   writer.writeVarint(records.length);
-  writeMappedVarintArray(writer, records, (record) =>
+  writeMappedZigZagDeltaArray(writer, records, (record) =>
     idIndex(idTable, record.id),
   );
-  writeMappedVarintArray(writer, records, (record) =>
+  writeMappedZigZagDeltaArray(writer, records, (record) =>
     idIndex(idTable, record.eventId),
   );
-  writeMappedVarintArray(writer, records, (record) =>
+  writeMappedZigZagDeltaArray(writer, records, (record) =>
     optionalIdIndex(idTable, record.originLeft),
   );
-  writeMappedVarintArray(writer, records, (record) =>
+  writeMappedZigZagDeltaArray(writer, records, (record) =>
     optionalIdIndex(idTable, record.originRight),
   );
   writeMappedVarintArray(writer, records, (record) =>
     record.everDeleted ? 1 : 0,
   );
   writeMappedVarintArray(writer, records, (record) => record.prepareState);
-  writeMappedVarintArray(writer, records, (record) =>
+  writeMappedZigZagDeltaArray(writer, records, (record) =>
     record.run === null
       ? 0
       : replicaIndex(replicaTable, record.run.replicaId) + 1,
   );
-  writeMappedVarintArray(
+  writeMappedZigZagDeltaArray(
     writer,
     records,
     (record) => record.run?.startSequence ?? 0,
@@ -379,7 +405,86 @@ const writeMappedVarintArray = <T>(
   }
 };
 
-const readSequenceRecords = (
+const writeMappedZigZagDeltaArray = <T>(
+  writer: BinaryWriter,
+  values: ReadonlyArray<T>,
+  mapValue: (value: T) => number,
+): void => {
+  writer.writeVarint(values.length);
+  let previous = 0;
+  for (const value of values) {
+    const next = mapValue(value);
+    writer.writeZigZagVarint(next - previous);
+    previous = next;
+  }
+};
+
+const readDeltaSequenceRecords = (
+  reader: BinaryReader,
+  idTable: ReadonlyArray<string>,
+  replicaTable: ReadonlyArray<string>,
+): CompactEngineSequenceRecords => {
+  const count = reader.readVarint();
+  const idRefs = expectColumnLength(
+    reader.readZigZagDeltaUint32Array(),
+    count,
+    "record ids",
+  );
+  const eventIds = expectColumnLength(
+    reader.readZigZagDeltaUint32Array(),
+    count,
+    "record event ids",
+  );
+  const originLefts = expectColumnLength(
+    reader.readZigZagDeltaUint32Array(),
+    count,
+    "record originLeft ids",
+  );
+  const originRights = expectColumnLength(
+    reader.readZigZagDeltaUint32Array(),
+    count,
+    "record originRight ids",
+  );
+  const everDeleted = expectColumnLength(
+    reader.readVarintUint32Array(),
+    count,
+    "record deletion flags",
+  );
+  const prepareStates = expectColumnLength(
+    reader.readVarintUint32Array(),
+    count,
+    "record prepare states",
+  );
+  const runReplicas = expectColumnLength(
+    reader.readZigZagDeltaUint32Array(),
+    count,
+    "record run replicas",
+  );
+  const runStartSequences = expectColumnLength(
+    reader.readZigZagDeltaUint32Array(),
+    count,
+    "record run start sequences",
+  );
+  const content = readContentBlob(reader, count);
+
+  return {
+    count,
+    idTable,
+    replicaTable,
+    idRefs,
+    eventIdRefs: eventIds,
+    originLeftRefs: originLefts,
+    originRightRefs: originRights,
+    everDeleted,
+    prepareStates,
+    runReplicaRefs: runReplicas,
+    runStartSequences,
+    contentOffsets: content.offsets,
+    contentBytes: content.bytes,
+  };
+};
+
+const readLegacySequenceRecords = (
   reader: BinaryReader,
   idTable: ReadonlyArray<string>,
   replicaTable: ReadonlyArray<string>,
@@ -496,15 +601,47 @@ const writeDeleteTargets = (
   idTable: StringTable,
 ): void => {
   writer.writeVarint(targets.length);
+  writeMappedZigZagDeltaArray(writer, targets, (target) =>
+    idIndex(idTable, target.deleteEventId),
+  );
+  const offsets: number[] = [0];
+  const targetRefs: number[] = [];
   for (const target of targets) {
-    writer.writeVarint(idIndex(idTable, target.deleteEventId));
-    writeMappedVarintArray(writer, target.targetIds, (targetId) =>
-      idIndex(idTable, targetId),
-    );
+    for (const targetId of target.targetIds) {
+      targetRefs.push(idIndex(idTable, targetId));
+    }
+    offsets.push(targetRefs.length);
   }
+  writer.writeZigZagDeltaArray(offsets);
+  writer.writeZigZagDeltaArray(targetRefs);
 };
 
-const readDeleteTargets = (
+const readDeltaDeleteTargets = (
+  reader: BinaryReader,
+  idTable: ReadonlyArray<string>,
+): CompactDeleteTargetRecords => {
+  const count = reader.readVarint();
+  const deleteEventRefs = expectColumnLength(
+    reader.readZigZagDeltaUint32Array(),
+    count,
+    "delete target event ids",
+  );
+  const targetOffsets = expectColumnLength(
+    reader.readZigZagDeltaUint32Array(),
+    count + 1,
+    "delete target offsets",
+  );
+  const targetRefs = reader.readZigZagDeltaUint32Array();
+  validateDeleteTargetOffsets(targetOffsets, targetRefs.length);
+  return {
+    idTable,
+    deleteEventRefs,
+    targetOffsets,
+    targetRefs,
+  };
+};
+
+const readLegacyDeleteTargets = (
   reader: BinaryReader,
   idTable: ReadonlyArray<string>,
 ): CompactDeleteTargetRecords => {
@@ -527,6 +664,31 @@ const readDeleteTargets = (
     targetOffsets,
     targetRefs: Uint32Array.from(targetRefs),
   };
+};
+
+const validateDeleteTargetOffsets = (
+  offsets: Uint32Array,
+  targetCount: number,
+): void => {
+  if (offsets[0] !== 0) {
+    throw new Error(
+      "Invalid native snapshot runtime state: delete target offsets must start at zero",
+    );
+  }
+  let previous = 0;
+  for (const offset of offsets) {
+    if (offset < previous || offset > targetCount) {
+      throw new Error(
+        "Invalid native snapshot runtime state: delete target offset out of bounds",
+      );
+    }
+    previous = offset;
+  }
+  if (offsets[offsets.length - 1] !== targetCount) {
+    throw new Error(
+      "Invalid native snapshot runtime state: delete target offsets must end at target count",
+    );
+  }
 };
 
 const idIndex = (table: StringTable, value: string): number => {

--- a/packages/eg-walker/src/core/native-snapshot.ts
+++ b/packages/eg-walker/src/core/native-snapshot.ts
@@ -279,20 +279,48 @@ const encodeRuntimeState = (state: NativeRuntimeState): Uint8Array => {
 };
 
 const decodeRuntimeState = (bytes: Uint8Array): NativeSnapshotRuntimeState => {
-  const isVersionedRuntimeState = hasPrefix(bytes, RUNTIME_STATE_MAGIC);
-  const reader = new BinaryReader(
-    isVersionedRuntimeState
-      ? bytes.subarray(RUNTIME_STATE_MAGIC.byteLength)
-      : bytes,
-  );
+  if (hasPrefix(bytes, RUNTIME_STATE_MAGIC)) {
+    try {
+      return decodeVersionedRuntimeState(
+        bytes.subarray(RUNTIME_STATE_MAGIC.byteLength),
+      );
+    } catch {
+      // Legacy runtime-state is unversioned and can legally begin with EGWR2.
+    }
+  }
+  return decodeLegacyRuntimeState(bytes);
+};
+
+const decodeVersionedRuntimeState = (
+  bytes: Uint8Array,
+): NativeSnapshotRuntimeState => {
+  const reader = new BinaryReader(bytes);
   const idTable = reader.readStringArray();
   const replicaTable = reader.readStringArray();
-  const sequenceRecords = isVersionedRuntimeState
-    ? readDeltaSequenceRecords(reader, idTable, replicaTable)
-    : readLegacySequenceRecords(reader, idTable, replicaTable);
-  const deleteTargets = isVersionedRuntimeState
-    ? readDeltaDeleteTargets(reader, idTable)
-    : readLegacyDeleteTargets(reader, idTable);
+  const sequenceRecords = readDeltaSequenceRecords(
+    reader,
+    idTable,
+    replicaTable,
+  );
+  const deleteTargets = readDeltaDeleteTargets(reader, idTable);
+  if (reader.remainingByteLength !== 0) {
+    throw new Error("Invalid native snapshot runtime state: trailing bytes");
+  }
+  return { sequenceRecords, deleteTargets };
+};
+
+const decodeLegacyRuntimeState = (
+  bytes: Uint8Array,
+): NativeSnapshotRuntimeState => {
+  const reader = new BinaryReader(bytes);
+  const idTable = reader.readStringArray();
+  const replicaTable = reader.readStringArray();
+  const sequenceRecords = readLegacySequenceRecords(
+    reader,
+    idTable,
+    replicaTable,
+  );
+  const deleteTargets = readLegacyDeleteTargets(reader, idTable);
   if (reader.remainingByteLength !== 0) {
     throw new Error("Invalid native snapshot runtime state: trailing bytes");
   }

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -22,6 +22,7 @@ import {
   type GenerateOptions,
   type IncrementalApplyResult,
 } from "./internals/engine-types";
+import { EventItemIndex } from "./internals/event-item-index";
 import {
   applyInsert,
   type InsertHandlerDeps,
@@ -71,7 +72,7 @@ export class EgWalkerEngine {
   private readonly eventsById = new Map<EventId, GraphEvent>();
   private readonly eventOrder = new Map<EventId, number>();
   private graph = new EventGraph();
-  private readonly eventItems = new Map<EventId, EventId[]>();
+  private readonly eventItems = new EventItemIndex();
   private readonly itemsById = new Map<EventId, AugmentedCRDTItem>();
   private readonly originLeftIndex = new OriginLeftIndex();
   private readonly deleteTargets = new DeleteTargetIndex();
@@ -396,27 +397,13 @@ export class EgWalkerEngine {
 
   private trackEventItems(item: AugmentedCRDTItem): void {
     if (item.run !== null) {
-      for (let offset = 0; offset < item.content.length; offset++) {
-        this.addEventItem(
-          `${item.run.replicaId}:${item.run.startSequence + offset}`,
-          item.id,
-        );
-      }
+      this.eventItems.registerRunItem(item);
       return;
     }
 
     if (item.eventId !== PLACEHOLDER_EVENT_ID) {
-      this.addEventItem(item.eventId, item.id);
+      this.eventItems.add(item.eventId, item.id);
     }
-  }
-
-  private addEventItem(eventId: EventId, itemId: EventId): void {
-    const items = this.eventItems.get(eventId);
-    if (items) {
-      items.push(itemId);
-      return;
-    }
-    this.eventItems.set(eventId, [itemId]);
   }
 
   private apply(event: GraphEvent): ExternalOperation[] {

--- a/packages/eg-walker/src/engine/internals/event-item-index.ts
+++ b/packages/eg-walker/src/engine/internals/event-item-index.ts
@@ -122,12 +122,8 @@ export class EventItemIndex {
     let candidate: AugmentedCRDTItem | null = null;
     while (low <= high) {
       const mid = low + Math.floor((high - low) / 2);
-      const item = items[mid];
-      const start = item?.run?.startSequence;
-      if (item === undefined || start === undefined) {
-        high = mid - 1;
-        continue;
-      }
+      const item = items[mid]!;
+      const start = item.run!.startSequence;
       if (start <= sequence) {
         candidate = item;
         low = mid + 1;
@@ -150,8 +146,7 @@ export class EventItemIndex {
       return;
     }
     items.sort(
-      (left, right) =>
-        (left.run?.startSequence ?? 0) - (right.run?.startSequence ?? 0),
+      (left, right) => left.run!.startSequence - right.run!.startSequence,
     );
     this.sortedRunReplicas.add(replicaId);
   }

--- a/packages/eg-walker/src/engine/internals/event-item-index.ts
+++ b/packages/eg-walker/src/engine/internals/event-item-index.ts
@@ -1,0 +1,158 @@
+import { parseEventId } from "../../graph/event-id";
+import type { EventId } from "../../types";
+import type { AugmentedCRDTItem } from "./engine-types";
+
+type DirectEventItems = EventId | EventId[];
+
+/**
+ * Event-id -> CRDT item lookup used by retreat / advance.
+ *
+ * Normal multi-character insert events keep direct map entries because one
+ * event can own multiple CRDT items. Coalesced typed-run records are cheaper:
+ * a record spans a contiguous `${replicaId}:${sequence}` range, so snapshot
+ * restore can register the range once instead of materializing one map entry
+ * and one string per character event.
+ */
+export class EventItemIndex {
+  private readonly direct = new Map<EventId, DirectEventItems>();
+  private readonly runItemsByReplica = new Map<string, AugmentedCRDTItem[]>();
+  private sortedRunReplicas = new Set<string>();
+
+  clear(): void {
+    this.direct.clear();
+    this.runItemsByReplica.clear();
+    this.sortedRunReplicas.clear();
+  }
+
+  set(eventId: EventId, itemIds: EventId[]): void {
+    this.direct.set(eventId, itemIds.length === 1 ? itemIds[0]! : itemIds);
+  }
+
+  add(eventId: EventId, itemId: EventId): void {
+    const items = this.direct.get(eventId);
+    if (items === undefined) {
+      this.direct.set(eventId, itemId);
+      return;
+    }
+    if (Array.isArray(items)) {
+      items.push(itemId);
+      return;
+    }
+    this.direct.set(eventId, [items, itemId]);
+  }
+
+  get(eventId: EventId): EventId[] | undefined {
+    const direct = this.direct.get(eventId);
+    if (direct !== undefined) {
+      return Array.isArray(direct) ? direct : [direct];
+    }
+
+    const parsed = parseEventId(eventId);
+    if (parsed === null) {
+      return undefined;
+    }
+
+    const item = this.findRunItem(parsed.replicaId, parsed.sequence);
+    return item ? [item.id] : undefined;
+  }
+
+  registerRunItem(item: AugmentedCRDTItem): void {
+    if (item.run === null) {
+      return;
+    }
+    const items = this.runItemsByReplica.get(item.run.replicaId);
+    if (items) {
+      items.push(item);
+      this.sortedRunReplicas.delete(item.run.replicaId);
+      return;
+    }
+    this.runItemsByReplica.set(item.run.replicaId, [item]);
+    this.sortedRunReplicas.add(item.run.replicaId);
+  }
+
+  rewriteDirectReferencesForRunSplit(
+    left: AugmentedCRDTItem,
+    right: AugmentedCRDTItem,
+    offsetInRecord: number,
+    leftOriginalLength: number,
+  ): void {
+    if (left.run === null) {
+      return;
+    }
+    const runStart = left.run.startSequence + offsetInRecord;
+    const runEnd = left.run.startSequence + leftOriginalLength;
+    for (let sequence = runStart; sequence < runEnd; sequence++) {
+      const eventId: EventId = `${left.run.replicaId}:${sequence}`;
+      const direct = this.direct.get(eventId);
+      if (direct === undefined) {
+        continue;
+      }
+      if (!Array.isArray(direct)) {
+        if (direct === left.id) {
+          this.direct.set(eventId, right.id);
+        }
+        continue;
+      }
+      let mutated = false;
+      const next = direct.map((id) => {
+        if (id === left.id) {
+          mutated = true;
+          return right.id;
+        }
+        return id;
+      });
+      if (mutated) {
+        this.direct.set(eventId, next);
+      }
+    }
+  }
+
+  private findRunItem(
+    replicaId: string,
+    sequence: number,
+  ): AugmentedCRDTItem | null {
+    const items = this.runItemsByReplica.get(replicaId);
+    if (!items || items.length === 0) {
+      return null;
+    }
+    this.sortRunItems(replicaId, items);
+
+    let low = 0;
+    let high = items.length - 1;
+    let candidate: AugmentedCRDTItem | null = null;
+    while (low <= high) {
+      const mid = low + Math.floor((high - low) / 2);
+      const item = items[mid];
+      const start = item?.run?.startSequence;
+      if (item === undefined || start === undefined) {
+        high = mid - 1;
+        continue;
+      }
+      if (start <= sequence) {
+        candidate = item;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    if (
+      candidate?.run &&
+      sequence < candidate.run.startSequence + candidate.content.length
+    ) {
+      return candidate;
+    }
+    return null;
+  }
+
+  private sortRunItems(replicaId: string, items: AugmentedCRDTItem[]): void {
+    if (this.sortedRunReplicas.has(replicaId)) {
+      return;
+    }
+    items.sort(
+      (left, right) =>
+        (left.run?.startSequence ?? 0) - (right.run?.startSequence ?? 0),
+    );
+    this.sortedRunReplicas.add(replicaId);
+  }
+}

--- a/packages/eg-walker/src/engine/internals/insert-handler.ts
+++ b/packages/eg-walker/src/engine/internals/insert-handler.ts
@@ -3,6 +3,7 @@ import { parseEventId } from "../../graph/event-id";
 import type { EventId, ExternalOperation, GraphEvent } from "../../types";
 import type { IndexedSequence } from "../indexed-sequence";
 import type { AugmentedCRDTItem, TypedRun } from "./engine-types";
+import { EventItemIndex } from "./event-item-index";
 import { OriginLeftIndex } from "./origin-left-index";
 import { PendingInsertBuffer } from "./pending-insert-buffer";
 import { RecordSplitter } from "./record-splitter";
@@ -17,7 +18,7 @@ type InsertOperation = Extract<
 export interface InsertHandlerDeps {
   readonly sequence: IndexedSequence<AugmentedCRDTItem>;
   readonly itemsById: Map<EventId, AugmentedCRDTItem>;
-  readonly eventItems: Map<EventId, EventId[]>;
+  readonly eventItems: EventItemIndex;
   readonly originLeftIndex: OriginLeftIndex;
   readonly recordSplitter: RecordSplitter;
   readonly pendingInsert: PendingInsertBuffer;

--- a/packages/eg-walker/src/engine/internals/origin-left-index.ts
+++ b/packages/eg-walker/src/engine/internals/origin-left-index.ts
@@ -1,6 +1,8 @@
 import type { EventId } from "../../types";
 import type { AugmentedCRDTItem } from "./engine-types";
 
+type OriginLeftRefs = EventId | Set<EventId>;
+
 /**
  * Reverse index: `target item id` -> set of item ids whose `originLeft`
  * points at it. Maintained alongside the engine's `itemsById` map so
@@ -17,7 +19,7 @@ import type { AugmentedCRDTItem } from "./engine-types";
  * back off and place a fresh item instead.
  */
 export class OriginLeftIndex {
-  private readonly refs = new Map<EventId, Set<EventId>>();
+  private readonly refs = new Map<EventId, OriginLeftRefs>();
 
   clear(): void {
     this.refs.clear();
@@ -27,14 +29,23 @@ export class OriginLeftIndex {
     if (originLeft === null) {
       return;
     }
-    const set = this.refs.get(originLeft) ?? new Set<EventId>();
-    set.add(itemId);
-    this.refs.set(originLeft, set);
+    const refs = this.refs.get(originLeft);
+    if (refs === undefined) {
+      this.refs.set(originLeft, itemId);
+      return;
+    }
+    if (typeof refs === "string") {
+      if (refs !== itemId) {
+        this.refs.set(originLeft, new Set([refs, itemId]));
+      }
+      return;
+    }
+    refs.add(itemId);
   }
 
   has(itemId: EventId): boolean {
     const refs = this.refs.get(itemId);
-    return refs !== undefined && refs.size > 0;
+    return refs !== undefined && (typeof refs === "string" || refs.size > 0);
   }
 
   rewriteReferences(
@@ -43,21 +54,38 @@ export class OriginLeftIndex {
     itemsById: ReadonlyMap<EventId, AugmentedCRDTItem>,
   ): void {
     const refs = this.refs.get(oldOriginLeft);
-    if (!refs || refs.size === 0) {
+    if (refs === undefined) {
       return;
     }
     this.refs.delete(oldOriginLeft);
-    const merged = this.refs.get(newOriginLeft) ?? new Set<EventId>();
-    for (const itemId of refs) {
+    const merged = this.refs.get(newOriginLeft);
+    const next = new Set<EventId>(
+      merged === undefined
+        ? []
+        : typeof merged === "string"
+          ? [merged]
+          : merged,
+    );
+    for (const itemId of refsToIterable(refs)) {
       const item = itemsById.get(itemId);
       if (!item || item.originLeft !== oldOriginLeft) {
         continue;
       }
       item.originLeft = newOriginLeft;
-      merged.add(itemId);
+      next.add(itemId);
     }
-    if (merged.size > 0) {
-      this.refs.set(newOriginLeft, merged);
+    if (next.size === 1) {
+      const [only] = next;
+      if (only !== undefined) {
+        this.refs.set(newOriginLeft, only);
+      }
+      return;
+    }
+    if (next.size > 1) {
+      this.refs.set(newOriginLeft, next);
     }
   }
 }
+
+const refsToIterable = (refs: OriginLeftRefs): Iterable<EventId> =>
+  typeof refs === "string" ? [refs] : refs;

--- a/packages/eg-walker/src/engine/internals/record-splitter.ts
+++ b/packages/eg-walker/src/engine/internals/record-splitter.ts
@@ -3,12 +3,13 @@ import type { EventId } from "../../types";
 import type { IndexedSequence } from "../indexed-sequence";
 import { DeleteTargetIndex } from "./delete-target-index";
 import { PLACEHOLDER_EVENT_ID, type AugmentedCRDTItem } from "./engine-types";
+import { EventItemIndex } from "./event-item-index";
 import { OriginLeftIndex } from "./origin-left-index";
 
 interface RecordSplitterDeps {
   readonly sequence: IndexedSequence<AugmentedCRDTItem>;
   readonly itemsById: Map<EventId, AugmentedCRDTItem>;
-  readonly eventItems: Map<EventId, EventId[]>;
+  readonly eventItems: EventItemIndex;
   readonly originLeftIndex: OriginLeftIndex;
   readonly deleteTargets: DeleteTargetIndex;
   readonly nextPlaceholderId: () => EventId;
@@ -221,30 +222,13 @@ export class RecordSplitter {
     if (left.run === null) {
       return;
     }
-    // Each sequence in `[startSequence + offsetInRecord, startSequence + N)`
-    // is a single-character INSERT whose `eventItems` entry currently lists
-    // `left.id`. Repoint those entries to `right.id` so retreat / advance
-    // visit the half that actually holds the slice.
-    const runStart = left.run.startSequence + offsetInRecord;
-    const runEnd = left.run.startSequence + leftOriginalLength;
     const { eventItems } = this.deps;
-    for (let sequence = runStart; sequence < runEnd; sequence++) {
-      const eventId: EventId = `${left.run.replicaId}:${sequence}`;
-      const items = eventItems.get(eventId);
-      if (!items) {
-        continue;
-      }
-      let mutated = false;
-      const next = items.map((id) => {
-        if (id === left.id) {
-          mutated = true;
-          return right.id;
-        }
-        return id;
-      });
-      if (mutated) {
-        eventItems.set(eventId, next);
-      }
-    }
+    eventItems.rewriteDirectReferencesForRunSplit(
+      left,
+      right,
+      offsetInRecord,
+      leftOriginalLength,
+    );
+    eventItems.registerRunItem(right);
   }
 }

--- a/packages/eg-walker/src/graph/internals/binary-io.ts
+++ b/packages/eg-walker/src/graph/internals/binary-io.ts
@@ -181,6 +181,19 @@ export class BinaryReader {
     return values;
   }
 
+  readZigZagDeltaUint32Array(): Uint32Array {
+    const values = this.readZigZagDeltaArray();
+    const out = new Uint32Array(values.length);
+    for (let index = 0; index < values.length; index++) {
+      const value = values[index] ?? 0;
+      if (!Number.isInteger(value) || value < 0 || value > 0xffffffff) {
+        throw new Error(`Invalid uint32 delta value ${value}`);
+      }
+      out[index] = value;
+    }
+    return out;
+  }
+
   readString(): string {
     return decodeText(this.readBytes(this.readVarint()));
   }

--- a/packages/eg-walker/src/test/native-snapshot.test.ts
+++ b/packages/eg-walker/src/test/native-snapshot.test.ts
@@ -392,6 +392,43 @@ describe("EgWalkerReplica native snapshots", () => {
     expect(restored.getReplayStats().fullReplays).toBe(0);
   });
 
+  it("should fall back to legacy runtime state when legacy bytes collide with EGWR2", () => {
+    // Arrange
+    const header = {
+      formatVersion: NATIVE_SNAPSHOT_FORMAT_VERSION,
+      text: "",
+      initialText: "",
+      currentVersion: [],
+      eventCount: 0,
+      nextSequenceNumber: 0,
+      checkpoints: [],
+    };
+    const runtimeBytes = encodeCollidingLegacyRuntimeState();
+    const body = new BinaryWriter();
+    body.writeBytes(new TextEncoder().encode(JSON.stringify(header)));
+    body.writeBytes(
+      new ColumnarEventGraphCodec().encodeBinary(new EventGraph()),
+    );
+    body.writeBytes(runtimeBytes);
+    const payload = body.toUint8Array();
+    const bytes = new Uint8Array(
+      NATIVE_SNAPSHOT_FORMAT_VERSION.length + payload.byteLength,
+    );
+    bytes.set(new TextEncoder().encode(NATIVE_SNAPSHOT_FORMAT_VERSION));
+    bytes.set(payload, NATIVE_SNAPSHOT_FORMAT_VERSION.length);
+    const codec = new NativeSnapshotCodec();
+
+    // Act
+    const decoded = codec.decode(bytes);
+    const restored = EgWalkerReplica.fromNativeSnapshot(decoded, "alice");
+
+    // Assert
+    expect(new TextDecoder().decode(runtimeBytes.subarray(0, 5))).toBe("EGWR2");
+    expect(decoded.sequenceRecords).toEqual([]);
+    expect(decoded.deleteTargets).toEqual([]);
+    expect(restored.getText()).toBe("");
+  });
+
   it("should persist delete targets for restored engine resume state", () => {
     // Arrange
     const replica = new EgWalkerReplica("alice", "");
@@ -618,6 +655,22 @@ const encodeLegacyRuntimeState = (
       target.targetIds.map((targetId) => idTable.ids.get(targetId) ?? 0),
     );
   }
+  return writer.toUint8Array();
+};
+
+const encodeCollidingLegacyRuntimeState = (): Uint8Array => {
+  const writer = new BinaryWriter();
+  writer.writeStringArray([
+    `WR2${"x".repeat(68)}`,
+    ...Array.from({ length: 68 }, (_, index) => `id-${index}`),
+  ]);
+  writer.writeStringArray([]);
+  writer.writeVarint(0);
+  for (let index = 0; index < 8; index++) {
+    writer.writeVarintArray([]);
+  }
+  writeLegacyContentBlob(writer, []);
+  writer.writeVarint(0);
   return writer.toUint8Array();
 };
 

--- a/packages/eg-walker/src/test/native-snapshot.test.ts
+++ b/packages/eg-walker/src/test/native-snapshot.test.ts
@@ -6,7 +6,14 @@ import {
 } from "../core/native-snapshot";
 import { EgWalkerReplica } from "../core/replica";
 import { REPLAY_SOURCE } from "../constants/replay-source";
-import { sequenceFromRecords } from "../engine/sequence-records";
+import {
+  EgWalkerEngine,
+  type DeleteTargetRecord,
+} from "../engine/eg-walker-engine";
+import {
+  sequenceFromRecords,
+  type EngineSequenceRecord,
+} from "../engine/sequence-records";
 import { EventGraph } from "../graph/event-graph";
 import { ColumnarEventGraphCodec } from "../graph/columnar-codec";
 import { BinaryReader, BinaryWriter } from "../graph/internals/binary-io";
@@ -269,6 +276,30 @@ describe("EgWalkerReplica native snapshots", () => {
     ]);
   });
 
+  it("should encode runtime state with a versioned compact binary section", () => {
+    // Arrange
+    const replica = new EgWalkerReplica("alice", "");
+    replica.insert(0, "A");
+    replica.insert(1, "B");
+    replica.delete(0, 1);
+    const codec = new NativeSnapshotCodec();
+    const snapshot = replica.createNativeSnapshot();
+
+    // Act
+    const bytes = codec.encode(snapshot);
+    const body = bytes.subarray(NATIVE_SNAPSHOT_FORMAT_VERSION.length);
+    const reader = new BinaryReader(body);
+    reader.readBytes(reader.readVarint());
+    reader.readBytes(reader.readVarint());
+    const runtimeBytes = reader.readBytes(reader.readVarint());
+    const decoded = codec.decode(bytes);
+
+    // Assert
+    expect(new TextDecoder().decode(runtimeBytes.subarray(0, 5))).toBe("EGWR2");
+    expect(decoded.sequenceRecords).toEqual(snapshot.sequenceRecords);
+    expect(decoded.deleteTargets).toEqual(snapshot.deleteTargets);
+  });
+
   it("should decode legacy length-prefixed snapshots with JSON runtime records", () => {
     // Arrange
     const replica = new EgWalkerReplica("alice", "");
@@ -309,6 +340,55 @@ describe("EgWalkerReplica native snapshots", () => {
     // Assert
     expect(decoded.sequenceRecords).toEqual(snapshot.sequenceRecords);
     expect(restored.getText()).toBe("AB");
+    expect(restored.getReplayStats().fullReplays).toBe(0);
+  });
+
+  it("should decode legacy binary runtime state without the version prefix", () => {
+    // Arrange
+    const replica = new EgWalkerReplica("alice", "");
+    replica.insert(0, "A");
+    replica.insert(1, "B");
+    replica.delete(0, 1);
+    const snapshot = replica.createNativeSnapshot();
+    const header = {
+      formatVersion: snapshot.formatVersion,
+      text: snapshot.text,
+      initialText: snapshot.initialText,
+      currentVersion: snapshot.currentVersion,
+      eventCount: snapshot.eventCount,
+      nextSequenceNumber: snapshot.nextSequenceNumber,
+      metadata: snapshot.metadata,
+      checkpoints: snapshot.checkpoints,
+    };
+    const body = new BinaryWriter();
+    body.writeBytes(new TextEncoder().encode(JSON.stringify(header)));
+    body.writeBytes(
+      new ColumnarEventGraphCodec().encodeBinary(
+        EventGraph.deserialize(snapshot.eventGraph),
+      ),
+    );
+    body.writeBytes(
+      encodeLegacyRuntimeState(
+        snapshot.sequenceRecords,
+        snapshot.deleteTargets,
+      ),
+    );
+    const payload = body.toUint8Array();
+    const bytes = new Uint8Array(
+      NATIVE_SNAPSHOT_FORMAT_VERSION.length + payload.byteLength,
+    );
+    bytes.set(new TextEncoder().encode(NATIVE_SNAPSHOT_FORMAT_VERSION));
+    bytes.set(payload, NATIVE_SNAPSHOT_FORMAT_VERSION.length);
+    const codec = new NativeSnapshotCodec();
+
+    // Act
+    const decoded = codec.decode(bytes);
+    const restored = EgWalkerReplica.fromNativeSnapshot(decoded, "alice");
+
+    // Assert
+    expect(decoded.sequenceRecords).toEqual(snapshot.sequenceRecords);
+    expect(decoded.deleteTargets).toEqual(snapshot.deleteTargets);
+    expect(restored.getText()).toBe("B");
     expect(restored.getReplayStats().fullReplays).toBe(0);
   });
 
@@ -427,6 +507,43 @@ describe("EgWalkerReplica native snapshots", () => {
     expect(restored.getReplayStats().fullReplays).toBe(0);
   });
 
+  it("should use restored typed-run event ranges for retreating concurrent edits", () => {
+    // Arrange
+    const replica = new EgWalkerReplica("alice", "");
+    replica.insert(0, "a");
+    replica.insert(1, "b");
+    replica.insert(2, "c");
+    replica.insert(3, "d");
+    replica.insert(4, "e");
+    replica.insert(5, "f");
+    const snapshot = replica.createNativeSnapshot();
+    const graph = EventGraph.deserialize(snapshot.eventGraph);
+    const remote = {
+      id: "bob:0",
+      parentVersion: new Set(["alice:2"]),
+      operation: { type: "insert" as const, index: 3, text: "B" },
+      timestamp: 7,
+    };
+    graph.addEvent(remote);
+    const engine = EgWalkerEngine.fromSnapshotState({
+      graph,
+      currentVersion: new Set(snapshot.currentVersion),
+      text: snapshot.text,
+      sequenceRecords: snapshot.sequenceRecords,
+      deleteTargets: snapshot.deleteTargets,
+    });
+
+    // Act
+    const result = engine.applyEvent(remote, graph);
+
+    // Assert
+    expect(result.text).toContain("B");
+    expect(engine.getStats().retreatCount).toBeGreaterThan(0);
+    expect(engine.getStats().sequenceRecordCount).toBeGreaterThan(
+      snapshot.sequenceRecords.length,
+    );
+  });
+
   it("should reject snapshots whose frontier does not match the event graph", () => {
     // Arrange
     const replica = new EgWalkerReplica("alice", "");
@@ -452,3 +569,119 @@ describe("EgWalkerReplica native snapshots", () => {
     );
   });
 });
+
+const encodeLegacyRuntimeState = (
+  sequenceRecords: ReadonlyArray<EngineSequenceRecord>,
+  deleteTargets: ReadonlyArray<DeleteTargetRecord>,
+): Uint8Array => {
+  const idTable = createRuntimeIdTable(sequenceRecords, deleteTargets);
+  const replicaTable = createRuntimeReplicaTable(sequenceRecords);
+  const writer = new BinaryWriter();
+  writer.writeStringArray(idTable.values);
+  writer.writeStringArray(replicaTable.values);
+  writer.writeVarint(sequenceRecords.length);
+  writer.writeVarintArray(
+    sequenceRecords.map((record) => idTable.ids.get(record.id) ?? 0),
+  );
+  writer.writeVarintArray(
+    sequenceRecords.map((record) => idTable.ids.get(record.eventId) ?? 0),
+  );
+  writer.writeVarintArray(
+    sequenceRecords.map((record) =>
+      optionalRuntimeId(idTable, record.originLeft),
+    ),
+  );
+  writer.writeVarintArray(
+    sequenceRecords.map((record) =>
+      optionalRuntimeId(idTable, record.originRight),
+    ),
+  );
+  writer.writeVarintArray(
+    sequenceRecords.map((record) => (record.everDeleted ? 1 : 0)),
+  );
+  writer.writeVarintArray(sequenceRecords.map((record) => record.prepareState));
+  writer.writeVarintArray(
+    sequenceRecords.map((record) =>
+      record.run === null
+        ? 0
+        : (replicaTable.ids.get(record.run.replicaId) ?? 0) + 1,
+    ),
+  );
+  writer.writeVarintArray(
+    sequenceRecords.map((record) => record.run?.startSequence ?? 0),
+  );
+  writeLegacyContentBlob(writer, sequenceRecords);
+  writer.writeVarint(deleteTargets.length);
+  for (const target of deleteTargets) {
+    writer.writeVarint(idTable.ids.get(target.deleteEventId) ?? 0);
+    writer.writeVarintArray(
+      target.targetIds.map((targetId) => idTable.ids.get(targetId) ?? 0),
+    );
+  }
+  return writer.toUint8Array();
+};
+
+const createRuntimeIdTable = (
+  sequenceRecords: ReadonlyArray<EngineSequenceRecord>,
+  deleteTargets: ReadonlyArray<DeleteTargetRecord>,
+): { readonly values: string[]; readonly ids: ReadonlyMap<string, number> } => {
+  const ids = new Map<string, number>();
+  const values: string[] = [];
+  const add = (value: string | null): void => {
+    if (value === null || ids.has(value)) {
+      return;
+    }
+    ids.set(value, values.length);
+    values.push(value);
+  };
+  for (const record of sequenceRecords) {
+    add(record.id);
+    add(record.eventId);
+    add(record.originLeft);
+    add(record.originRight);
+  }
+  for (const target of deleteTargets) {
+    add(target.deleteEventId);
+    target.targetIds.forEach(add);
+  }
+  return { values, ids };
+};
+
+const createRuntimeReplicaTable = (
+  sequenceRecords: ReadonlyArray<EngineSequenceRecord>,
+): { readonly values: string[]; readonly ids: ReadonlyMap<string, number> } => {
+  const ids = new Map<string, number>();
+  const values: string[] = [];
+  for (const record of sequenceRecords) {
+    if (record.run === null || ids.has(record.run.replicaId)) {
+      continue;
+    }
+    ids.set(record.run.replicaId, values.length);
+    values.push(record.run.replicaId);
+  }
+  return { values, ids };
+};
+
+const optionalRuntimeId = (
+  table: { readonly ids: ReadonlyMap<string, number> },
+  value: string | null,
+): number => (value === null ? 0 : (table.ids.get(value) ?? 0) + 1);
+
+const writeLegacyContentBlob = (
+  writer: BinaryWriter,
+  records: ReadonlyArray<EngineSequenceRecord>,
+): void => {
+  const encoder = new TextEncoder();
+  const encoded = records.map((record) => encoder.encode(record.content));
+  const offsets: number[] = [0];
+  for (const content of encoded) {
+    offsets.push(offsets[offsets.length - 1]! + content.byteLength);
+  }
+  const blob = new Uint8Array(offsets[offsets.length - 1]!);
+  encoded.reduce((offset, content) => {
+    blob.set(content, offset);
+    return offset + content.byteLength;
+  }, 0);
+  writer.writeZigZagDeltaArray(offsets);
+  writer.writeBytes(blob);
+};


### PR DESCRIPTION
## Summary

- Keep decoded native snapshot restore on compact runtime state while preserving lazy public compatibility getters.
- Add a versioned `EGWR2` runtime-state section with id/replica tables, delta-varint columns, UTF-8 content blobs, and flat delete-target refs/offsets.
- Avoid per-character `eventItems` materialization for restored typed-run records and reduce single-reference `originLeft` index allocation.

## Validation

- `pnpm --filter @softmaple/eg-walker test`
- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker lint` (passes with two pre-existing unused-import warnings in unrelated test files)

## Notes

This PR intentionally excludes the local benchmark/docs worktree files and `.pnpm-store/`; those remain uncommitted locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced versioned ("EGWR2") encoding for native snapshot runtime state with delta/zigzag compression to improve efficiency while maintaining backward compatibility with legacy formats.
  * Added comprehensive structural validation for snapshot data integrity.

* **Tests**
  * Expanded native snapshot codec test coverage to verify encoding/decoding behavior across current and legacy formats.

* **Refactor**
  * Restructured internal event item indexing system for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->