### PR TITLE
perf(packages/eg-walker): reduce snapshot restore materialization

### DIFF
--- a/packages/eg-walker/src/core/native-snapshot.ts
+++ b/packages/eg-walker/src/core/native-snapshot.ts
@@ -135,16 +135,16 @@ const decodeLengthPrefixedNativeSnapshotBody = (
     const headerPayload = validateNativeSnapshotHeaderPayload(
       JSON.parse(
         decoder.decode(
-          decodeCompressedSection(reader.readBytes(reader.readVarint())),
+          decodeCompressedSection(reader.readByteView(reader.readVarint())),
         ),
       ) as unknown,
     );
-    const graphBytes = reader.readBytes(reader.readVarint());
+    const graphBytes = reader.readByteView(reader.readVarint());
     const compactRuntimeState =
       reader.remainingByteLength === 0
         ? undefined
         : decodeRuntimeState(
-            decodeCompressedSection(reader.readBytes(reader.readVarint())),
+            decodeCompressedSection(reader.readByteView(reader.readVarint())),
           );
     const legacyRuntimeState =
       compactRuntimeState === undefined
@@ -281,7 +281,7 @@ const decodeCompressedSection = (bytes: Uint8Array): Uint8Array => {
     bytes.subarray(COMPRESSED_SECTION_MAGIC.byteLength),
   );
   const expectedLength = reader.readVarint();
-  const compressed = reader.readBytes(reader.readVarint());
+  const compressed = reader.readByteView(reader.readVarint());
   if (reader.remainingByteLength !== 0) {
     throw new Error(
       "Invalid native snapshot compressed section: trailing bytes",
@@ -667,7 +667,7 @@ const readContentBlob = (
   recordCount: number,
 ): { readonly offsets: Uint32Array; readonly bytes: Uint8Array } => {
   const offsets = expectColumnLength(
-    Uint32Array.from(reader.readZigZagDeltaArray()),
+    reader.readZigZagDeltaUint32Array(),
     recordCount + 1,
     "record content offsets",
   );
@@ -676,7 +676,7 @@ const readContentBlob = (
       "Invalid native snapshot runtime state: content offsets must start at zero",
     );
   }
-  const blob = reader.readBytes(reader.readVarint());
+  const blob = reader.readByteView(reader.readVarint());
   for (let index = 0; index < recordCount; index++) {
     const start = offsets[index]!;
     const end = offsets[index + 1]!;

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -71,6 +71,7 @@ export interface EngineSnapshotState {
 export class EgWalkerEngine {
   private readonly eventsById = new Map<EventId, GraphEvent>();
   private readonly eventOrder = new Map<EventId, number>();
+  private eventIndexesComplete = false;
   private graph = new EventGraph();
   private readonly eventItems = new EventItemIndex();
   private readonly itemsById = new Map<EventId, AugmentedCRDTItem>();
@@ -146,7 +147,7 @@ export class EgWalkerEngine {
    * graph that already contains {@link event}.
    */
   applyEvent(event: GraphEvent, graph: EventGraph): IncrementalApplyResult {
-    if (!this.eventsById.has(event.id)) {
+    if (this.eventIndexesComplete && !this.eventsById.has(event.id)) {
       this.eventsById.set(event.id, event);
       this.eventOrder.set(event.id, this.eventOrder.size);
     }
@@ -186,7 +187,9 @@ export class EgWalkerEngine {
     return {
       retreatCount: this.retreatCount,
       advanceCount: this.advanceCount,
-      eventsProcessed: this.eventsById.size,
+      eventsProcessed: this.eventIndexesComplete
+        ? this.eventsById.size
+        : this.graph.getEventCount(),
       nonConflictingRunCount: this.nonConflictingRunCount,
       fullReplayCount: this.fullReplayCount,
       sequenceRecordCount: this.itemsById.size,
@@ -210,6 +213,7 @@ export class EgWalkerEngine {
 
     this.eventsById.clear();
     this.eventOrder.clear();
+    this.eventIndexesComplete = false;
     this.graph = state.graph;
     this.eventItems.clear();
     this.deleteTargets.clear();
@@ -225,11 +229,6 @@ export class EgWalkerEngine {
     this.fullReplayCount = 0;
     this.peakSequenceRecordCount = items.length;
     this.placeholderCounter = inferNextPlaceholderCounter(items);
-
-    state.graph.getTopologicalOrder().forEach((event, index) => {
-      this.eventsById.set(event.id, event);
-      this.eventOrder.set(event.id, index);
-    });
 
     for (const item of items) {
       this.itemsById.set(item.id, item);
@@ -331,6 +330,7 @@ export class EgWalkerEngine {
   ): void {
     this.eventsById.clear();
     this.eventOrder.clear();
+    this.eventIndexesComplete = false;
     this.graph = options.eventGraph ?? new EventGraph();
     this.eventItems.clear();
     this.deleteTargets.clear();
@@ -356,6 +356,7 @@ export class EgWalkerEngine {
         this.graph.addEvent(event);
       }
     });
+    this.eventIndexesComplete = true;
 
     if (initialText.length === 0) {
       return;
@@ -532,6 +533,7 @@ export class EgWalkerEngine {
     currentVersion: ReadonlySet<EventId>,
     targetVersion: ReadonlySet<EventId>,
   ): { retreat: EventId[]; advance: EventId[] } {
+    this.ensureEventIndexes();
     const { onlyInLeft, onlyInRight } = this.graph.diffVersions(
       currentVersion,
       targetVersion,
@@ -564,6 +566,19 @@ export class EgWalkerEngine {
         : compareEventIds(left.id, right.id);
     });
     return ranked.map(({ id }) => id);
+  }
+
+  private ensureEventIndexes(): void {
+    if (this.eventIndexesComplete) {
+      return;
+    }
+    this.eventsById.clear();
+    this.eventOrder.clear();
+    this.graph.getTopologicalOrder().forEach((event, index) => {
+      this.eventsById.set(event.id, event);
+      this.eventOrder.set(event.id, index);
+    });
+    this.eventIndexesComplete = true;
   }
 
   private requireItem(itemId: EventId): AugmentedCRDTItem {

--- a/packages/eg-walker/src/graph/internals/binary-io.ts
+++ b/packages/eg-walker/src/graph/internals/binary-io.ts
@@ -189,14 +189,16 @@ export class BinaryReader {
   }
 
   readZigZagDeltaUint32Array(): Uint32Array {
-    const values = this.readZigZagDeltaArray();
-    const out = new Uint32Array(values.length);
-    for (let index = 0; index < values.length; index++) {
-      const value = values[index] ?? 0;
+    const length = this.readVarint();
+    const out = new Uint32Array(length);
+    let previous = 0;
+    for (let index = 0; index < length; index++) {
+      const value = previous + this.readZigZagVarint();
       if (!Number.isInteger(value) || value < 0 || value > 0xffffffff) {
         throw new Error(`Invalid uint32 delta value ${value}`);
       }
       out[index] = value;
+      previous = value;
     }
     return out;
   }
@@ -211,10 +213,14 @@ export class BinaryReader {
   }
 
   readBytes(length: number): Uint8Array {
+    return this.readByteView(length).slice();
+  }
+
+  readByteView(length: number): Uint8Array {
     if (this.offset + length > this.bytes.length) {
       throw new Error("Unexpected end of binary eg-walker graph");
     }
-    const result = this.bytes.slice(this.offset, this.offset + length);
+    const result = this.bytes.subarray(this.offset, this.offset + length);
     this.offset += length;
     return result;
   }

--- a/packages/eg-walker/src/test/binary-io.test.ts
+++ b/packages/eg-walker/src/test/binary-io.test.ts
@@ -78,4 +78,33 @@ describe("BinaryReader.readVarint hardening", () => {
       new BinaryReader(writer.toUint8Array()).readVarintUint32Array(),
     ).toThrow(/Uint32 range/);
   });
+
+  it("can read a byte view without copying", () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const view = new BinaryReader(bytes).readByteView(2);
+
+    bytes[0] = 9;
+
+    expect(view[0]).toBe(9);
+  });
+
+  it("keeps readBytes isolated from later source mutations", () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const copy = new BinaryReader(bytes).readBytes(2);
+
+    bytes[0] = 9;
+
+    expect(copy[0]).toBe(1);
+  });
+
+  it("reads zigzag delta Uint32 arrays without changing the wire format", () => {
+    const writer = new BinaryWriter();
+    writer.writeZigZagDeltaArray([10, 8, 20]);
+
+    expect(
+      Array.from(
+        new BinaryReader(writer.toUint8Array()).readZigZagDeltaUint32Array(),
+      ),
+    ).toEqual([10, 8, 20]);
+  });
 });

--- a/packages/eg-walker/src/test/native-snapshot.test.ts
+++ b/packages/eg-walker/src/test/native-snapshot.test.ts
@@ -636,6 +636,7 @@ describe("EgWalkerReplica native snapshots", () => {
       // Assert
       expect(restored.getText()).toBe("ABC");
       expect(restored.getReplayStats().fullReplays).toBe(0);
+      expect(restored.getReplayStats().incrementalApplies).toBe(1);
     } finally {
       EventGraph.prototype.getTopologicalOrder = originalGetTopologicalOrder;
     }

--- a/packages/eg-walker/src/test/native-snapshot.test.ts
+++ b/packages/eg-walker/src/test/native-snapshot.test.ts
@@ -615,6 +615,32 @@ describe("EgWalkerReplica native snapshots", () => {
     expect(restored.getReplayStats().fullReplays).toBe(0);
   });
 
+  it("should defer restored event indexes for linear local edits", () => {
+    // Arrange
+    const replica = new EgWalkerReplica("alice", "");
+    replica.insert(0, "A");
+    replica.insert(1, "B");
+    const codec = new NativeSnapshotCodec();
+    const decoded = codec.decode(codec.encode(replica.createNativeSnapshot()));
+    const originalGetTopologicalOrder =
+      EventGraph.prototype.getTopologicalOrder;
+    EventGraph.prototype.getTopologicalOrder = () => {
+      throw new Error("topological order should stay lazy on linear restore");
+    };
+
+    try {
+      // Act
+      const restored = EgWalkerReplica.fromNativeSnapshot(decoded, "alice");
+      restored.insert(2, "C");
+
+      // Assert
+      expect(restored.getText()).toBe("ABC");
+      expect(restored.getReplayStats().fullReplays).toBe(0);
+    } finally {
+      EventGraph.prototype.getTopologicalOrder = originalGetTopologicalOrder;
+    }
+  });
+
   it("should use restored typed-run event ranges for retreating concurrent edits", () => {
     // Arrange
     const replica = new EgWalkerReplica("alice", "");


### PR DESCRIPTION
## Summary

- Avoid large native snapshot decode copies by adding `BinaryReader.readByteView()` and using byte views on snapshot sections/content blobs.
- Decode zigzag-delta runtime columns directly into `Uint32Array` instead of allocating an intermediate `number[]`.
- Defer restored event index materialization until divergent edits need retreat/advance, keeping linear local edits on restored snapshots lighter.
- Add tests for byte-view semantics, preserved `readBytes()` copy behavior, direct zigzag-delta decoding, and lazy restored event indexes.

## Validation

- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker test`
- `pnpm --filter @softmaple/eg-walker build`
- `pnpm --filter @softmaple/eg-walker paper-bench -- --phase6-gates --memory`

## Notes

This PR intentionally includes only the core snapshot/restore code changes and tests. Existing local benchmark/docs drafts and package/lock changes were left out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Defer event-index computation until needed to speed replica initialization and preserve fast incremental applies.
  * Reduce memory copies when reading binary snapshot data, lowering memory usage during decode.

* **Tests**
  * Added tests covering binary read behaviors (views vs copies) and snapshot restore to ensure correctness and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->