### PR TITLE
fix: address collaboration review findings

### DIFF
--- a/apps/playground/e2e/lexical-eg-walker.spec.ts
+++ b/apps/playground/e2e/lexical-eg-walker.spec.ts
@@ -15,9 +15,9 @@ interface RoomPage {
 }
 
 const roomFor = (testInfo: TestInfo): string =>
-  `pw-${testInfo.workerIndex}-${testInfo.retry}-${Date.now()}-${Math.random()
-    .toString(36)
-    .slice(2, 8)}`;
+  `pw-${testInfo.workerIndex}-${testInfo.retry}-${Date.now()}-${crypto
+    .randomUUID()
+    .slice(0, 6)}`;
 
 const openRoom = async (page: Page, roomId: string): Promise<RoomPage> => {
   await page.goto(`/demo/lexical-eg-walker?room=${roomId}`);
@@ -261,9 +261,9 @@ test.describe("Lexical EG-walker cross-tab collaboration", () => {
     await expectDurableAfter(follower, bytesBeforeTakeover);
 
     await follower.page.reload();
-    const reloaded = await openRoom(follower.page, roomId);
-    await expectDocument(reloaded, "Before takeover + after takeover");
-    await expect(reloaded.demo).toHaveAttribute(
+    await expect(follower.page.getByTestId("lexical-room-ready")).toBeVisible();
+    await expectDocument(follower, "Before takeover + after takeover");
+    await expect(follower.demo).toHaveAttribute(
       "data-persistence-leader",
       "leader",
     );

--- a/apps/playground/src/components/Header.tsx
+++ b/apps/playground/src/components/Header.tsx
@@ -17,11 +17,12 @@ export default function Header() {
   const [groupedExpanded, setGroupedExpanded] = useState<
     Record<string, boolean>
   >({});
-  const isLexicalCollaborationCanvas = useRouterState({
-    select: (state) => state.location.pathname === "/demo/lexical-eg-walker",
+  const isHeaderHidden = useRouterState({
+    select: (state) =>
+      state.matches.some((match) => match.staticData?.hideHeader === true),
   });
 
-  if (isLexicalCollaborationCanvas) return null;
+  if (isHeaderHidden) return null;
 
   return (
     <>

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
@@ -6,7 +6,7 @@ import { LexicalEgWalkerPlugin } from "@softmaple/binding-lexical/react";
 import { CoreEditor } from "@softmaple/editor/components/core/CoreEditor";
 import { LEXICAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
 import type { LexicalEditor } from "lexical";
-import { ArrowLeft, GitFork, ShieldCheck } from "lucide-react";
+import { ShieldCheck } from "lucide-react";
 import {
   type SetStateAction,
   useCallback,
@@ -15,19 +15,22 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  LexicalEgWalkerHeader,
+  LexicalRoomLoadingState,
+} from "./LexicalEgWalkerShell";
 import { useRoomPresence } from "./presence";
 import { RemoteSelectionLayer } from "./RemoteSelectionLayer";
 import { createRoomId, resolveRoomId } from "./room";
 import { type PersistenceDisplayState, StatusRail } from "./StatusRail";
-import { toPresenceSelection, useLexicalRoom } from "./useLexicalRoom";
+import {
+  type SessionValue,
+  sessionKeyFor,
+  useLexicalRoom,
+} from "./useLexicalRoom";
 
 export interface LexicalEgWalkerDemoProps {
   readonly requestedRoom?: string;
-}
-
-interface RoomSessionValue<T> {
-  readonly sessionKey: string;
-  readonly value: T;
 }
 
 export function LexicalEgWalkerDemo({
@@ -37,14 +40,14 @@ export function LexicalEgWalkerDemo({
   const roomId = resolveRoomId(requestedRoom, generatedRoomId);
   const presence = useRoomPresence(roomId);
   const room = useLexicalRoom(roomId, presence.identity.userId);
-  const sessionKey = JSON.stringify([roomId, presence.identity.userId]);
-  const [activeEditorState, setActiveEditorState] = useState<RoomSessionValue<
+  const sessionKey = sessionKeyFor(roomId, presence.identity.userId);
+  const [activeEditorState, setActiveEditorState] = useState<SessionValue<
     LexicalEditor | undefined
   > | null>(null);
   const [bindingState, setBindingState] =
-    useState<RoomSessionValue<LexicalBinding | null> | null>(null);
+    useState<SessionValue<LexicalBinding | null> | null>(null);
   const [bindingErrorState, setBindingErrorState] =
-    useState<RoomSessionValue<Error> | null>(null);
+    useState<SessionValue<Error> | null>(null);
   const activeEditor =
     activeEditorState?.sessionKey === sessionKey
       ? activeEditorState.value
@@ -75,11 +78,11 @@ export function LexicalEgWalkerDemo({
   const copyRoomLink = useCallback(() => {
     const url = new URL(window.location.href);
     url.searchParams.set("room", roomId);
-    void navigator.clipboard?.writeText(url.toString());
+    void navigator.clipboard?.writeText(url.toString()).catch(() => undefined);
   }, [roomId]);
   const updatePresenceSelection = useCallback(
     (selection: StableBlockSelection | null) => {
-      presence.updateSelection(toPresenceSelection(selection));
+      presence.updateSelection(selection);
     },
     [presence.updateSelection],
   );
@@ -139,28 +142,7 @@ export function LexicalEgWalkerDemo({
         onCopyRoomLink={copyRoomLink}
       />
 
-      <header className="flex items-start justify-between gap-4 px-4 pb-3 pt-4 md:px-8 md:pb-4 md:pt-6">
-        <div className="min-w-0">
-          <div className="mb-1.5 flex items-center gap-2 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[#475BD8]">
-            <GitFork className="size-3.5" />
-            Causal canvas · local first
-          </div>
-          <h1 className="font-serif text-2xl leading-tight tracking-[-0.025em] md:text-3xl">
-            EG-walker × Lexical
-          </h1>
-          <p className="mt-1 max-w-xl text-xs leading-relaxed text-[#67758B] md:text-sm">
-            One document, any number of tabs. Changes converge through stable
-            sequence anchors and remain on this device after every tab closes.
-          </p>
-        </div>
-        <a
-          href="/"
-          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-[#CBD6E2] bg-white px-2.5 py-2 text-xs font-semibold text-[#526078] shadow-sm outline-none transition-colors hover:border-[#9BAAC0] hover:text-[#17253D] focus-visible:ring-2 focus-visible:ring-[#475BD8]"
-        >
-          <ArrowLeft className="size-3.5" />
-          <span className="hidden sm:inline">Playground</span>
-        </a>
-      </header>
+      <LexicalEgWalkerHeader />
 
       <section className="relative mx-auto flex w-full max-w-[1120px] flex-1 px-3 pb-3 md:px-8 md:pb-8">
         <div className="pointer-events-none absolute inset-x-10 bottom-2 top-4 rounded-[28px] bg-[#475BD8]/8 blur-2xl" />
@@ -173,22 +155,7 @@ export function LexicalEgWalkerDemo({
             </span>
           </div>
           {room.replica === null ? (
-            <div
-              className="grid flex-1 place-items-center p-8 text-center"
-              data-testid="lexical-room-loading"
-            >
-              <div>
-                <div className="mx-auto mb-4 flex size-10 items-center justify-center rounded-full border border-[#BCC8D8] bg-[#EEF3F7]">
-                  <span className="size-2 rounded-full bg-[#475BD8] motion-safe:animate-pulse" />
-                </div>
-                <p className="font-serif text-lg">
-                  Replaying the room history…
-                </p>
-                <p className="mt-1 text-xs text-[#7A879A]">
-                  Editing opens after the first converged document is ready.
-                </p>
-              </div>
-            </div>
+            <LexicalRoomLoadingState />
           ) : (
             <div
               ref={editorHostRef}

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerShell.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerShell.tsx
@@ -1,0 +1,43 @@
+import { ArrowLeft, GitFork } from "lucide-react";
+
+export const LexicalEgWalkerHeader = () => (
+  <header className="flex items-start justify-between gap-4 px-4 pb-3 pt-4 md:px-8 md:pb-4 md:pt-6">
+    <div className="min-w-0">
+      <div className="mb-1.5 flex items-center gap-2 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[#475BD8]">
+        <GitFork className="size-3.5" />
+        Causal canvas · local first
+      </div>
+      <h1 className="font-serif text-2xl leading-tight tracking-[-0.025em] md:text-3xl">
+        EG-walker × Lexical
+      </h1>
+      <p className="mt-1 max-w-xl text-xs leading-relaxed text-[#67758B] md:text-sm">
+        One document, any number of tabs. Changes converge through stable
+        sequence anchors and remain on this device after every tab closes.
+      </p>
+    </div>
+    <a
+      href="/"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-[#CBD6E2] bg-white px-2.5 py-2 text-xs font-semibold text-[#526078] shadow-sm outline-none transition-colors hover:border-[#9BAAC0] hover:text-[#17253D] focus-visible:ring-2 focus-visible:ring-[#475BD8]"
+    >
+      <ArrowLeft className="size-3.5" />
+      <span className="hidden sm:inline">Playground</span>
+    </a>
+  </header>
+);
+
+export const LexicalRoomLoadingState = () => (
+  <div
+    className="grid flex-1 place-items-center p-8 text-center"
+    data-testid="lexical-room-loading"
+  >
+    <div>
+      <div className="mx-auto mb-4 flex size-10 items-center justify-center rounded-full border border-[#BCC8D8] bg-[#EEF3F7]">
+        <span className="size-2 rounded-full bg-[#475BD8] motion-safe:animate-pulse" />
+      </div>
+      <p className="font-serif text-lg">Replaying the room history…</p>
+      <p className="mt-1 text-xs text-[#7A879A]">
+        Editing opens after the first converged document is ready.
+      </p>
+    </div>
+  </div>
+);

--- a/apps/playground/src/modules/lexical-eg-walker/RemoteSelectionLayer.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/RemoteSelectionLayer.test.ts
@@ -80,7 +80,6 @@ describe("remote selection resolution", () => {
       getBlockIndex: () => ({
         blockIdToNodeKey: new Map(),
         nodeKeyToBlockId: new Map(),
-        numberedListOverrides: new Map(),
       }),
     } as unknown as LexicalBinding;
     const host = document.createElement("div");

--- a/apps/playground/src/modules/lexical-eg-walker/RemoteSelectionLayer.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/RemoteSelectionLayer.tsx
@@ -1,43 +1,11 @@
+import type { PresenceUser } from "@softmaple/awareness";
+import type { LexicalBinding } from "@softmaple/binding-lexical";
+import { type RefObject, useLayoutEffect, useRef, useState } from "react";
 import {
-  type DirectionalSelectionRange,
-  isDirectionalSelectionRange,
-  type PresenceUser,
-} from "@softmaple/awareness";
-import type {
-  LexicalBinding,
-  LogicalSelection,
-  LogicalSelectionPoint,
-  StableBlockSelection,
-} from "@softmaple/binding-lexical";
-import { type RefObject, useLayoutEffect, useState } from "react";
-
-interface OverlayRect {
-  readonly height: number;
-  readonly left: number;
-  readonly top: number;
-  readonly width: number;
-}
-
-interface PeerGeometry {
-  readonly backward: boolean;
-  readonly caret: OverlayRect | null;
-  readonly peer: PresenceUser;
-  readonly selection: ReadonlyArray<OverlayRect>;
-}
-
-interface DomPoint {
-  readonly node: Node;
-  readonly offset: number;
-}
-
-interface DomUnit {
-  readonly from: number;
-  readonly to: number;
-  readonly node: Node;
-  readonly parent: Node;
-  readonly childIndex: number;
-  readonly type: "text" | "break";
-}
+  measurePeer,
+  type PeerGeometry,
+  resolvePeerSelection,
+} from "./remote-selection-geometry";
 
 export interface RemoteSelectionLayerProps {
   readonly binding: LexicalBinding | null;
@@ -46,145 +14,7 @@ export interface RemoteSelectionLayerProps {
   readonly users: ReadonlyArray<PresenceUser>;
 }
 
-const childIndex = (node: ChildNode): number =>
-  node.parentNode === null
-    ? 0
-    : Array.from(node.parentNode.childNodes).indexOf(node);
-
-const collectUnits = (
-  node: Node,
-  units: DomUnit[],
-  initialOffset = 0,
-): number => {
-  let offset = initialOffset;
-  for (const child of node.childNodes) {
-    if (child.nodeType === Node.TEXT_NODE) {
-      const length = child.textContent?.length ?? 0;
-      units.push({
-        from: offset,
-        to: offset + length,
-        node: child,
-        parent: node,
-        childIndex: childIndex(child),
-        type: "text",
-      });
-      offset += length;
-      continue;
-    }
-    if (!(child instanceof HTMLElement)) continue;
-    if (child.tagName === "BR") {
-      units.push({
-        from: offset,
-        to: offset + 1,
-        node: child,
-        parent: node,
-        childIndex: childIndex(child),
-        type: "break",
-      });
-      offset++;
-      continue;
-    }
-    if (child.tagName === "UL" || child.tagName === "OL") continue;
-    offset = collectUnits(child, units, offset);
-  }
-  return offset;
-};
-
-const resolveDomPoint = (
-  binding: LexicalBinding,
-  point: LogicalSelectionPoint,
-): DomPoint | null => {
-  const key = binding.getBlockIndex().blockIdToNodeKey.get(point.blockId);
-  if (key === undefined) return null;
-  const block = binding.editor.getElementByKey(key);
-  if (block === null) return null;
-  const units: DomUnit[] = [];
-  const length = collectUnits(block, units);
-  const offset = Math.max(0, Math.min(length, point.offset));
-  const text = units.find(
-    (unit) => unit.type === "text" && offset >= unit.from && offset <= unit.to,
-  );
-  if (text !== undefined) {
-    return { node: text.node, offset: offset - text.from };
-  }
-  const next = units.find((unit) => unit.from >= offset);
-  if (next !== undefined) {
-    return { node: next.parent, offset: next.childIndex };
-  }
-  return { node: block, offset: block.childNodes.length };
-};
-
-const collapsedRange = (point: DomPoint): Range => {
-  const range = document.createRange();
-  range.setStart(point.node, point.offset);
-  range.collapse(true);
-  return range;
-};
-
-const relativeRect = (
-  rect: DOMRect,
-  host: DOMRect,
-  minimumWidth = 0,
-): OverlayRect => ({
-  left: rect.left - host.left,
-  top: rect.top - host.top,
-  width: Math.max(minimumWidth, rect.width),
-  height: Math.max(18, rect.height),
-});
-
-const toStableSelection = (
-  selection: DirectionalSelectionRange,
-): StableBlockSelection => selection;
-
-export const resolvePeerSelection = (
-  binding: Pick<LexicalBinding, "resolveSelection">,
-  peer: PresenceUser,
-): LogicalSelection | null => {
-  if (!isDirectionalSelectionRange(peer.selection)) return null;
-  try {
-    return binding.resolveSelection(toStableSelection(peer.selection));
-  } catch {
-    return null;
-  }
-};
-
-const measurePeer = (
-  binding: LexicalBinding,
-  host: HTMLElement,
-  peer: PresenceUser,
-): PeerGeometry | null => {
-  const logical = resolvePeerSelection(binding, peer);
-  if (logical === null) return null;
-  const anchor = resolveDomPoint(binding, logical.anchor);
-  const focus = resolveDomPoint(binding, logical.focus);
-  if (anchor === null || focus === null) return null;
-
-  const anchorRange = collapsedRange(anchor);
-  const focusRange = collapsedRange(focus);
-  const backward =
-    anchorRange.compareBoundaryPoints(Range.START_TO_START, focusRange) > 0;
-  const start = backward ? focus : anchor;
-  const end = backward ? anchor : focus;
-  const selectionRange = document.createRange();
-  selectionRange.setStart(start.node, start.offset);
-  selectionRange.setEnd(end.node, end.offset);
-  const hostRect = host.getBoundingClientRect();
-  const selection = Array.from(selectionRange.getClientRects())
-    .filter((rect) => rect.width > 0 && rect.height > 0)
-    .map((rect) => relativeRect(rect, hostRect));
-  const focusRect =
-    focusRange.getClientRects()[0] ?? focusRange.getBoundingClientRect();
-  const caret =
-    focusRect.height > 0
-      ? relativeRect(focusRect, hostRect, 2)
-      : {
-          left: focusRect.left - hostRect.left,
-          top: focusRect.top - hostRect.top,
-          width: 2,
-          height: 20,
-        };
-  return { backward, caret, peer, selection };
-};
+export { resolvePeerSelection };
 
 export function RemoteSelectionLayer({
   binding,
@@ -193,6 +23,8 @@ export function RemoteSelectionLayer({
   users,
 }: RemoteSelectionLayerProps) {
   const [geometry, setGeometry] = useState<ReadonlyArray<PeerGeometry>>([]);
+  const usersRef = useRef(users);
+  const measureRef = useRef<(() => void) | null>(null);
 
   useLayoutEffect(() => {
     const host = hostRef.current;
@@ -205,7 +37,7 @@ export function RemoteSelectionLayer({
       cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
         setGeometry(
-          users.flatMap((peer) => {
+          usersRef.current.flatMap((peer) => {
             if (peer.userId === selfId) return [];
             const measured = measurePeer(binding, host, peer);
             return measured === null ? [] : [measured];
@@ -213,6 +45,7 @@ export function RemoteSelectionLayer({
         );
       });
     };
+    measureRef.current = measure;
     measure();
     const resizeObserver = new ResizeObserver(measure);
     const mutationObserver = new MutationObserver(measure);
@@ -226,6 +59,7 @@ export function RemoteSelectionLayer({
     window.addEventListener("resize", measure);
     window.addEventListener("scroll", measure, true);
     return () => {
+      measureRef.current = null;
       cancelAnimationFrame(frame);
       resizeObserver.disconnect();
       mutationObserver.disconnect();
@@ -233,14 +67,19 @@ export function RemoteSelectionLayer({
       window.removeEventListener("resize", measure);
       window.removeEventListener("scroll", measure, true);
     };
-  }, [binding, hostRef, selfId, users]);
+  }, [binding, hostRef, selfId]);
+
+  useLayoutEffect(() => {
+    usersRef.current = users;
+    measureRef.current?.();
+  }, [users]);
 
   return (
     <div className="pointer-events-none absolute inset-0 z-10 overflow-hidden">
       {geometry.flatMap(({ peer, selection }) =>
-        selection.map((rect, index) => (
+        selection.map((rect) => (
           <span
-            key={`${peer.userId}:selection:${index}`}
+            key={`${peer.userId}:selection:${rect.left}:${rect.top}:${rect.width}:${rect.height}`}
             data-testid={`remote-selection-${peer.userId}`}
             className="absolute rounded-[3px]"
             style={{

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
@@ -139,6 +139,11 @@ export function StatusRail({
             {user.name.slice(0, 2).toUpperCase()}
           </span>
         ))}
+        {users.length > 5 ? (
+          <span className="-ml-[5px] grid size-6 place-items-center rounded-full border-2 border-white bg-[#526078] text-[9px] font-bold text-white shadow-sm">
+            +{users.length - 5}
+          </span>
+        ) : null}
         <span className="ml-2 whitespace-nowrap text-[#526078]">
           {users.length} online
         </span>

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/channel.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/channel.test.ts
@@ -1,53 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-  type BroadcastChannelFactory,
-  type BroadcastChannelLike,
   createPersistenceChannel,
   getPersistenceChannelName,
   PERSISTENCE_CHANNEL_MESSAGE_TYPE,
   PERSISTENCE_CHANNEL_PROTOCOL_VERSION,
 } from "./channel";
 import { type WireBatch, WireBatchSchema } from "./schema";
-
-class MockBroadcastNetwork {
-  private readonly channels = new Map<string, Set<MockBroadcastChannel>>();
-
-  readonly createChannel: BroadcastChannelFactory = (name) => {
-    const channel = new MockBroadcastChannel(name, this);
-    const peers = this.channels.get(name) ?? new Set<MockBroadcastChannel>();
-    peers.add(channel);
-    this.channels.set(name, peers);
-    return channel;
-  };
-
-  deliver(sender: MockBroadcastChannel, message: unknown): void {
-    for (const peer of this.channels.get(sender.name) ?? []) {
-      if (peer === sender) continue;
-      peer.onmessage?.({ data: structuredClone(message) });
-    }
-  }
-
-  remove(channel: MockBroadcastChannel): void {
-    this.channels.get(channel.name)?.delete(channel);
-  }
-}
-
-class MockBroadcastChannel implements BroadcastChannelLike {
-  onmessage: BroadcastChannelLike["onmessage"] = null;
-
-  constructor(
-    readonly name: string,
-    private readonly network: MockBroadcastNetwork,
-  ) {}
-
-  postMessage(message: unknown): void {
-    this.network.deliver(this, message);
-  }
-
-  close(): void {
-    this.network.remove(this);
-  }
-}
+import { MockBroadcastNetwork } from "./test-helpers";
 
 const createBatch = (batchId: string, text: string): WireBatch =>
   WireBatchSchema.parse({
@@ -120,6 +79,8 @@ describe("persistence BroadcastChannel protocol", () => {
 
     expect(acknowledgements).toEqual([["batch-1"]]);
     expect([...b.getDurableBatchIds()]).toEqual(["batch-1"]);
+    a.close();
+    b.close();
   });
 
   it("rejects malformed messages and conflicting duplicate batches", () => {
@@ -160,6 +121,9 @@ describe("persistence BroadcastChannel protocol", () => {
     expect(errors[0]).toMatch(/Invalid persistence channel message/);
     expect(errors[1]).toMatch(/Conflicting payloads/);
     expect(receiver.getKnownBatches()).toEqual([original]);
+    raw.close();
+    receiver.close();
+    sender.close();
   });
 
   it("validates domain batches before accepting channel messages", () => {
@@ -194,6 +158,8 @@ describe("persistence BroadcastChannel protocol", () => {
     expect(errors).toEqual([
       "Invalid persistence batch: Rich-text effect is required",
     ]);
+    receiver.close();
+    sender.close();
   });
 
   it("isolates rooms through channel names", () => {
@@ -211,5 +177,7 @@ describe("persistence BroadcastChannel protocol", () => {
 
     a.publishBatch(createBatch("batch-1", "hello"));
     expect(b.getKnownBatches()).toEqual([]);
+    a.close();
+    b.close();
   });
 });

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/channel.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/channel.ts
@@ -138,19 +138,21 @@ export const createPersistenceChannel = ({
     for (const listener of errorListeners) listener(error);
   };
 
-  const acceptBatch = (
-    candidate: unknown,
-    source: BatchDeliverySource,
-  ): WireBatch | null => {
-    let batch: WireBatch;
+  const validateBatch = (candidate: unknown): WireBatch | null => {
     try {
-      batch = parseBatch(candidate);
+      return parseBatch(candidate);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Unknown validation error";
       notifyError(new Error(`Invalid persistence batch: ${message}`));
       return null;
     }
+  };
+
+  const acceptBatch = (
+    batch: WireBatch,
+    source: BatchDeliverySource,
+  ): WireBatch | null => {
     const existing = knownBatches.get(batch.batchId);
     if (existing) {
       if (serializeBatch(existing) !== serializeBatch(batch)) {
@@ -209,7 +211,10 @@ export const createPersistenceChannel = ({
 
     switch (message.type) {
       case PERSISTENCE_CHANNEL_MESSAGE_TYPE.Event:
-        acceptBatch(message.batch, "remote");
+        {
+          const batch = validateBatch(message.batch);
+          if (batch !== null) acceptBatch(batch, "remote");
+        }
         return;
       case PERSISTENCE_CHANNEL_MESSAGE_TYPE.RepairRequest: {
         const requesterKnown = new Set(message.knownBatchIds);
@@ -230,7 +235,10 @@ export const createPersistenceChannel = ({
       }
       case PERSISTENCE_CHANNEL_MESSAGE_TYPE.RepairResponse:
         if (message.recipientId !== peerId) return;
-        for (const batch of message.batches) acceptBatch(batch, "repair");
+        for (const candidate of message.batches) {
+          const batch = validateBatch(candidate);
+          if (batch !== null) acceptBatch(batch, "repair");
+        }
         return;
       case PERSISTENCE_CHANNEL_MESSAGE_TYPE.DurableAck:
         markDurable(message.batchIds);
@@ -240,7 +248,9 @@ export const createPersistenceChannel = ({
 
   return {
     publishBatch: (candidate) => {
-      const batch = acceptBatch(candidate, "local");
+      const validated = validateBatch(candidate);
+      if (validated === null) return false;
+      const batch = acceptBatch(validated, "local");
       if (batch === null) return false;
       postMessage({
         protocolVersion: PERSISTENCE_CHANNEL_PROTOCOL_VERSION,

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator-fallback.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator-fallback.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createPersistenceCoordinator,
+  getPersistenceStorageKey,
+} from "./coordinator";
+import {
+  createBatch,
+  FakeLockManager,
+  MockBroadcastNetwork,
+  SharedStorageBackend,
+  tick,
+} from "./test-helpers";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("persistence coordinator fallbacks", () => {
+  it("keeps collaborating in memory when Web Locks are unsupported", async () => {
+    const storage = new SharedStorageBackend();
+    const broadcast = new MockBroadcastNetwork();
+    const tab = storage.createTab("a");
+    const coordinator = await createPersistenceCoordinator({
+      roomId: "room-a",
+      peerId: "a",
+      storage: tab,
+      storageEventApi: tab,
+      lockManager: null,
+      channelFactory: broadcast.createChannel,
+    });
+
+    coordinator.publishBatch(createBatch("memory-batch", "hello"));
+    await coordinator.flushPending();
+    expect(coordinator.getSnapshot()).toMatchObject({
+      mode: "memory-only",
+      durability: "unsaved",
+      failureReason: "web-locks-unsupported",
+    });
+    expect(coordinator.getKnownBatches()).toHaveLength(1);
+    expect(storage.writes).toEqual([]);
+    await coordinator.close();
+  });
+
+  it("does not start leader election when storage is unavailable", async () => {
+    const broadcast = new MockBroadcastNetwork();
+    const locks = new FakeLockManager();
+    const coordinator = await createPersistenceCoordinator({
+      roomId: "room-a",
+      peerId: "a",
+      storage: null,
+      storageEventApi: null,
+      lockManager: locks,
+      channelFactory: broadcast.createChannel,
+    });
+
+    expect(locks.requestCount).toBe(0);
+    expect(coordinator.getSnapshot()).toMatchObject({
+      mode: "memory-only",
+      failureReason: "storage-unavailable",
+      leader: { status: "stopped", isLeader: false },
+    });
+    await coordinator.close();
+  });
+
+  it("preserves corrupt storage and refuses to overwrite it", async () => {
+    const storage = new SharedStorageBackend();
+    const broadcast = new MockBroadcastNetwork();
+    const locks = new FakeLockManager();
+    const tab = storage.createTab("a");
+    const key = getPersistenceStorageKey("room-a");
+    storage.data.set(key, "{broken");
+    const coordinator = await createPersistenceCoordinator({
+      roomId: "room-a",
+      peerId: "a",
+      storage: tab,
+      storageEventApi: tab,
+      lockManager: locks,
+      channelFactory: broadcast.createChannel,
+    });
+
+    coordinator.publishBatch(createBatch("memory-batch", "hello"));
+    await coordinator.flushPending();
+    expect(coordinator.getSnapshot()).toMatchObject({
+      mode: "memory-only",
+      failureReason: "corrupt-storage",
+    });
+    expect(storage.data.get(key)).toBe("{broken");
+    expect(storage.writes).toEqual([]);
+    await coordinator.close();
+  });
+
+  it("degrades to an explicit unsaved state when quota is exceeded", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const storage = new SharedStorageBackend();
+    const broadcast = new MockBroadcastNetwork();
+    const locks = new FakeLockManager();
+    const tab = storage.createTab("a");
+    const coordinator = await createPersistenceCoordinator({
+      roomId: "room-a",
+      peerId: "a",
+      storage: tab,
+      storageEventApi: tab,
+      lockManager: locks,
+      channelFactory: broadcast.createChannel,
+      repairDelayMs: 0,
+    });
+    storage.quotaExceeded = true;
+
+    coordinator.publishBatch(createBatch("quota-batch", "hello"));
+    await coordinator.flushPending();
+    expect(coordinator.getSnapshot()).toMatchObject({
+      mode: "memory-only",
+      durability: "unsaved",
+      failureReason: "quota-exceeded",
+      pendingBatchIds: ["quota-batch"],
+    });
+    expect(storage.writes).toEqual([]);
+    await coordinator.close();
+  });
+
+  it("releases leadership after degrading so a waiting tab can take over", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const storage = new SharedStorageBackend();
+    const broadcast = new MockBroadcastNetwork();
+    const locks = new FakeLockManager();
+    const tabA = storage.createTab("a");
+    const tabB = storage.createTab("b");
+    const a = await createPersistenceCoordinator({
+      roomId: "room-a",
+      peerId: "a",
+      storage: tabA,
+      storageEventApi: tabA,
+      lockManager: locks,
+      channelFactory: broadcast.createChannel,
+      repairDelayMs: 1_000,
+    });
+    const b = await createPersistenceCoordinator({
+      roomId: "room-a",
+      peerId: "b",
+      storage: tabB,
+      storageEventApi: tabB,
+      lockManager: locks,
+      channelFactory: broadcast.createChannel,
+      repairDelayMs: 1_000,
+    });
+    storage.quotaExceeded = true;
+
+    a.publishBatch(createBatch("quota-batch", "hello"));
+    await a.flushPending();
+    await tick();
+
+    expect(a.getSnapshot()).toMatchObject({
+      mode: "memory-only",
+      leader: { status: "stopped", isLeader: false },
+    });
+    expect(b.getSnapshot().leader).toMatchObject({
+      status: "leader",
+      isLeader: true,
+    });
+    await a.close();
+    await b.close();
+  });
+});

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator.test.ts
@@ -1,209 +1,17 @@
-import type { StorageApi, StorageEventApi } from "@tanstack/react-db";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BroadcastChannelFactory, BroadcastChannelLike } from "./channel";
+import { describe, expect, it } from "vitest";
+import { createPersistenceChannel } from "./channel";
 import {
   createPersistenceCoordinator,
   getPersistenceStorageKey,
 } from "./coordinator";
-import type {
-  ExclusiveLockRequestOptions,
-  LockHandleLike,
-  LockManagerLike,
-} from "./leader";
+import { PERSISTENCE_ROW_KIND, parsePersistenceStorage } from "./schema";
 import {
-  PERSISTENCE_ROW_KIND,
-  parsePersistenceStorage,
-  type WireBatch,
-  WireBatchSchema,
-} from "./schema";
-
-class MockBroadcastNetwork {
-  private readonly channels = new Map<string, Set<MockBroadcastChannel>>();
-
-  readonly createChannel: BroadcastChannelFactory = (name) => {
-    const channel = new MockBroadcastChannel(name, this);
-    const peers = this.channels.get(name) ?? new Set<MockBroadcastChannel>();
-    peers.add(channel);
-    this.channels.set(name, peers);
-    return channel;
-  };
-
-  deliver(sender: MockBroadcastChannel, message: unknown): void {
-    for (const peer of this.channels.get(sender.name) ?? []) {
-      if (peer !== sender) peer.onmessage?.({ data: structuredClone(message) });
-    }
-  }
-
-  remove(channel: MockBroadcastChannel): void {
-    this.channels.get(channel.name)?.delete(channel);
-  }
-}
-
-class MockBroadcastChannel implements BroadcastChannelLike {
-  onmessage: BroadcastChannelLike["onmessage"] = null;
-
-  constructor(
-    readonly name: string,
-    private readonly network: MockBroadcastNetwork,
-  ) {}
-
-  postMessage(message: unknown): void {
-    this.network.deliver(this, message);
-  }
-
-  close(): void {
-    this.network.remove(this);
-  }
-}
-
-interface PendingLock {
-  readonly callback: (lock: LockHandleLike) => Promise<void> | void;
-  readonly name: string;
-  readonly options: ExclusiveLockRequestOptions;
-  readonly reject: (error: Error) => void;
-  readonly resolve: () => void;
-}
-
-class FakeLockManager implements LockManagerLike {
-  private readonly activeNames = new Set<string>();
-  private readonly pending: PendingLock[] = [];
-  requestCount = 0;
-
-  request(
-    name: string,
-    options: ExclusiveLockRequestOptions,
-    callback: (lock: LockHandleLike) => Promise<void> | void,
-  ): Promise<void> {
-    this.requestCount++;
-    return new Promise<void>((resolve, reject) => {
-      const request = { name, options, callback, resolve, reject };
-      options.signal.addEventListener(
-        "abort",
-        () => {
-          const index = this.pending.indexOf(request);
-          if (index < 0) return;
-          this.pending.splice(index, 1);
-          const error = new Error("Lock request aborted");
-          error.name = "AbortError";
-          reject(error);
-        },
-        { once: true },
-      );
-      this.pending.push(request);
-      this.drain(name);
-    });
-  }
-
-  private drain(name: string): void {
-    if (this.activeNames.has(name)) return;
-    const index = this.pending.findIndex((request) => request.name === name);
-    if (index < 0) return;
-    const [request] = this.pending.splice(index, 1);
-    if (!request) return;
-    this.activeNames.add(name);
-    Promise.resolve(
-      request.callback({ name, mode: request.options.mode }),
-    ).finally(() => {
-      this.activeNames.delete(name);
-      request.resolve();
-      this.drain(name);
-    });
-  }
-}
-
-class SharedStorageBackend {
-  readonly data = new Map<string, string>();
-  readonly writes: string[] = [];
-  readonly tabs = new Set<TestStorageTab>();
-  quotaExceeded = false;
-
-  createTab(id: string): TestStorageTab {
-    const tab = new TestStorageTab(id, this);
-    this.tabs.add(tab);
-    return tab;
-  }
-
-  write(source: TestStorageTab, key: string, value: string): void {
-    if (this.quotaExceeded) {
-      const error = new Error("Local storage quota exceeded");
-      error.name = "QuotaExceededError";
-      throw error;
-    }
-    this.data.set(key, value);
-    this.writes.push(source.id);
-    for (const tab of this.tabs) {
-      if (tab !== source) tab.dispatch(key);
-    }
-  }
-}
-
-class TestStorageTab implements StorageApi, StorageEventApi {
-  private readonly listeners = new Set<(event: StorageEvent) => void>();
-
-  constructor(
-    readonly id: string,
-    private readonly backend: SharedStorageBackend,
-  ) {}
-
-  getItem(key: string): string | null {
-    return this.backend.data.get(key) ?? null;
-  }
-
-  setItem(key: string, value: string): void {
-    this.backend.write(this, key, value);
-  }
-
-  removeItem(key: string): void {
-    this.backend.data.delete(key);
-    for (const tab of this.backend.tabs) {
-      if (tab !== this) tab.dispatch(key);
-    }
-  }
-
-  addEventListener(
-    _type: "storage",
-    listener: (event: StorageEvent) => void,
-  ): void {
-    this.listeners.add(listener);
-  }
-
-  removeEventListener(
-    _type: "storage",
-    listener: (event: StorageEvent) => void,
-  ): void {
-    this.listeners.delete(listener);
-  }
-
-  dispatch(key: string): void {
-    const event = { key, storageArea: this } as unknown as StorageEvent;
-    for (const listener of this.listeners) listener(event);
-  }
-}
-
-const createBatch = (batchId: string, text: string): WireBatch =>
-  WireBatchSchema.parse({
-    schemaVersion: 1,
-    batchId,
-    parentVersion: [],
-    events: [
-      {
-        schemaVersion: 1,
-        id: `${batchId}:event`,
-        parentVersion: [],
-        timestamp: 1,
-        operation: { type: "insert", text },
-        effect: { type: "text-insert", blockId: "block-1", text },
-      },
-    ],
-  });
-
-const tick = async (): Promise<void> => {
-  await new Promise<void>((resolve) => setTimeout(resolve, 0));
-};
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
+  createBatch,
+  FakeLockManager,
+  MockBroadcastNetwork,
+  SharedStorageBackend,
+  tick,
+} from "./test-helpers";
 
 describe("TanStack DB persistence coordinator", () => {
   it("lets only the leader append and acknowledges after persistence", async () => {
@@ -304,81 +112,7 @@ describe("TanStack DB persistence coordinator", () => {
     await b.close();
   });
 
-  it("keeps collaborating in memory when Web Locks are unsupported", async () => {
-    const storage = new SharedStorageBackend();
-    const broadcast = new MockBroadcastNetwork();
-    const tab = storage.createTab("a");
-    const coordinator = await createPersistenceCoordinator({
-      roomId: "room-a",
-      peerId: "a",
-      storage: tab,
-      storageEventApi: tab,
-      lockManager: null,
-      channelFactory: broadcast.createChannel,
-    });
-
-    coordinator.publishBatch(createBatch("memory-batch", "hello"));
-    await coordinator.flushPending();
-    expect(coordinator.getSnapshot()).toMatchObject({
-      mode: "memory-only",
-      durability: "unsaved",
-      failureReason: "web-locks-unsupported",
-    });
-    expect(coordinator.getKnownBatches()).toHaveLength(1);
-    expect(storage.writes).toEqual([]);
-    await coordinator.close();
-  });
-
-  it("does not start leader election when storage is unavailable", async () => {
-    const broadcast = new MockBroadcastNetwork();
-    const locks = new FakeLockManager();
-    const coordinator = await createPersistenceCoordinator({
-      roomId: "room-a",
-      peerId: "a",
-      storage: null,
-      storageEventApi: null,
-      lockManager: locks,
-      channelFactory: broadcast.createChannel,
-    });
-
-    expect(locks.requestCount).toBe(0);
-    expect(coordinator.getSnapshot()).toMatchObject({
-      mode: "memory-only",
-      failureReason: "storage-unavailable",
-      leader: { status: "stopped", isLeader: false },
-    });
-    await coordinator.close();
-  });
-
-  it("preserves corrupt storage and refuses to overwrite it", async () => {
-    const storage = new SharedStorageBackend();
-    const broadcast = new MockBroadcastNetwork();
-    const locks = new FakeLockManager();
-    const tab = storage.createTab("a");
-    const key = getPersistenceStorageKey("room-a");
-    storage.data.set(key, "{broken");
-    const coordinator = await createPersistenceCoordinator({
-      roomId: "room-a",
-      peerId: "a",
-      storage: tab,
-      storageEventApi: tab,
-      lockManager: locks,
-      channelFactory: broadcast.createChannel,
-    });
-
-    coordinator.publishBatch(createBatch("memory-batch", "hello"));
-    await coordinator.flushPending();
-    expect(coordinator.getSnapshot()).toMatchObject({
-      mode: "memory-only",
-      failureReason: "corrupt-storage",
-    });
-    expect(storage.data.get(key)).toBe("{broken");
-    expect(storage.writes).toEqual([]);
-    await coordinator.close();
-  });
-
-  it("degrades to an explicit unsaved state when quota is exceeded", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  it("flushes final batches before closing", async () => {
     const storage = new SharedStorageBackend();
     const broadcast = new MockBroadcastNetwork();
     const locks = new FakeLockManager();
@@ -390,62 +124,48 @@ describe("TanStack DB persistence coordinator", () => {
       storageEventApi: tab,
       lockManager: locks,
       channelFactory: broadcast.createChannel,
-      repairDelayMs: 0,
     });
-    storage.quotaExceeded = true;
 
-    coordinator.publishBatch(createBatch("quota-batch", "hello"));
-    await coordinator.flushPending();
-    expect(coordinator.getSnapshot()).toMatchObject({
-      mode: "memory-only",
-      durability: "unsaved",
-      failureReason: "quota-exceeded",
-      pendingBatchIds: ["quota-batch"],
-    });
-    expect(storage.writes).toEqual([]);
+    coordinator.publishBatch(createBatch("closing-batch", "saved"));
     await coordinator.close();
+
+    const rows = parsePersistenceStorage(
+      storage.data.get(getPersistenceStorageKey("room-a")) ?? null,
+      "room-a",
+    );
+    expect(
+      rows.some(
+        (row) =>
+          row.kind === PERSISTENCE_ROW_KIND.Event &&
+          row.batch.batchId === "closing-batch",
+      ),
+    ).toBe(true);
   });
 
-  it("releases leadership after degrading so a waiting tab can take over", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  it("retains channel durability acknowledgements across storage refreshes", async () => {
     const storage = new SharedStorageBackend();
     const broadcast = new MockBroadcastNetwork();
     const locks = new FakeLockManager();
-    const tabA = storage.createTab("a");
-    const tabB = storage.createTab("b");
-    const a = await createPersistenceCoordinator({
+    const tab = storage.createTab("a");
+    const coordinator = await createPersistenceCoordinator({
       roomId: "room-a",
       peerId: "a",
-      storage: tabA,
-      storageEventApi: tabA,
+      storage: tab,
+      storageEventApi: tab,
       lockManager: locks,
       channelFactory: broadcast.createChannel,
-      repairDelayMs: 1_000,
     });
-    const b = await createPersistenceCoordinator({
+    const sender = createPersistenceChannel({
       roomId: "room-a",
-      peerId: "b",
-      storage: tabB,
-      storageEventApi: tabB,
-      lockManager: locks,
+      peerId: "sender",
       channelFactory: broadcast.createChannel,
-      repairDelayMs: 1_000,
     });
-    storage.quotaExceeded = true;
 
-    a.publishBatch(createBatch("quota-batch", "hello"));
-    await a.flushPending();
-    await tick();
+    sender.broadcastDurableAck(["channel-only"]);
+    tab.dispatch(getPersistenceStorageKey("room-a"));
 
-    expect(a.getSnapshot()).toMatchObject({
-      mode: "memory-only",
-      leader: { status: "stopped", isLeader: false },
-    });
-    expect(b.getSnapshot().leader).toMatchObject({
-      status: "leader",
-      isLeader: true,
-    });
-    await a.close();
-    await b.close();
+    expect(coordinator.getSnapshot().durableBatchIds).toContain("channel-only");
+    sender.close();
+    await coordinator.close();
   });
 });

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator.ts
@@ -301,7 +301,6 @@ export const createPersistenceCoordinator = async (
       (row) => row.kind === PERSISTENCE_ROW_KIND.Event,
     );
     persistedBatchIds.clear();
-    durableBatchIds.clear();
     for (const row of eventRows) {
       persistedBatchIds.add(row.batch.batchId);
       durableBatchIds.add(row.batch.batchId);
@@ -502,14 +501,14 @@ export const createPersistenceCoordinator = async (
     },
     close: async () => {
       if (closed) return;
-      closed = true;
       if (repairTimer) clearTimeout(repairTimer);
+      await flushPending();
+      closed = true;
       unsubscribeLeader();
       unsubscribeBatches();
       unsubscribeAcks();
       unsubscribeChannelErrors();
       sourceEventApi?.removeEventListener("storage", handleStorageEvent);
-      await flushPromise;
       await election.stop();
       leaderSnapshot = election.getSnapshot();
       await collection?.cleanup();

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/schema.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/schema.test.ts
@@ -139,4 +139,37 @@ describe("lexical EG-walker persistence schema", () => {
       /does not match/,
     );
   });
+
+  it("rejects duplicate event batches, multiple room rows, and mismatched event keys", () => {
+    const eventRow = createEventRow(ROOM_ID, batch, 2);
+    const duplicateEventRow = {
+      ...createEventRow(ROOM_ID, batch, 3),
+      key: "event:duplicate-batch-1",
+    };
+    expect(() =>
+      parsePersistenceStorage(
+        encodeRows([eventRow, duplicateEventRow]),
+        ROOM_ID,
+      ),
+    ).toThrow(CorruptPersistenceStorageError);
+
+    const duplicateRoomRow = {
+      ...createRoomRow(ROOM_ID, 2),
+      key: "room:duplicate-room-a",
+    };
+    expect(() =>
+      parsePersistenceStorage(
+        encodeRows([createRoomRow(ROOM_ID, 1), duplicateRoomRow]),
+        ROOM_ID,
+      ),
+    ).toThrow(/more than one room row/);
+
+    const mismatchedEventRow = {
+      ...eventRow,
+      key: "event:not-batch-1",
+    };
+    expect(() =>
+      parsePersistenceStorage(encodeRows([mismatchedEventRow]), ROOM_ID),
+    ).toThrow(/does not match its batch ID/);
+  });
 });

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/schema.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/schema.ts
@@ -43,7 +43,12 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   ]),
 );
 
-const NonEmptyIdSchema = z.string().trim().min(1);
+const NonEmptyIdSchema = z
+  .string()
+  .min(1)
+  .refine((value) => value.trim() === value, {
+    message: "identifier must not contain surrounding whitespace",
+  });
 const ParentVersionSchema = z
   .array(NonEmptyIdSchema)
   .refine((parents) => new Set(parents).size === parents.length, {

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/test-helpers.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/test-helpers.ts
@@ -1,0 +1,203 @@
+import type { StorageApi, StorageEventApi } from "@tanstack/react-db";
+import type { BroadcastChannelFactory, BroadcastChannelLike } from "./channel";
+import type {
+  ExclusiveLockRequestOptions,
+  LockHandleLike,
+  LockManagerLike,
+} from "./leader";
+import { type WireBatch, WireBatchSchema } from "./schema";
+
+export class MockBroadcastNetwork {
+  private readonly channels = new Map<string, Set<MockBroadcastChannel>>();
+
+  readonly createChannel: BroadcastChannelFactory = (name) => {
+    const channel = new MockBroadcastChannel(name, this);
+    const peers = this.channels.get(name) ?? new Set<MockBroadcastChannel>();
+    peers.add(channel);
+    this.channels.set(name, peers);
+    return channel;
+  };
+
+  deliver(sender: MockBroadcastChannel, message: unknown): void {
+    for (const peer of this.channels.get(sender.name) ?? []) {
+      if (peer !== sender) peer.onmessage?.({ data: structuredClone(message) });
+    }
+  }
+
+  remove(channel: MockBroadcastChannel): void {
+    this.channels.get(channel.name)?.delete(channel);
+  }
+}
+
+class MockBroadcastChannel implements BroadcastChannelLike {
+  onmessage: BroadcastChannelLike["onmessage"] = null;
+
+  constructor(
+    readonly name: string,
+    private readonly network: MockBroadcastNetwork,
+  ) {}
+
+  postMessage(message: unknown): void {
+    this.network.deliver(this, message);
+  }
+
+  close(): void {
+    this.network.remove(this);
+  }
+}
+
+interface PendingLock {
+  readonly callback: (lock: LockHandleLike) => Promise<void> | void;
+  readonly name: string;
+  readonly options: ExclusiveLockRequestOptions;
+  readonly reject: (error: Error) => void;
+  readonly resolve: () => void;
+}
+
+export class FakeLockManager implements LockManagerLike {
+  private readonly activeNames = new Set<string>();
+  private readonly pending: PendingLock[] = [];
+  requestCount = 0;
+
+  request(
+    name: string,
+    options: ExclusiveLockRequestOptions,
+    callback: (lock: LockHandleLike) => Promise<void> | void,
+  ): Promise<void> {
+    this.requestCount++;
+    return new Promise<void>((resolve, reject) => {
+      const request = { name, options, callback, resolve, reject };
+      options.signal.addEventListener(
+        "abort",
+        () => {
+          const index = this.pending.indexOf(request);
+          if (index < 0) return;
+          this.pending.splice(index, 1);
+          const error = new Error("Lock request aborted");
+          error.name = "AbortError";
+          reject(error);
+        },
+        { once: true },
+      );
+      this.pending.push(request);
+      this.drain(name);
+    });
+  }
+
+  private drain(name: string): void {
+    if (this.activeNames.has(name)) return;
+    const index = this.pending.findIndex((request) => request.name === name);
+    if (index < 0) return;
+    const [request] = this.pending.splice(index, 1);
+    if (request === undefined) return;
+    this.activeNames.add(name);
+    const finish = (): void => {
+      this.activeNames.delete(name);
+      this.drain(name);
+    };
+    Promise.resolve(
+      request.callback({ name, mode: request.options.mode }),
+    ).then(
+      () => {
+        finish();
+        request.resolve();
+      },
+      (error: unknown) => {
+        finish();
+        request.reject(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      },
+    );
+  }
+}
+
+export class SharedStorageBackend {
+  readonly data = new Map<string, string>();
+  readonly writes: string[] = [];
+  readonly tabs = new Set<TestStorageTab>();
+  quotaExceeded = false;
+
+  createTab(id: string): TestStorageTab {
+    const tab = new TestStorageTab(id, this);
+    this.tabs.add(tab);
+    return tab;
+  }
+
+  write(source: TestStorageTab, key: string, value: string): void {
+    if (this.quotaExceeded) {
+      const error = new Error("Local storage quota exceeded");
+      error.name = "QuotaExceededError";
+      throw error;
+    }
+    this.data.set(key, value);
+    this.writes.push(source.id);
+    for (const tab of this.tabs) {
+      if (tab !== source) tab.dispatch(key);
+    }
+  }
+}
+
+export class TestStorageTab implements StorageApi, StorageEventApi {
+  private readonly listeners = new Set<(event: StorageEvent) => void>();
+
+  constructor(
+    readonly id: string,
+    private readonly backend: SharedStorageBackend,
+  ) {}
+
+  getItem(key: string): string | null {
+    return this.backend.data.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.backend.write(this, key, value);
+  }
+
+  removeItem(key: string): void {
+    this.backend.data.delete(key);
+    for (const tab of this.backend.tabs) {
+      if (tab !== this) tab.dispatch(key);
+    }
+  }
+
+  addEventListener(
+    _type: "storage",
+    listener: (event: StorageEvent) => void,
+  ): void {
+    this.listeners.add(listener);
+  }
+
+  removeEventListener(
+    _type: "storage",
+    listener: (event: StorageEvent) => void,
+  ): void {
+    this.listeners.delete(listener);
+  }
+
+  dispatch(key: string): void {
+    const event = { key, storageArea: this } as unknown as StorageEvent;
+    for (const listener of this.listeners) listener(event);
+  }
+}
+
+export const createBatch = (batchId: string, text: string): WireBatch =>
+  WireBatchSchema.parse({
+    schemaVersion: 1,
+    batchId,
+    parentVersion: [],
+    events: [
+      {
+        schemaVersion: 1,
+        id: `${batchId}:event`,
+        parentVersion: [],
+        timestamp: 1,
+        operation: { type: "insert", text },
+        effect: { type: "text-insert", blockId: "block-1", text },
+      },
+    ],
+  });
+
+export const tick = async (): Promise<void> => {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+};

--- a/apps/playground/src/modules/lexical-eg-walker/presence.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/presence.test.ts
@@ -30,14 +30,18 @@ describe("room presence", () => {
     );
   });
 
-  it("uses an isolated presence channel for each room", () => {
+  it("uses an isolated presence channel for each room", async () => {
     const identity = createRoomIdentity("peer-a");
     const first = createRoomPresenceAdapter("room-a", identity);
     const second = createRoomPresenceAdapter("room-b", identity);
 
-    expect(first).not.toBe(second);
-    expect(first.getConnectionState()).toBe("disconnected");
-    expect(second.getConnectionState()).toBe("disconnected");
+    try {
+      expect(first).not.toBe(second);
+      expect(first.getConnectionState()).toBe("disconnected");
+      expect(second.getConnectionState()).toBe("disconnected");
+    } finally {
+      await Promise.all([first.disconnect(), second.disconnect()]);
+    }
   });
 
   it("does not expose users from the previous room during a room switch", async () => {

--- a/apps/playground/src/modules/lexical-eg-walker/presence.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/presence.ts
@@ -36,17 +36,12 @@ interface AdapterValue<T> {
   readonly value: T;
 }
 
-const randomId = (): string => {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-    return crypto.randomUUID();
-  }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-};
+const randomId = (): string => crypto.randomUUID();
 
 const hashString = (value: string): number => {
   let hash = 2166136261;
   for (const character of value) {
-    hash ^= character.charCodeAt(0);
+    hash ^= character.codePointAt(0) ?? 0;
     hash = Math.imul(hash, 16777619);
   }
   return hash >>> 0;

--- a/apps/playground/src/modules/lexical-eg-walker/remote-selection-geometry.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/remote-selection-geometry.ts
@@ -1,0 +1,173 @@
+import {
+  isDirectionalSelectionRange,
+  type PresenceUser,
+} from "@softmaple/awareness";
+import type {
+  LexicalBinding,
+  LogicalSelection,
+  LogicalSelectionPoint,
+} from "@softmaple/binding-lexical";
+
+export interface OverlayRect {
+  readonly height: number;
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+}
+
+export interface PeerGeometry {
+  readonly backward: boolean;
+  readonly caret: OverlayRect | null;
+  readonly peer: PresenceUser;
+  readonly selection: ReadonlyArray<OverlayRect>;
+}
+
+interface DomPoint {
+  readonly node: Node;
+  readonly offset: number;
+}
+
+interface DomUnit {
+  readonly from: number;
+  readonly to: number;
+  readonly node: Node;
+  readonly parent: Node;
+  readonly childIndex: number;
+  readonly type: "text" | "break";
+}
+
+const childIndex = (node: ChildNode): number =>
+  node.parentNode === null
+    ? 0
+    : Array.from(node.parentNode.childNodes).indexOf(node);
+
+const collectUnits = (
+  node: Node,
+  units: DomUnit[],
+  initialOffset = 0,
+): number => {
+  let offset = initialOffset;
+  for (const child of node.childNodes) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      const length = child.textContent?.length ?? 0;
+      units.push({
+        from: offset,
+        to: offset + length,
+        node: child,
+        parent: node,
+        childIndex: childIndex(child),
+        type: "text",
+      });
+      offset += length;
+      continue;
+    }
+    if (!(child instanceof HTMLElement)) continue;
+    if (child.tagName === "BR") {
+      units.push({
+        from: offset,
+        to: offset + 1,
+        node: child,
+        parent: node,
+        childIndex: childIndex(child),
+        type: "break",
+      });
+      offset++;
+      continue;
+    }
+    if (child.tagName === "UL" || child.tagName === "OL") continue;
+    offset = collectUnits(child, units, offset);
+  }
+  return offset;
+};
+
+const resolveDomPoint = (
+  binding: LexicalBinding,
+  point: LogicalSelectionPoint,
+): DomPoint | null => {
+  const key = binding.getBlockIndex().blockIdToNodeKey.get(point.blockId);
+  if (key === undefined) return null;
+  const block = binding.editor.getElementByKey(key);
+  if (block === null) return null;
+  const units: DomUnit[] = [];
+  const length = collectUnits(block, units);
+  const offset = Math.max(0, Math.min(length, point.offset));
+  const text = units.find(
+    (unit) => unit.type === "text" && offset >= unit.from && offset <= unit.to,
+  );
+  if (text !== undefined) {
+    return { node: text.node, offset: offset - text.from };
+  }
+  const next = units.find((unit) => unit.from >= offset);
+  if (next !== undefined) {
+    return { node: next.parent, offset: next.childIndex };
+  }
+  return { node: block, offset: block.childNodes.length };
+};
+
+const collapsedRange = (point: DomPoint): Range => {
+  const range = document.createRange();
+  range.setStart(point.node, point.offset);
+  range.collapse(true);
+  return range;
+};
+
+const relativeRect = (
+  rect: DOMRect,
+  host: DOMRect,
+  minimumWidth = 0,
+): OverlayRect => ({
+  left: rect.left - host.left,
+  top: rect.top - host.top,
+  width: Math.max(minimumWidth, rect.width),
+  height: Math.max(18, rect.height),
+});
+
+export const resolvePeerSelection = (
+  binding: Pick<LexicalBinding, "resolveSelection">,
+  peer: PresenceUser,
+): LogicalSelection | null => {
+  if (!isDirectionalSelectionRange(peer.selection)) return null;
+  try {
+    return binding.resolveSelection(peer.selection);
+  } catch {
+    return null;
+  }
+};
+
+export const measurePeer = (
+  binding: LexicalBinding,
+  host: HTMLElement,
+  peer: PresenceUser,
+): PeerGeometry | null => {
+  const logical = resolvePeerSelection(binding, peer);
+  if (logical === null) return null;
+  const anchor = resolveDomPoint(binding, logical.anchor);
+  const focus = resolveDomPoint(binding, logical.focus);
+  if (anchor === null || focus === null) return null;
+
+  const anchorRange = collapsedRange(anchor);
+  const focusRange = collapsedRange(focus);
+  const backward =
+    anchorRange.compareBoundaryPoints(Range.START_TO_START, focusRange) > 0;
+  const start = backward ? focus : anchor;
+  const end = backward ? anchor : focus;
+  const selectionRange = document.createRange();
+  selectionRange.setStart(start.node, start.offset);
+  selectionRange.setEnd(end.node, end.offset);
+  const hostRect = host.getBoundingClientRect();
+  const selection = Array.from(selectionRange.getClientRects())
+    .filter((rect) => rect.width > 0 && rect.height > 0)
+    .map((rect) => relativeRect(rect, hostRect));
+  const focusRect =
+    focusRange.getClientRects()[0] ?? focusRange.getBoundingClientRect();
+  const caret =
+    focusRect.height > 0
+      ? relativeRect(focusRect, hostRect, 2)
+      : {
+          left: focusRect.left - hostRect.left,
+          top: focusRect.top - hostRect.top,
+          width: 2,
+          height: 20,
+        };
+  return { backward, caret, peer, selection };
+};

--- a/apps/playground/src/modules/lexical-eg-walker/room.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/room.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { createRoomId, resolveRoomId } from "./room";
 
-describe("Lexical EG-walker demo", () => {
-  it("creates URL-safe room identifiers", () => {
-    expect(createRoomId()).toMatch(/^[a-zA-Z0-9_-]{8,64}$/);
+describe("room", () => {
+  it("creates unique 12-character URL-safe room identifiers", () => {
+    const ids = Array.from({ length: 8 }, createRoomId);
+
+    expect(ids).toHaveLength(new Set(ids).size);
+    for (const id of ids) {
+      expect(id).toHaveLength(12);
+      expect(id).toMatch(/^[a-zA-Z0-9_-]+$/);
+    }
   });
 
   it("derives requested rooms while retaining the generated fallback", () => {

--- a/apps/playground/src/modules/lexical-eg-walker/room.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/room.ts
@@ -1,8 +1,5 @@
 export const createRoomId = (): string => {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-    return crypto.randomUUID().replaceAll("-", "").slice(0, 12);
-  }
-  return Math.random().toString(36).slice(2).padEnd(12, "0").slice(0, 12);
+  return crypto.randomUUID().replaceAll("-", "").slice(0, 12);
 };
 
 export const resolveRoomId = (

--- a/apps/playground/src/modules/lexical-eg-walker/useLexicalRoom.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/useLexicalRoom.ts
@@ -1,7 +1,4 @@
-import type {
-  LexicalBinding,
-  StableBlockSelection,
-} from "@softmaple/binding-lexical";
+import type { LexicalBinding } from "@softmaple/binding-lexical";
 import {
   type BlockReplica,
   createBlockReplica,
@@ -24,10 +21,13 @@ export interface LexicalRoomState {
   readonly flush: () => Promise<void>;
 }
 
-interface SessionValue<T> {
+export interface SessionValue<T> {
   readonly sessionKey: string;
   readonly value: T;
 }
+
+export const sessionKeyFor = (roomId: string, peerId: string): string =>
+  JSON.stringify([roomId, peerId]);
 
 const parseBatch = (batch: WireBatch): RichTextEventBatch =>
   parseRichTextEventBatch(batch);
@@ -42,7 +42,7 @@ export const useLexicalRoom = (
   roomId: string,
   peerId: string,
 ): LexicalRoomState => {
-  const sessionKey = JSON.stringify([roomId, peerId]);
+  const sessionKey = sessionKeyFor(roomId, peerId);
   const [replicaState, setReplicaState] =
     useState<SessionValue<BlockReplica> | null>(null);
   const [persistenceState, setPersistenceState] =
@@ -107,14 +107,9 @@ export const useLexicalRoom = (
 
       unsubscribeReplica = nextReplica.subscribe((change) => {
         if (change.origin !== "local" || coordinator === null) return;
-        const batches = new Map(
-          nextReplica
-            .exportEvents()
-            .map((batch) => [batch.batchId, batch] as const),
-        );
         for (const batchId of change.batchIds) {
-          const batch = batches.get(batchId);
-          if (batch !== undefined) coordinator.publishBatch(wireBatch(batch));
+          const batch = nextReplica.getBatch(batchId);
+          if (batch !== null) coordinator.publishBatch(wireBatch(batch));
         }
       });
       unsubscribeState = coordinator.subscribeState((value) => {
@@ -178,7 +173,3 @@ export const useLexicalRoom = (
 
   return { replica, persistence, error, onBindingChange, flush };
 };
-
-export const toPresenceSelection = (
-  selection: StableBlockSelection | null,
-): StableBlockSelection | null => selection;

--- a/apps/playground/src/routes/__root.tsx
+++ b/apps/playground/src/routes/__root.tsx
@@ -12,6 +12,12 @@ import Header from "@/components/Header";
 import TanStackQueryDevtools from "@/integrations/tanstack-query/devtools";
 import appCss from "@/styles.css?url";
 
+declare module "@tanstack/react-router" {
+  interface StaticDataRouteOption {
+    readonly hideHeader?: boolean;
+  }
+}
+
 export interface MyRouterContext {
   queryClient: QueryClient;
 }

--- a/apps/playground/src/routes/demo/lexical-eg-walker.tsx
+++ b/apps/playground/src/routes/demo/lexical-eg-walker.tsx
@@ -15,6 +15,7 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/demo/lexical-eg-walker")({
   ssr: false,
+  staticData: { hideHeader: true },
   validateSearch: searchSchema,
   component: LexicalEgWalkerRoute,
 });

--- a/docs/design/collaboration-layers.md
+++ b/docs/design/collaboration-layers.md
@@ -15,7 +15,7 @@ awareness's equivalent Biome rule (see [Enforcement](#enforcement) below).
 
 ## Layers at a glance
 
-```
+```text
 @softmaple/eg-walker
     - convergent sequence, event graph, stable sequence anchors
                  ↓
@@ -210,7 +210,7 @@ awareness expresses the same independence boundary in Biome:
   frameworks.
 - **`@softmaple/binding-lexical`** (ESLint) — uses
   `blockModelBindingCollaborationPatterns`. It allows block-model,
-  Lexical, and React, while forbidding a direct EG-walker import.
+  Lexical, and React, while forbidding direct EG-walker and awareness imports.
 - **`@softmaple/awareness`** (Biome) — wired in via the
   `style/noRestrictedImports` rule in `packages/awareness/biome.jsonc`.
   Forbids EG-walker, block-model, binding-lexical, and editor frameworks

--- a/docs/design/collaboration-models.md
+++ b/docs/design/collaboration-models.md
@@ -31,18 +31,22 @@ spatial concepts it does not need, and canvas would pay for sequence
 concepts that do not fit. Keeping the models distinct lets each engine
 ship the algorithm that is actually correct for its data shape.
 
+## Abstract sequence model
+
+In the abstract, a sequence collaboration model can operate on any ordered
+unit type as long as its engine defines stable boundaries for those units.
+Concrete engines must document their unit and position contract explicitly.
+
 ## 1. Sequence model
 
-The collaborative document is a **flat UTF-16 sequence**. This is the model
-implemented today by `@softmaple/eg-walker`.
+The collaborative document is a **flat UTF-16 code-unit sequence**. This is
+the concrete string model implemented today by `@softmaple/eg-walker`.
 
 ### State shape
 
 ```ts
 type SequenceState = string;
 ```
-
-(Or any sequence-shaped data; the engine does not interpret the unit.)
 
 ### Op shape
 
@@ -52,8 +56,9 @@ type SequenceOp =
   | { type: "delete"; index: number; length: number };
 ```
 
-Indices are UTF-16 code-unit boundaries. Public operations and anchors reject
-a position that splits a surrogate pair.
+The current `@softmaple/eg-walker` string API measures indices and lengths in
+UTF-16 code units. Public operations and anchors reject a boundary that splits
+a surrogate pair.
 
 ### Position shape
 

--- a/packages/binding-lexical/package.json
+++ b/packages/binding-lexical/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "version": "0.1.0",
   "private": true,
-  "draft": true,
   "description": "Thin Lexical binding for the Softmaple EG-walker block model",
   "exports": {
     ".": {
@@ -58,8 +57,5 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.6"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/binding-lexical/src/binding.test.ts
+++ b/packages/binding-lexical/src/binding.test.ts
@@ -61,6 +61,22 @@ const replaceFirstBlock = (editor: LexicalEditor, text: string): void => {
 };
 
 describe("createLexicalBinding", () => {
+  it("reports an initial materialization failure and still creates a binding", () => {
+    const replica = createBlockReplica("initial-materialize-error");
+    const editor = createTestEditor();
+    const error = new Error("initial materialization failed");
+    vi.spyOn(editor, "update").mockImplementationOnce(() => {
+      throw error;
+    });
+    const onError = vi.fn();
+
+    const binding = createLexicalBinding({ editor, replica, onError });
+
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(binding.replica).toBe(replica);
+    binding.destroy();
+  });
+
   it("broadcasts one local batch per update and applies a remote update without echo", () => {
     const firstReplica = createBlockReplica("first");
     const secondReplica = createBlockReplica("second");
@@ -204,19 +220,17 @@ describe("createLexicalBinding", () => {
     root.remove();
   });
 
-  it("flushes composition state when the editor root is replaced", () => {
+  it("flushes composition state when the editor root is removed", () => {
     const replica = createBlockReplica("ime-root-replacement");
     const editor = createTestEditor();
     const firstRoot = document.createElement("div");
-    const secondRoot = document.createElement("div");
     firstRoot.contentEditable = "true";
-    secondRoot.contentEditable = "true";
-    document.body.append(firstRoot, secondRoot);
+    document.body.append(firstRoot);
     editor.setRootElement(firstRoot);
     const binding = createLexicalBinding({ editor, replica });
 
     firstRoot.dispatchEvent(new CompositionEvent("compositionstart"));
-    editor.setRootElement(secondRoot);
+    editor.setRootElement(null);
     editor.update(
       () => {
         const block = $getRoot().getFirstChild();
@@ -229,9 +243,35 @@ describe("createLexicalBinding", () => {
     expect(replica.getDocument().blocks[0]?.text).toBe("committed");
 
     binding.destroy();
-    editor.setRootElement(null);
     firstRoot.remove();
-    secondRoot.remove();
+  });
+
+  it("materializes direct remote changes after composition ends", async () => {
+    const replica = createBlockReplica("ime-direct-local");
+    const remote = createBlockReplica("ime-direct-remote");
+    const editor = createTestEditor();
+    const root = document.createElement("div");
+    root.contentEditable = "true";
+    document.body.append(root);
+    editor.setRootElement(root);
+    const binding = createLexicalBinding({ editor, replica });
+    const batch = remote.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "remote");
+    });
+    if (batch === null) throw new Error("Expected a remote batch");
+
+    root.dispatchEvent(new CompositionEvent("compositionstart"));
+    replica.applyRemoteEvents(batch);
+    expect(getProjectedText(editor)).toBe("");
+
+    root.dispatchEvent(new CompositionEvent("compositionend"));
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    expect(getProjectedText(editor)).toBe("remote");
+    binding.destroy();
+    editor.setRootElement(null);
+    root.remove();
   });
 
   it("restores read-only state only when the binding enabled editing", () => {

--- a/packages/binding-lexical/src/binding.ts
+++ b/packages/binding-lexical/src/binding.ts
@@ -3,6 +3,7 @@ import {
   type BlockAnchor,
   type BlockDocument,
   type BlockReplica,
+  type MarkSpan,
   type RichTextEventBatch,
 } from "@softmaple/block-model";
 import { $isListItemNode } from "@lexical/list";
@@ -25,6 +26,7 @@ import {
 import { projectLexicalDocument } from "./lexical-to-projection";
 import {
   materializeLexicalDocument,
+  type MaterializedDocument,
   type LexicalBlockIndex,
 } from "./projection-to-lexical";
 import type {
@@ -32,6 +34,8 @@ import type {
   ProjectedBlockAttributes,
   ProjectedBlockType,
   ProjectedDocument,
+  ProjectedLinkValue,
+  ProjectedMark,
 } from "./projection-types";
 
 export interface StableBlockSelection {
@@ -84,6 +88,8 @@ interface NumberedListContext {
   readonly boundary?: NumberedListBoundary;
 }
 
+type NumberedListSourceContext = Omit<NumberedListContext, "overridden">;
+
 const EMPTY_NUMBERED_LIST_STATE: NumberedListState = {
   boundaries: new Map(),
   fallbackBoundaries: new Map(),
@@ -104,7 +110,7 @@ const createNumberedListState = (
   const boundaries = new Map<string, NumberedListBoundary>();
   const fallbackBoundaries = new Map<string, NumberedListBoundary>();
   const displayValues = new Map<string, number>();
-  const contexts = new Map<string | null, NumberedListContext>();
+  const contexts = new Map<string | null, NumberedListSourceContext>();
 
   for (const block of document.blocks) {
     const parentId = block.attrs.parentId;
@@ -114,7 +120,6 @@ const createNumberedListState = (
         activeType: block.type,
         start: 1,
         nextValue: 1,
-        overridden: false,
       });
       continue;
     }
@@ -125,8 +130,12 @@ const createNumberedListState = (
       ? previous.start
       : (attributes.start ?? 1);
     const expectedValue = continuesList ? previous.nextValue : expectedStart;
+    const hasExplicitNumbering =
+      attributes.start !== undefined || attributes.value !== undefined;
     const isBoundary =
-      attributes.start !== expectedStart || attributes.value !== expectedValue;
+      hasExplicitNumbering &&
+      (attributes.start !== expectedStart ||
+        attributes.value !== expectedValue);
     const start = isBoundary
       ? (attributes.start ?? expectedStart)
       : expectedStart;
@@ -146,7 +155,6 @@ const createNumberedListState = (
       activeType: "number-list",
       start,
       nextValue: displayValue + 1,
-      overridden: isBoundary || (previous?.overridden ?? false),
       ...(boundary === undefined ? {} : { boundary }),
     });
   }
@@ -247,24 +255,26 @@ const compareLogicalPoints = (
   left: LogicalSelection["anchor"],
   right: LogicalSelection["anchor"],
   document: BlockDocument,
-): number => {
-  if (left.blockId === right.blockId) return left.offset - right.offset;
+): number | null => {
   const leftIndex = document.blocks.findIndex(({ id }) => id === left.blockId);
   const rightIndex = document.blocks.findIndex(
     ({ id }) => id === right.blockId,
   );
+  if (leftIndex < 0 || rightIndex < 0) return null;
+  if (left.blockId === right.blockId) return left.offset - right.offset;
   return leftIndex - rightIndex;
 };
 
 const stableSelection = (
   logical: LogicalSelection,
   replica: BlockReplica,
-): StableBlockSelection => {
+): StableBlockSelection | null => {
   const order = compareLogicalPoints(
     logical.anchor,
     logical.focus,
     replica.getDocument(),
   );
+  if (order === null) return null;
   const collapsed = order === 0;
   const anchorAffinity = collapsed ? "after" : order < 0 ? "after" : "before";
   const focusAffinity = collapsed ? "after" : order < 0 ? "before" : "after";
@@ -290,8 +300,35 @@ const resolveStableSelection = (
   focus: replica.resolveBlockAnchor(selection.focus),
 });
 
-const sameJson = (left: unknown, right: unknown): boolean =>
-  JSON.stringify(left) === JSON.stringify(right);
+const sameLinkValue = (
+  left: ProjectedLinkValue,
+  right: MarkSpan["value"],
+): boolean =>
+  right !== true &&
+  left.url === right.url &&
+  left.target === right.target &&
+  left.rel === right.rel &&
+  left.title === right.title;
+
+const sameProjectedMarks = (
+  projected: ReadonlyArray<ProjectedMark>,
+  materialized: ReadonlyArray<MarkSpan>,
+): boolean =>
+  projected.length === materialized.length &&
+  projected.every((mark, index) => {
+    const other = materialized[index];
+    if (
+      other === undefined ||
+      mark.kind !== other.kind ||
+      mark.from !== other.from ||
+      mark.to !== other.to
+    ) {
+      return false;
+    }
+    return mark.kind === "link"
+      ? sameLinkValue(mark.value, other.value)
+      : other.value === true;
+  });
 
 const expectedParentId = (
   block: ProjectedBlock,
@@ -331,13 +368,7 @@ const projectionMatchesDocument = (
         (attributes.start ?? null) === block.attrs.start &&
         (attributes.value ?? null) === block.attrs.value &&
         (attributes.checked ?? null) === block.attrs.checked &&
-        sameJson(
-          projected.marks.map((mark) => ({
-            ...mark,
-            value: mark.kind === "link" ? mark.value : true,
-          })),
-          block.marks,
-        )
+        sameProjectedMarks(projected.marks, block.marks)
       );
     })
   );
@@ -429,7 +460,9 @@ export const createLexicalBinding = ({
   let isComposing = false;
   let isApplyingRemote = false;
   let hasPendingCompositionUpdate = false;
+  let hasMissedRemoteChange = false;
   let blockIndex = EMPTY_BLOCK_INDEX;
+  let materializedDocument: MaterializedDocument | null = null;
   let numberedListState = EMPTY_NUMBERED_LIST_STATE;
   let queuedRemoteBatches: RichTextEventBatch[] = [];
   let pendingSelection: StableBlockSelection | null = null;
@@ -439,12 +472,25 @@ export const createLexicalBinding = ({
     onError(error instanceof Error ? error : new Error(String(error)));
   };
 
+  const applyNumberedListValues = (): void => {
+    if (numberedListState.displayValues.size === 0) return;
+    editor.update(
+      () => {
+        restoreNumberedListValues(blockIndex, numberedListState);
+      },
+      {
+        discrete: true,
+        skipTransforms: true,
+        tag: COLLABORATION_TAG,
+      },
+    );
+  };
+
   const captureSelection = (): StableBlockSelection | null => {
-    let logical: LogicalSelection | null = null;
-    editor.getEditorState().read(() => {
-      logical = captureLogicalSelection(blockIndex);
+    return editor.getEditorState().read(() => {
+      const logical = captureLogicalSelection(blockIndex);
+      return logical === null ? null : stableSelection(logical, replica);
     });
-    return logical === null ? null : stableSelection(logical, replica);
   };
 
   const publishSelection = (): void => {
@@ -461,6 +507,7 @@ export const createLexicalBinding = ({
   ): void => {
     if (destroyed) return;
     const document = replica.getDocument();
+    const nextMaterializedDocument = toMaterializedDocument(document);
     numberedListState = createNumberedListState(document);
     const logical =
       selection === null ? null : resolveStableSelection(selection, replica);
@@ -469,24 +516,17 @@ export const createLexicalBinding = ({
       editor.update(
         () => {
           blockIndex = materializeLexicalDocument(
-            toMaterializedDocument(document),
+            nextMaterializedDocument,
+            materializedDocument === null
+              ? undefined
+              : { document: materializedDocument, index: blockIndex },
           );
           if (logical !== null) restoreLogicalSelection(logical, blockIndex);
         },
         { discrete: true, tag: COLLABORATION_TAG },
       );
-      if (numberedListState.displayValues.size > 0) {
-        editor.update(
-          () => {
-            restoreNumberedListValues(blockIndex, numberedListState);
-          },
-          {
-            discrete: true,
-            skipTransforms: true,
-            tag: COLLABORATION_TAG,
-          },
-        );
-      }
+      materializedDocument = nextMaterializedDocument;
+      applyNumberedListValues();
     } finally {
       isApplyingRemote = false;
       pendingSelection = null;
@@ -509,18 +549,7 @@ export const createLexicalBinding = ({
         projected.blocks,
         document.blocks.map(({ id }) => id),
       );
-      if (numberedListState.displayValues.size > 0) {
-        editor.update(
-          () => {
-            restoreNumberedListValues(blockIndex, numberedListState);
-          },
-          {
-            discrete: true,
-            skipTransforms: true,
-            tag: COLLABORATION_TAG,
-          },
-        );
-      }
+      applyNumberedListValues();
       publishSelection();
       return;
     }
@@ -530,23 +559,17 @@ export const createLexicalBinding = ({
       );
       blockIndex = blockIndexForProjection(projected.blocks, blockIds);
     });
+    materializedDocument = toMaterializedDocument(replica.getDocument());
     numberedListState = createNumberedListState(replica.getDocument());
-    if (numberedListState.displayValues.size > 0) {
-      editor.update(
-        () => {
-          restoreNumberedListValues(blockIndex, numberedListState);
-        },
-        {
-          discrete: true,
-          skipTransforms: true,
-          tag: COLLABORATION_TAG,
-        },
-      );
-    }
+    applyNumberedListValues();
     publishSelection();
   };
 
-  materialize(null);
+  try {
+    materialize(null);
+  } catch (error) {
+    reportError(error);
+  }
   if (enableEditingOnReady) editor.setEditable(true);
 
   const unregisterUpdate = editor.registerUpdateListener(
@@ -585,8 +608,14 @@ export const createLexicalBinding = ({
         queuedRemoteBatches = [];
         replica.applyRemoteEvents(queued);
       }
+      if (hasMissedRemoteChange) {
+        materialize();
+        publishSelection();
+      }
     } catch (error) {
       reportError(error);
+    } finally {
+      hasMissedRemoteChange = false;
     }
   };
 
@@ -613,7 +642,10 @@ export const createLexicalBinding = ({
 
   const unsubscribeReplica = replica.subscribe((change) => {
     if (destroyed || change.origin !== "remote") return;
-    if (isComposing) return;
+    if (isComposing) {
+      hasMissedRemoteChange = true;
+      return;
+    }
     try {
       materialize();
       publishSelection();

--- a/packages/binding-lexical/src/block-model-projection.ts
+++ b/packages/binding-lexical/src/block-model-projection.ts
@@ -31,9 +31,6 @@ const inputMark = (mark: ProjectedMark): MarkSpan => {
   if (mark.kind !== "link") {
     return { kind: mark.kind, from: mark.from, to: mark.to, value: true };
   }
-  if (mark.value === undefined) {
-    throw new Error("A projected link mark must include link attributes");
-  }
   return {
     kind: mark.kind,
     from: mark.from,
@@ -60,6 +57,21 @@ const blockInput = (block: ProjectedBlock): BlockInput => ({
   marks: block.marks.map(inputMark),
 });
 
+const projectedMark = (mark: MarkSpan): ProjectedMark => {
+  if (mark.kind === "link") {
+    if (mark.value === true) {
+      throw new Error("A materialized link mark must include link attributes");
+    }
+    return {
+      kind: "link",
+      from: mark.from,
+      to: mark.to,
+      value: mark.value,
+    };
+  }
+  return { kind: mark.kind, from: mark.from, to: mark.to };
+};
+
 export const toBlockDocumentInput = (
   projection: ProjectedDocument,
 ): BlockDocumentInput => ({
@@ -74,14 +86,7 @@ export const toMaterializedDocument = (
     parentId: block.attrs.parentId,
     type: block.type,
     text: block.text,
-    marks: block.marks.map((mark) => ({
-      kind: mark.kind,
-      from: mark.from,
-      to: mark.to,
-      ...(mark.kind === "link" && mark.value !== true
-        ? { value: mark.value }
-        : {}),
-    })),
+    marks: block.marks.map(projectedMark),
     attributes: {
       checked: block.attrs.checked ?? undefined,
       language: block.attrs.language,

--- a/packages/binding-lexical/src/index.ts
+++ b/packages/binding-lexical/src/index.ts
@@ -11,3 +11,4 @@ export {
   type LogicalSelection,
   type LogicalSelectionPoint,
 } from "./lexical-selection";
+export type { LexicalBlockIndex } from "./projection-to-lexical";

--- a/packages/binding-lexical/src/lexical-selection.ts
+++ b/packages/binding-lexical/src/lexical-selection.ts
@@ -35,16 +35,14 @@ interface InlineLeaf {
   readonly type: "text" | "linebreak" | "tab";
 }
 
-const inlineChildren = (node: ElementNode): ReadonlyArray<LexicalNode> =>
-  node.getChildren().filter((child) => !$isListNode(child));
-
 const collectLeaves = (
   node: ElementNode,
   leaves: InlineLeaf[],
   initialOffset = 0,
 ): number => {
   let offset = initialOffset;
-  for (const [childIndex, child] of inlineChildren(node).entries()) {
+  for (const [childIndex, child] of node.getChildren().entries()) {
+    if ($isListNode(child)) continue;
     if ($isTextNode(child)) {
       const end = offset + child.getTextContentSize();
       leaves.push({
@@ -110,7 +108,7 @@ const pointOffset = (block: ElementNode, point: PointType): number | null => {
   const pointNode = $getNodeByKey(point.key);
   if (pointNode === null || !$isElementNode(pointNode)) return null;
   if (pointNode.getKey() === block.getKey()) {
-    const child = inlineChildren(block)[point.offset];
+    const child = block.getChildren()[point.offset];
     if (child === undefined) return documentLength;
     const leaf = leaves.find((candidate) => candidate.key === child.getKey());
     if (leaf !== undefined) return leaf.start;
@@ -125,7 +123,7 @@ const pointOffset = (block: ElementNode, point: PointType): number | null => {
     return descendant?.start ?? documentLength;
   }
 
-  const child = inlineChildren(pointNode)[point.offset];
+  const child = pointNode.getChildren()[point.offset];
   if (child !== undefined) {
     const direct = leaves.find((candidate) => candidate.key === child.getKey());
     if (direct !== undefined) return direct.start;
@@ -187,7 +185,7 @@ const setPointAtOffset = (
     point.set(next.parentKey, next.childIndex, "element");
     return;
   }
-  point.set(block.getKey(), inlineChildren(block).length, "element");
+  point.set(block.getKey(), block.getChildrenSize(), "element");
 };
 
 /** Restore anchor/focus without normalizing backwards selections. */
@@ -202,7 +200,12 @@ export const restoreLogicalSelection = (
   const focusBlock = $getNodeByKey(focusKey);
   if (!$isElementNode(anchorBlock) || !$isElementNode(focusBlock)) return false;
 
+  const currentSelection = $getSelection();
   const range = $createRangeSelection();
+  if ($isRangeSelection(currentSelection)) {
+    range.format = currentSelection.format;
+    range.style = currentSelection.style;
+  }
   setPointAtOffset(range.anchor, anchorBlock, selection.anchor.offset);
   setPointAtOffset(range.focus, focusBlock, selection.focus.offset);
   $setSelection(range);

--- a/packages/binding-lexical/src/lexical-to-projection.ts
+++ b/packages/binding-lexical/src/lexical-to-projection.ts
@@ -14,6 +14,7 @@ import {
 } from "@lexical/rich-text";
 import {
   $getRoot,
+  $isElementNode,
   $isLineBreakNode,
   $isParagraphNode,
   $isTabNode,
@@ -59,7 +60,13 @@ interface InlineAccumulator {
 const sameLinkValue = (
   left: ProjectedLinkValue | undefined,
   right: ProjectedLinkValue | undefined,
-): boolean => JSON.stringify(left) === JSON.stringify(right);
+): boolean =>
+  left === undefined || right === undefined
+    ? left === right
+    : left.url === right.url &&
+      left.target === right.target &&
+      left.rel === right.rel &&
+      left.title === right.title;
 
 const compareMarkKinds = (
   left: ProjectedMarkKind,
@@ -150,7 +157,9 @@ const appendTextNode = (
   const from = accumulator.text.length;
   accumulator.text += node.getTextContent();
   const to = accumulator.text.length;
-  const formats: ReadonlyArray<readonly [ProjectedMarkKind, boolean]> = [
+  const formats: ReadonlyArray<
+    readonly [Exclude<ProjectedMarkKind, "link">, boolean]
+  > = [
     ["bold", node.hasFormat("bold")],
     ["italic", node.hasFormat("italic")],
     ["underline", node.hasFormat("underline")],
@@ -368,6 +377,8 @@ export const projectLexicalDocument = (
   const blocks: ProjectedBlock[] = [];
   for (const child of $getRoot().getChildren()) {
     if ($isListNode(child)) {
+      assertNoUnsupportedIndent(child);
+      assertNoUnsupportedAlignment(child);
       projectList(child, stableIds, blocks);
       continue;
     }
@@ -377,10 +388,10 @@ export const projectLexicalDocument = (
         "list items must be owned by a list",
       );
     }
-    if (!child.isAttached() || !("getChildren" in child)) {
+    if (!$isElementNode(child)) {
       throw new UnsupportedLexicalNodeError(child.getType());
     }
-    blocks.push(projectTopLevelBlock(child as ElementNode, stableIds));
+    blocks.push(projectTopLevelBlock(child, stableIds));
   }
   return { blocks };
 };

--- a/packages/binding-lexical/src/projection-to-lexical.ts
+++ b/packages/binding-lexical/src/projection-to-lexical.ts
@@ -1,5 +1,5 @@
 import { $createCodeNode } from "@lexical/code";
-import { $createLinkNode } from "@lexical/link";
+import { $createLinkNode, type LinkNode } from "@lexical/link";
 import {
   $createListItemNode,
   $createListNode,
@@ -14,7 +14,9 @@ import {
   $createParagraphNode,
   $createTabNode,
   $createTextNode,
+  $getNodeByKey,
   $getRoot,
+  $isElementNode,
   type ElementNode,
   type LexicalNode,
   type NodeKey,
@@ -46,6 +48,11 @@ export interface LexicalBlockIndex {
   readonly nodeKeyToBlockId: ReadonlyMap<NodeKey, string>;
 }
 
+export interface PreviousLexicalMaterialization {
+  readonly document: MaterializedDocument;
+  readonly index: LexicalBlockIndex;
+}
+
 const textFormats: ReadonlyArray<
   readonly [ProjectedMark["kind"], TextFormatType]
 > = [
@@ -67,7 +74,8 @@ const appendMarkedTextNode = (
   parent: ElementNode,
   textNode: TextNode,
   marks: ReadonlyArray<ProjectedMark>,
-): void => {
+  openLink: LinkNode | null,
+): LinkNode | null => {
   for (const [kind, format] of textFormats) {
     if (marks.some((mark) => mark.kind === kind)) {
       textNode.toggleFormat(format);
@@ -76,21 +84,31 @@ const appendMarkedTextNode = (
   const link = marks.find((mark) => mark.kind === "link");
   if (link === undefined) {
     parent.append(textNode);
-    return;
+    return null;
   }
-  if (link.value === undefined) {
-    throw new Error("A materialized link mark must have a value");
+  if (
+    openLink !== null &&
+    openLink.getURL() === link.value.url &&
+    openLink.getTarget() === (link.value.target ?? null) &&
+    openLink.getRel() === (link.value.rel ?? null) &&
+    openLink.getTitle() === (link.value.title ?? null)
+  ) {
+    openLink.append(textNode);
+    return openLink;
   }
   const linkNode = createLink(link.value);
   linkNode.append(textNode);
   parent.append(linkNode);
+  return linkNode;
 };
 
 const appendTextRun = (
   parent: ElementNode,
   text: string,
   marks: ReadonlyArray<ProjectedMark>,
-): void => appendMarkedTextNode(parent, $createTextNode(text), marks);
+  openLink: LinkNode | null,
+): LinkNode | null =>
+  appendMarkedTextNode(parent, $createTextNode(text), marks, openLink);
 
 const createLink = (value: ProjectedLinkValue) =>
   $createLinkNode(value.url, {
@@ -116,6 +134,7 @@ const appendInlineContent = (
     }
   }
   const ordered = [...boundaries].sort((left, right) => left - right);
+  let openLink: LinkNode | null = null;
   for (let index = 0; index < ordered.length - 1; index++) {
     const from = ordered[index];
     const to = ordered[index + 1];
@@ -123,17 +142,24 @@ const appendInlineContent = (
     const content = text.slice(from, to);
     if (content === "\n") {
       parent.append($createLineBreakNode());
+      openLink = null;
       continue;
     }
     if (content === "\t") {
-      appendMarkedTextNode(
+      openLink = appendMarkedTextNode(
         parent,
         $createTabNode(),
         activeMarks(marks, from, to),
+        openLink,
       );
       continue;
     }
-    appendTextRun(parent, content, activeMarks(marks, from, to));
+    openLink = appendTextRun(
+      parent,
+      content,
+      activeMarks(marks, from, to),
+      openLink,
+    );
   }
 };
 
@@ -183,6 +209,50 @@ const lexicalListType = (type: ProjectedBlockType): ListType => {
 const isListBlock = (type: ProjectedBlockType): boolean =>
   type === "bullet-list" || type === "number-list" || type === "check-list";
 
+const sameLinkValue = (
+  left: ProjectedLinkValue,
+  right: ProjectedLinkValue,
+): boolean =>
+  left.url === right.url &&
+  left.target === right.target &&
+  left.rel === right.rel &&
+  left.title === right.title;
+
+const sameMarks = (
+  left: ReadonlyArray<ProjectedMark>,
+  right: ReadonlyArray<ProjectedMark>,
+): boolean =>
+  left.length === right.length &&
+  left.every((mark, index) => {
+    const other = right[index];
+    if (
+      other === undefined ||
+      mark.kind !== other.kind ||
+      mark.from !== other.from ||
+      mark.to !== other.to
+    ) {
+      return false;
+    }
+    return mark.kind !== "link" || other.kind !== "link"
+      ? mark.kind === other.kind
+      : sameLinkValue(mark.value, other.value);
+  });
+
+const sameBlock = (
+  left: MaterializedBlock,
+  right: MaterializedBlock,
+): boolean =>
+  left.id === right.id &&
+  (left.parentId ?? null) === (right.parentId ?? null) &&
+  left.type === right.type &&
+  left.text === right.text &&
+  left.attributes?.checked === right.attributes?.checked &&
+  left.attributes?.language === right.attributes?.language &&
+  left.attributes?.theme === right.attributes?.theme &&
+  left.attributes?.start === right.attributes?.start &&
+  left.attributes?.value === right.attributes?.value &&
+  sameMarks(left.marks, right.marks);
+
 const createListItem = (block: MaterializedBlock): ListItemNode => {
   const checked =
     block.type === "check-list" ? block.attributes?.checked : undefined;
@@ -202,8 +272,30 @@ interface ActiveChildList {
 /** Replace the Lexical root in one update and rebuild the temporary ID map. */
 export const materializeLexicalDocument = (
   document: MaterializedDocument,
+  previous?: PreviousLexicalMaterialization,
 ): LexicalBlockIndex => {
   const root = $getRoot();
+  const previousBlocks = new Map(
+    previous?.document.blocks.map((block) => [block.id, block]),
+  );
+  const reusableNodes = new Map<string, ElementNode>();
+  if (previous !== undefined) {
+    for (const block of document.blocks) {
+      const previousBlock = previousBlocks.get(block.id);
+      const key = previous.index.blockIdToNodeKey.get(block.id);
+      const node = key === undefined ? null : $getNodeByKey(key);
+      if (
+        previousBlock !== undefined &&
+        sameBlock(block, previousBlock) &&
+        $isElementNode(node) &&
+        (isListBlock(block.type)
+          ? $isListItemNode(node)
+          : !$isListItemNode(node))
+      ) {
+        reusableNodes.set(block.id, node);
+      }
+    }
+  }
   root.clear();
   const blockIdToNodeKey = new Map<string, NodeKey>();
   const nodeKeyToBlockId = new Map<NodeKey, string>();
@@ -219,14 +311,15 @@ export const materializeLexicalDocument = (
   for (const block of document.blocks) {
     if (!isListBlock(block.type)) {
       activeTopList = null;
-      const element = createTextBlock(block);
+      const element = reusableNodes.get(block.id) ?? createTextBlock(block);
       root.append(element);
       remember(block.id, element);
       continue;
     }
 
     const listType = lexicalListType(block.type);
-    const item = createListItem(block);
+    const reusable = reusableNodes.get(block.id);
+    const item = $isListItemNode(reusable) ? reusable : createListItem(block);
     if (block.parentId === undefined || block.parentId === null) {
       if (
         activeTopList === null ||

--- a/packages/binding-lexical/src/projection-types.ts
+++ b/packages/binding-lexical/src/projection-types.ts
@@ -26,12 +26,20 @@ export interface ProjectedLinkValue {
   readonly title?: string | null;
 }
 
-export interface ProjectedMark {
-  readonly kind: ProjectedMarkKind;
+interface ProjectedMarkRange {
   readonly from: number;
   readonly to: number;
-  readonly value?: ProjectedLinkValue;
 }
+
+export type ProjectedMark =
+  | (ProjectedMarkRange & {
+      readonly kind: Exclude<ProjectedMarkKind, "link">;
+      readonly value?: never;
+    })
+  | (ProjectedMarkRange & {
+      readonly kind: "link";
+      readonly value: ProjectedLinkValue;
+    });
 
 export interface ProjectedBlockAttributes {
   readonly checked?: boolean;

--- a/packages/block-model/src/materialize.ts
+++ b/packages/block-model/src/materialize.ts
@@ -12,6 +12,7 @@ import {
   METADATA_MARKER,
   TEXT_ESCAPE,
 } from "./constants";
+import { MARK_KINDS } from "./schema-values";
 import type {
   Block,
   BlockAttributes,
@@ -101,6 +102,11 @@ interface ResolvedMarkEvent {
   readonly end: number;
 }
 
+interface AncestorResolver {
+  collect(eventId: string): ReadonlySet<string>;
+  isAncestor(ancestorId: string, descendantId: string): boolean;
+}
+
 export const materializeBlockState = (
   replica: EgWalkerReplica,
   events: ReadonlyArray<RichTextEvent>,
@@ -110,6 +116,7 @@ export const materializeBlockState = (
   const parents = new Map(
     events.map((event) => [event.id, new Set(event.parentVersion)]),
   );
+  const ancestors = createAncestorResolver(parents);
   const assignments = collectFieldAssignments(events);
   const removalCauses = new Map<BlockId, Set<string>>();
   const joined = new Set<BlockId>();
@@ -169,7 +176,7 @@ export const materializeBlockState = (
         removalCauses.get(marker.blockId) ?? new Set<string>();
       for (const removeEventId of sourceCauses) {
         if (
-          !isAncestor(marker.eventId, removeEventId, parents) &&
+          !ancestors.isAncestor(marker.eventId, removeEventId) &&
           !childCauses.has(removeEventId)
         ) {
           childCauses.add(removeEventId);
@@ -228,7 +235,7 @@ export const materializeBlockState = (
     const fields = resolveBlockFields(
       marker.blockId,
       assignments.get(marker.blockId),
-      parents,
+      ancestors,
       eventsById,
     );
     mutableBlocks.push({
@@ -258,7 +265,7 @@ export const materializeBlockState = (
     sequenceProjection,
     events,
     markers,
-    parents,
+    ancestors,
     removalCauses,
     joinEvents,
   );
@@ -272,7 +279,7 @@ export const materializeBlockState = (
     const marks = materializeMarks(
       mutable.units,
       resolvedMarks,
-      parents,
+      ancestors,
       splitLineages,
     );
     const block: Block = Object.freeze({
@@ -314,16 +321,28 @@ const buildSplitLineages = (
   const lineages = new Map<BlockId, ReadonlySet<BlockId>>();
 
   for (const { blockId } of markers) {
-    const lineage = new Set<BlockId>();
+    const path: BlockId[] = [];
+    const visited = new Set<BlockId>();
     let current: BlockId | null = blockId;
+    let inherited: ReadonlySet<BlockId> = new Set();
     while (current !== null) {
-      if (lineage.has(current)) {
+      if (visited.has(current)) {
         throw new Error(`Cyclic split lineage at block ${current}`);
       }
-      lineage.add(current);
+      visited.add(current);
+      const cached = lineages.get(current);
+      if (cached !== undefined) {
+        inherited = cached;
+        break;
+      }
+      path.push(current);
       current = sourceByBlock.get(current) ?? null;
     }
-    lineages.set(blockId, lineage);
+    for (let index = path.length - 1; index >= 0; index--) {
+      const id = path[index]!;
+      inherited = new Set([...inherited, id]);
+      lineages.set(id, inherited);
+    }
   }
 
   return lineages;
@@ -378,7 +397,7 @@ const addFields = (
 const resolveBlockFields = (
   blockId: BlockId,
   assignments: ReadonlyMap<BlockFieldName, FieldAssignment[]> | undefined,
-  parents: ReadonlyMap<string, ReadonlySet<string>>,
+  ancestors: AncestorResolver,
   eventsById: ReadonlyMap<string, RichTextEvent>,
 ): CompleteBlockFields => {
   if (assignments === undefined) {
@@ -389,7 +408,7 @@ const resolveBlockFields = (
     if (candidates === undefined || candidates.length === 0) {
       return DEFAULT_BLOCK_FIELDS[field];
     }
-    return selectCausalMaximal(candidates, parents, eventsById).value;
+    return selectCausalMaximal(candidates, ancestors, eventsById).value;
   };
   return {
     type: winner("type") as BlockType,
@@ -404,7 +423,7 @@ const resolveBlockFields = (
 
 const selectCausalMaximal = <T extends { readonly eventId: string }>(
   candidates: ReadonlyArray<T>,
-  parents: ReadonlyMap<string, ReadonlySet<string>>,
+  ancestors: AncestorResolver,
   eventsById?: ReadonlyMap<string, RichTextEvent>,
 ): T => {
   const maxima = candidates.filter(
@@ -412,7 +431,7 @@ const selectCausalMaximal = <T extends { readonly eventId: string }>(
       !candidates.some(
         (other) =>
           candidate.eventId !== other.eventId &&
-          isAncestor(candidate.eventId, other.eventId, parents),
+          ancestors.isAncestor(candidate.eventId, other.eventId),
       ),
   );
   const winner = maxima.reduce<T | null>(
@@ -428,25 +447,34 @@ const selectCausalMaximal = <T extends { readonly eventId: string }>(
   return winner;
 };
 
-const isAncestor = (
-  ancestorId: string,
-  descendantId: string,
+const createAncestorResolver = (
   parents: ReadonlyMap<string, ReadonlySet<string>>,
-): boolean => {
-  const stack = [...(parents.get(descendantId) ?? [])];
-  const visited = new Set<string>();
-  while (stack.length > 0) {
-    const current = stack.pop()!;
-    if (current === ancestorId) {
-      return true;
+): AncestorResolver => {
+  const cache = new Map<string, ReadonlySet<string>>();
+  const collect = (eventId: string): ReadonlySet<string> => {
+    const cached = cache.get(eventId);
+    if (cached !== undefined) return cached;
+    const result = new Set<string>();
+    const stack = [...(parents.get(eventId) ?? [])];
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      if (result.has(current)) continue;
+      result.add(current);
+      const currentCached = cache.get(current);
+      if (currentCached !== undefined) {
+        for (const ancestor of currentCached) result.add(ancestor);
+      } else {
+        stack.push(...(parents.get(current) ?? []));
+      }
     }
-    if (visited.has(current)) {
-      continue;
-    }
-    visited.add(current);
-    stack.push(...(parents.get(current) ?? []));
-  }
-  return false;
+    cache.set(eventId, result);
+    return result;
+  };
+  return {
+    collect,
+    isAncestor: (ancestorId, descendantId) =>
+      collect(descendantId).has(ancestorId),
+  };
 };
 
 const decodeSegment = (
@@ -528,7 +556,7 @@ const resolveMarkEvents = (
   projection: SequenceAnchorProjection,
   events: ReadonlyArray<RichTextEvent>,
   markers: ReadonlyArray<MarkerRecord>,
-  parents: ReadonlyMap<string, ReadonlySet<string>>,
+  ancestors: AncestorResolver,
   removalCauses: ReadonlyMap<BlockId, ReadonlySet<string>>,
   joinEvents: ReadonlyMap<BlockId, ReadonlyArray<string>>,
 ): ReadonlyArray<ResolvedMarkEvent> =>
@@ -549,7 +577,7 @@ const resolveMarkEvents = (
             ? new Set([event.effect.blockId])
             : resolveMarkOwnership(
                 event.effect.blockId,
-                collectAncestors(event.id, parents),
+                ancestors.collect(event.id),
                 markers,
                 removalCauses,
                 joinEvents,
@@ -561,23 +589,6 @@ const resolveMarkEvents = (
       },
     ];
   });
-
-const collectAncestors = (
-  eventId: string,
-  parents: ReadonlyMap<string, ReadonlySet<string>>,
-): ReadonlySet<string> => {
-  const ancestors = new Set<string>();
-  const stack = [...(parents.get(eventId) ?? [])];
-  while (stack.length > 0) {
-    const current = stack.pop()!;
-    if (ancestors.has(current)) {
-      continue;
-    }
-    ancestors.add(current);
-    stack.push(...(parents.get(current) ?? []));
-  }
-  return ancestors;
-};
 
 /**
  * Recover the visible block group that owned a mark range when it was set.
@@ -627,33 +638,43 @@ const resolveMarkOwnership = (
 const materializeMarks = (
   units: ReadonlyArray<DecodedUnit>,
   markEvents: ReadonlyArray<ResolvedMarkEvent>,
-  parents: ReadonlyMap<string, ReadonlySet<string>>,
+  ancestors: AncestorResolver,
   splitLineages: ReadonlyMap<BlockId, ReadonlySet<BlockId>>,
 ): MarkSpan[] => {
   const spans: MarkSpan[] = [];
-  for (const kind of [
-    "bold",
-    "italic",
-    "underline",
-    "strike",
-    "inline-code",
-    "link",
-  ] as const) {
+  const eventsByKind = new Map<MarkKind, ReadonlyArray<ResolvedMarkEvent>>();
+  for (const kind of MARK_KINDS) {
+    eventsByKind.set(
+      kind,
+      markEvents
+        .filter((event) => event.kind === kind)
+        .sort(
+          (left, right) =>
+            left.start - right.start ||
+            left.end - right.end ||
+            compareIds(left.eventId, right.eventId),
+        ),
+    );
+  }
+  for (const kind of MARK_KINDS) {
+    const kindEvents = eventsByKind.get(kind) ?? [];
     for (const unit of units) {
-      const candidates = markEvents.filter((event) => {
-        const lineage = splitLineages.get(unit.blockId);
-        return (
-          event.kind === kind &&
-          lineage !== undefined &&
+      const lineage = splitLineages.get(unit.blockId);
+      if (lineage === undefined) continue;
+      const candidates: ResolvedMarkEvent[] = [];
+      for (const event of kindEvents) {
+        if (event.start > unit.rawFrom) break;
+        if (
           setsIntersect(lineage, event.ownedBlockIds) &&
-          event.start <= unit.rawFrom &&
           unit.rawTo <= event.end
-        );
-      });
+        ) {
+          candidates.push(event);
+        }
+      }
       if (candidates.length === 0) {
         continue;
       }
-      const winner = selectCausalMaximal(candidates, parents);
+      const winner = selectCausalMaximal(candidates, ancestors);
       if (winner.value === null) {
         continue;
       }
@@ -700,7 +721,13 @@ const setsIntersect = <T>(
 const sameMarkValue = (
   left: true | LinkAttributes,
   right: true | LinkAttributes,
-): boolean => JSON.stringify(left) === JSON.stringify(right);
+): boolean =>
+  left === true || right === true
+    ? left === right
+    : left.url === right.url &&
+      left.target === right.target &&
+      left.rel === right.rel &&
+      left.title === right.title;
 
 const normalizeOutputAttributes = (
   type: BlockType,

--- a/packages/block-model/src/replica.ts
+++ b/packages/block-model/src/replica.ts
@@ -89,11 +89,16 @@ export class BlockReplica {
 
     const nextBatches = new Map(this.batchesById);
     nextBatches.set(batch.batchId, batch);
-    const rebuilt = rebuildReplica(this.replicaId, nextBatches);
+    this.egWalker.applyRemoteEvents(batch.events.map(toGraphEvent));
+    const ordered = readyBatches(nextBatches);
     this.batchesById = nextBatches;
-    this.egWalker = rebuilt.egWalker;
-    this.integratedBatchIds = rebuilt.integratedBatchIds;
-    this.state = rebuilt.state;
+    this.integratedBatchIds = new Set(
+      ordered.map((orderedBatch) => orderedBatch.batchId),
+    );
+    this.state = materializeBlockState(
+      this.egWalker,
+      ordered.flatMap((orderedBatch) => [...orderedBatch.events]),
+    );
     this.notify("local", [batch.batchId]);
     return cloneBatch(batch);
   }
@@ -164,6 +169,11 @@ export class BlockReplica {
     );
   }
 
+  getBatch(batchId: string): RichTextEventBatch | null {
+    const batch = this.batchesById.get(batchId);
+    return batch === undefined ? null : cloneBatch(batch);
+  }
+
   serialize(): SerializedBlockReplica {
     return Object.freeze({
       schemaVersion: BLOCK_MODEL_SCHEMA_VERSION,
@@ -182,7 +192,22 @@ export class BlockReplica {
     if (!Array.isArray(serialized.batches)) {
       throw new Error("Serialized block replica batches must be an array");
     }
-    const batches = serialized.batches.map(parseBatch);
+    const batches = serialized.batches.flatMap((candidate) => {
+      try {
+        return [parseBatch(candidate)];
+      } catch {
+        const record =
+          candidate !== null &&
+          typeof candidate === "object" &&
+          !Array.isArray(candidate)
+            ? (candidate as Record<string, unknown>)
+            : null;
+        if (record?.batchId === BOOTSTRAP_BATCH_ID) {
+          throw new Error("Serialized block replica has an invalid bootstrap");
+        }
+        return [];
+      }
+    });
     const bootstrap = batches.find(
       (batch) => batch.batchId === BOOTSTRAP_BATCH_ID,
     );
@@ -192,9 +217,17 @@ export class BlockReplica {
       );
     }
     const replica = new BlockReplica(replicaId);
-    replica.applyRemoteEvents(
-      batches.filter((batch) => batch.batchId !== BOOTSTRAP_BATCH_ID),
+    const ordered = readyBatches(
+      new Map(batches.map((batch) => [batch.batchId, batch])),
     );
+    for (const batch of ordered) {
+      if (batch.batchId === BOOTSTRAP_BATCH_ID) continue;
+      try {
+        replica.applyRemoteEvents(batch);
+      } catch {
+        // Keep replaying independent valid batches after quarantining this one.
+      }
+    }
     return replica;
   }
 
@@ -241,7 +274,11 @@ export class BlockReplica {
       document: this.state.document,
     });
     for (const listener of [...this.listeners]) {
-      listener(change);
+      try {
+        listener(change);
+      } catch {
+        // A subscriber must not prevent delivery to the remaining listeners.
+      }
     }
   }
 }
@@ -269,6 +306,7 @@ class BlockTransactionContext implements BlockTransaction {
   private readonly events: RichTextEvent[] = [];
   private readonly initialParentVersion: ReadonlyArray<string>;
   private state: MaterializedBlockState;
+  private stateDirty = false;
 
   constructor(
     replicaId: string,
@@ -290,7 +328,7 @@ class BlockTransactionContext implements BlockTransaction {
     if (text.length === 0) {
       return;
     }
-    const projected = requireProjectedBlock(this.state, blockId);
+    const projected = requireProjectedBlock(this.currentState(), blockId);
     const rawIndex = rawBoundary(projected, offset);
     const encoded = encodeText(text);
     const graphEvent = this.egWalker.insert(rawIndex, encoded);
@@ -301,7 +339,7 @@ class BlockTransactionContext implements BlockTransaction {
   }
 
   deleteText(blockId: BlockId, from: number, to: number): void {
-    const projected = requireProjectedBlock(this.state, blockId);
+    const projected = requireProjectedBlock(this.currentState(), blockId);
     rawBoundary(projected, from);
     rawBoundary(projected, to);
     if (from > to) {
@@ -333,15 +371,16 @@ class BlockTransactionContext implements BlockTransaction {
         fromGraphEvent(graphEvent, { type: "text-delete", blockId }),
       );
     }
-    this.refresh();
+    this.stateDirty = true;
   }
 
+  /** Insert after a projected block; null anchors after the first block. */
   insertBlock(afterBlockId: BlockId | null, input: BlockInput): BlockId {
     assertBlockInput(input);
     const after =
       afterBlockId === null
-        ? this.state.projectedBlocks[0]
-        : requireProjectedBlock(this.state, afterBlockId);
+        ? this.currentState().projectedBlocks[0]
+        : requireProjectedBlock(this.currentState(), afterBlockId);
     if (after === undefined) {
       throw new Error("Cannot insert a block into an empty projection");
     }
@@ -360,7 +399,6 @@ class BlockTransactionContext implements BlockTransaction {
         fields: normalizeFields(input.type, input.attrs),
       }),
     );
-    this.refresh();
     if (input.text.length > 0) {
       this.insertText(blockId, 0, input.text);
     }
@@ -377,7 +415,7 @@ class BlockTransactionContext implements BlockTransaction {
     preferredBlockId?: BlockId,
   ): BlockId {
     assertFieldPatch(fields);
-    const source = requireProjectedBlock(this.state, blockId);
+    const source = requireProjectedBlock(this.currentState(), blockId);
     const rawIndex = rawBoundary(source, offset);
     const graphEvent = this.egWalker.insert(rawIndex, BLOCK_MARKER);
     if (graphEvent === null) {
@@ -396,7 +434,6 @@ class BlockTransactionContext implements BlockTransaction {
         }),
       }),
     );
-    this.refresh();
     return newBlockId;
   }
 
@@ -404,8 +441,9 @@ class BlockTransactionContext implements BlockTransaction {
     if (blockId === BOOTSTRAP_BLOCK_ID) {
       throw new Error("The bootstrap block cannot be joined");
     }
-    const projected = requireProjectedBlock(this.state, blockId);
-    const index = this.state.projectedBlocks.indexOf(projected);
+    const state = this.currentState();
+    const projected = requireProjectedBlock(state, blockId);
+    const index = state.projectedBlocks.indexOf(projected);
     if (index <= 0) {
       throw new Error("The first visible block cannot be joined");
     }
@@ -416,12 +454,12 @@ class BlockTransactionContext implements BlockTransaction {
     if (blockId === BOOTSTRAP_BLOCK_ID) {
       throw new Error("The bootstrap block cannot be deleted");
     }
-    requireProjectedBlock(this.state, blockId);
+    requireProjectedBlock(this.currentState(), blockId);
     this.pushMetadata({ type: "block-delete", blockId });
   }
 
   setBlock(blockId: BlockId, fields: BlockFieldPatch): void {
-    requireProjectedBlock(this.state, blockId);
+    requireProjectedBlock(this.currentState(), blockId);
     assertFieldPatch(fields);
     if (Object.keys(fields).length === 0) {
       return;
@@ -441,7 +479,7 @@ class BlockTransactionContext implements BlockTransaction {
       throw new Error(`Unsupported mark kind ${String(kind)}`);
     }
     assertMarkValue(kind, value);
-    const projected = requireProjectedBlock(this.state, blockId);
+    const projected = requireProjectedBlock(this.currentState(), blockId);
     const rawFrom = rawBoundary(projected, from);
     const rawTo = rawBoundary(projected, to);
     if (from >= to || rawFrom >= rawTo) {
@@ -463,7 +501,7 @@ class BlockTransactionContext implements BlockTransaction {
       throw new Error("A block document must contain at least one block");
     }
     next.blocks.forEach(assertBlockInput);
-    const before = this.state.document.blocks;
+    const before = this.currentState().document.blocks;
     const existingIndex = new Map(
       before.map((block, index) => [block.id, index]),
     );
@@ -476,7 +514,7 @@ class BlockTransactionContext implements BlockTransaction {
       let stableId: BlockId;
       const knownIndex = input.id ? existingIndex.get(input.id) : undefined;
       if (index === 0) {
-        const first = this.state.document.blocks[0]!;
+        const first = this.currentState().document.blocks[0]!;
         if (input.id !== undefined && input.id !== first.id) {
           throw new Error(
             `replaceDocument cannot replace first block ID ${first.id} with ${input.id}`,
@@ -520,7 +558,7 @@ class BlockTransactionContext implements BlockTransaction {
       const input = next.blocks[index]!;
       const stableId = selectedIds[index]!;
       const parentId = resolveInputParent(input, inputIds);
-      const current = requireBlock(this.state.document, stableId);
+      const current = requireBlock(this.currentState().document, stableId);
       const desiredFields = normalizeFields(input.type, {
         ...input.attrs,
         parentId,
@@ -540,7 +578,7 @@ class BlockTransactionContext implements BlockTransaction {
           this.insertText(stableId, textChange.from, textChange.insert);
         }
       }
-      const refreshed = requireBlock(this.state.document, stableId);
+      const refreshed = requireBlock(this.currentState().document, stableId);
       const desiredMarks = input.marks ?? [];
       if (!sameMarks(refreshed.marks, desiredMarks)) {
         for (const mark of refreshed.marks) {
@@ -579,14 +617,17 @@ class BlockTransactionContext implements BlockTransaction {
 
   private pushEvent(graphEvent: GraphEvent, effect: RichTextEffect): void {
     this.events.push(fromGraphEvent(graphEvent, effect));
-    this.refresh();
+    this.stateDirty = true;
   }
 
-  private refresh(): void {
+  private currentState(): MaterializedBlockState {
+    if (!this.stateDirty) return this.state;
     this.state = materializeBlockState(this.egWalker, [
       ...this.baseEvents,
       ...this.events,
     ]);
+    this.stateDirty = false;
+    return this.state;
   }
 
   private assertUnusedBlockId(blockId: string): void {
@@ -830,7 +871,28 @@ const sameBlockAttributes = (
 const sameMarks = (
   left: ReadonlyArray<MarkSpan>,
   right: ReadonlyArray<MarkSpan>,
-): boolean => JSON.stringify(left) === JSON.stringify(right);
+): boolean =>
+  left.length === right.length &&
+  left.every((mark, index) => {
+    const other = right[index];
+    if (
+      other === undefined ||
+      mark.kind !== other.kind ||
+      mark.from !== other.from ||
+      mark.to !== other.to
+    ) {
+      return false;
+    }
+    if (mark.value === true || other.value === true) {
+      return mark.value === other.value;
+    }
+    return (
+      mark.value.url === other.value.url &&
+      mark.value.target === other.value.target &&
+      mark.value.rel === other.value.rel &&
+      mark.value.title === other.value.title
+    );
+  });
 
 interface TextChange {
   readonly from: number;
@@ -889,30 +951,69 @@ const nearestBlockBoundary = (
   rawIndex: number,
   anchor: BlockAnchor,
 ): ResolvedBlockAnchor | null => {
-  let best: {
+  type BoundaryCandidate = {
     readonly blockId: BlockId;
     readonly offset: number;
     readonly raw: number;
-  } | null = null;
-  for (const projected of projectedBlocks) {
-    for (const { offset, raw } of projected.anchorBoundaries) {
-      if (best === null) {
-        best = { blockId: projected.block.id, offset, raw };
-        continue;
+  };
+  const choose = (
+    best: BoundaryCandidate | null,
+    candidate: BoundaryCandidate,
+  ): BoundaryCandidate => {
+    if (best === null) return candidate;
+    const distance = Math.abs(candidate.raw - rawIndex);
+    const bestDistance = Math.abs(best.raw - rawIndex);
+    const affinity: AnchorAffinity = anchor.anchor.affinity;
+    const preferredTie =
+      distance === bestDistance &&
+      ((candidate.raw === best.raw &&
+        candidate.blockId === anchor.blockId &&
+        best.blockId !== anchor.blockId) ||
+        (candidate.raw !== best.raw &&
+          // "after" affinity chooses the lower raw boundary on a tie.
+          (affinity === "after"
+            ? candidate.raw < best.raw
+            : candidate.raw > best.raw)));
+    return distance < bestDistance || preferredTie ? candidate : best;
+  };
+
+  let low = 0;
+  let high = projectedBlocks.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if ((projectedBlocks[middle]?.rawEnd ?? -1) < rawIndex) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  const blockIndexes = [low - 1, low, low + 1]
+    .filter((index) => index >= 0 && index < projectedBlocks.length)
+    .filter((index, position, indexes) => indexes.indexOf(index) === position)
+    .sort((left, right) => left - right);
+
+  let best: BoundaryCandidate | null = null;
+  for (const blockIndex of blockIndexes) {
+    const projected = projectedBlocks[blockIndex]!;
+    const boundaries = projected.anchorBoundaries;
+    let boundaryLow = 0;
+    let boundaryHigh = boundaries.length;
+    while (boundaryLow < boundaryHigh) {
+      const middle = Math.floor((boundaryLow + boundaryHigh) / 2);
+      if ((boundaries[middle]?.raw ?? -1) < rawIndex) {
+        boundaryLow = middle + 1;
+      } else {
+        boundaryHigh = middle;
       }
-      const distance = Math.abs(raw - rawIndex);
-      const bestDistance = Math.abs(best.raw - rawIndex);
-      const affinity: AnchorAffinity = anchor.anchor.affinity;
-      const preferredTie =
-        distance === bestDistance &&
-        ((raw === best.raw &&
-          projected.block.id === anchor.blockId &&
-          best.blockId !== anchor.blockId) ||
-          (raw !== best.raw &&
-            (affinity === "after" ? raw < best.raw : raw > best.raw)));
-      if (distance < bestDistance || preferredTie) {
-        best = { blockId: projected.block.id, offset, raw };
-      }
+    }
+    for (const boundaryIndex of [boundaryLow - 1, boundaryLow]) {
+      const boundary = boundaries[boundaryIndex];
+      if (boundary === undefined) continue;
+      best = choose(best, {
+        blockId: projected.block.id,
+        offset: boundary.offset,
+        raw: boundary.raw,
+      });
     }
   }
   return best === null

--- a/packages/block-model/src/schema-values.ts
+++ b/packages/block-model/src/schema-values.ts
@@ -1,0 +1,23 @@
+export const BLOCK_TYPES = [
+  "paragraph",
+  "h1",
+  "h2",
+  "h3",
+  "quote",
+  "code",
+  "bullet-list",
+  "number-list",
+  "check-list",
+] as const;
+
+export const MARK_KINDS = [
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "inline-code",
+  "link",
+] as const;
+
+export const BLOCK_TYPE_SET: ReadonlySet<string> = new Set(BLOCK_TYPES);
+export const MARK_KIND_SET: ReadonlySet<string> = new Set(MARK_KINDS);

--- a/packages/block-model/src/test/property/convergence.property.test.ts
+++ b/packages/block-model/src/test/property/convergence.property.test.ts
@@ -2,18 +2,34 @@ import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
 import {
+  BLOCK_MARKER,
   BOOTSTRAP_BLOCK_ID,
   BlockReplica,
+  METADATA_MARKER,
+  TEXT_ESCAPE,
   type BlockType,
   type RichTextEventBatch,
 } from "../../index";
+
+const richTextArbitrary = fc.oneof(
+  fc.string(),
+  fc.string({
+    unit: fc.constantFrom(
+      "😀",
+      "𐐷",
+      BLOCK_MARKER,
+      METADATA_MARKER,
+      TEXT_ESCAPE,
+    ),
+  }),
+);
 
 describe("property: rich-text event DAG convergence", () => {
   it("should converge under out-of-order duplicate batch delivery", () => {
     fc.assert(
       fc.property(
-        fc.string(),
-        fc.string(),
+        richTextArbitrary,
+        richTextArbitrary,
         fc.constantFrom<BlockType>(
           "paragraph",
           "h1",

--- a/packages/block-model/src/test/replica.test.ts
+++ b/packages/block-model/src/test/replica.test.ts
@@ -163,10 +163,15 @@ describe("BlockReplica", () => {
     });
 
     // Assert
-    expect(replica.getDocument().blocks).toMatchObject([
-      { id: BOOTSTRAP_BLOCK_ID, marks: [{ kind: "bold", from: 0, to: 1 }] },
-      { id: "plain-block", text: "B", marks: [] },
+    const blocks = replica.getDocument().blocks;
+    expect(blocks).toMatchObject([
+      { id: BOOTSTRAP_BLOCK_ID },
+      { id: "plain-block", text: "B" },
     ]);
+    expect(blocks[0]?.marks).toEqual([
+      { kind: "bold", from: 0, to: 1, value: true },
+    ]);
+    expect(blocks[1]?.marks).toEqual([]);
   });
 
   it("should keep a block-end mark out of a block inserted before its successor", () => {
@@ -620,6 +625,78 @@ describe("BlockReplica", () => {
     expect(receiver.getDocument()).toEqual(source.getDocument());
   });
 
+  it("should isolate listener failures while preserving notification order", () => {
+    const replica = new BlockReplica("listener-isolation");
+    const delivered: string[] = [];
+    replica.subscribe(() => {
+      delivered.push("first");
+      throw new Error("listener failed");
+    });
+    replica.subscribe(() => delivered.push("second"));
+
+    expect(() =>
+      replica.transact((transaction) => {
+        transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "x");
+      }),
+    ).not.toThrow();
+    expect(delivered).toEqual(["first", "second"]);
+  });
+
+  it("should keep state atomic for invalid remote materialization and pending parents", () => {
+    const base = new BlockReplica("atomic-base");
+    base.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "A");
+      transaction.insertBlock(BOOTSTRAP_BLOCK_ID, {
+        id: "second",
+        type: "paragraph",
+        text: "B",
+      });
+    });
+    const remote = BlockReplica.deserialize(base.serialize(), "atomic-remote");
+    const deleteBatch = remote.transact((transaction) => {
+      transaction.deleteText(BOOTSTRAP_BLOCK_ID, 0, 1);
+    })!;
+    const firstDelete = deleteBatch.events[0];
+    if (firstDelete?.operation.type !== "delete") {
+      throw new Error("Expected a delete event");
+    }
+    const spanningDelete = parseRichTextEventBatch({
+      ...deleteBatch,
+      events: [
+        {
+          ...firstDelete,
+          operation: { ...firstDelete.operation, length: 2 },
+        },
+        ...deleteBatch.events.slice(1),
+      ],
+    });
+    const receiver = BlockReplica.deserialize(
+      base.serialize(),
+      "atomic-receiver",
+    );
+    const documentBefore = receiver.getDocument();
+    const serializedBefore = receiver.serialize();
+
+    expect(() => receiver.applyRemoteEvents(spanningDelete)).toThrow();
+    expect(receiver.getDocument()).toEqual(documentBefore);
+    expect(receiver.serialize()).toEqual(serializedBefore);
+
+    const pendingSource = new BlockReplica("pending-source");
+    const pendingBatch = pendingSource.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "pending");
+    })!;
+    const pending = parseRichTextEventBatch({
+      ...pendingBatch,
+      parentVersion: ["missing-parent"],
+      events: pendingBatch.events.map((event, index) =>
+        index === 0 ? { ...event, parentVersion: ["missing-parent"] } : event,
+      ),
+    });
+    const result = receiver.applyRemoteEvents(pending);
+    expect(result.pendingBatchIds).toContain(pending.batchId);
+    expect(receiver.getDocument()).toEqual(documentBefore);
+  });
+
   it("should replace a document with transaction-local nested parent IDs", () => {
     // Arrange
     const replica = new BlockReplica("alice");
@@ -836,6 +913,8 @@ describe("BlockReplica", () => {
     }
     const receiver = new BlockReplica("receiver");
     receiver.applyRemoteEvents(wire);
+    const documentBeforeMutation = receiver.getDocument();
+    const eventsBeforeMutation = receiver.serialize();
 
     // Act
     const mutableStart = wireMark.effect.range.start as { offset: number };
@@ -843,11 +922,50 @@ describe("BlockReplica", () => {
 
     // Assert
     expect(Object.isFrozen(parsedMark.effect.range.start)).toBe(true);
+    expect(receiver.getDocument()).toEqual(documentBeforeMutation);
+    expect(receiver.serialize()).toEqual(eventsBeforeMutation);
     expect(() =>
       receiver.transact((transaction) => {
         transaction.insertText(BOOTSTRAP_BLOCK_ID, 2, "x");
       }),
     ).not.toThrow();
+  });
+
+  it("should reject unsafe links and non-deterministic bootstrap effects", () => {
+    const source = new BlockReplica("wire-validation");
+    const marked = source.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "AB");
+      transaction.setMark(BOOTSTRAP_BLOCK_ID, 0, 2, "link", {
+        url: "https://example.com",
+      });
+    })!;
+    const unsafe = JSON.parse(JSON.stringify(marked)) as {
+      events: Array<{
+        effect: {
+          type: string;
+          value?: { url?: string };
+        };
+      }>;
+    };
+    const link = unsafe.events.find(({ effect }) => effect.type === "mark-set");
+    if (link?.effect.value === undefined) {
+      throw new Error("Expected link attributes");
+    }
+    link.effect.value.url = "javascript:alert(1)";
+
+    expect(() => parseRichTextEventBatch(unsafe)).toThrow(/link attributes/);
+
+    const bootstrap = JSON.parse(
+      JSON.stringify(new BlockReplica("bootstrap-wire").exportEvents()[0]),
+    ) as {
+      batchId: string;
+      events: Array<{ id: string }>;
+    };
+    bootstrap.batchId = "attacker:0";
+    bootstrap.events[0]!.id = "attacker:0";
+    expect(() => parseRichTextEventBatch(bootstrap)).toThrow(
+      /deterministic identities/,
+    );
   });
 
   it("should replay the sequence once when materializing many anchors", () => {

--- a/packages/block-model/src/types.ts
+++ b/packages/block-model/src/types.ts
@@ -1,27 +1,13 @@
 import type { SequenceAnchor } from "@softmaple/eg-walker/anchors";
 
 import type { BLOCK_MODEL_SCHEMA_VERSION } from "./constants";
+import type { BLOCK_TYPES, MARK_KINDS } from "./schema-values";
 
 export type BlockId = string;
 
-export type BlockType =
-  | "paragraph"
-  | "h1"
-  | "h2"
-  | "h3"
-  | "quote"
-  | "code"
-  | "bullet-list"
-  | "number-list"
-  | "check-list";
+export type BlockType = (typeof BLOCK_TYPES)[number];
 
-export type MarkKind =
-  | "bold"
-  | "italic"
-  | "underline"
-  | "strike"
-  | "inline-code"
-  | "link";
+export type MarkKind = (typeof MARK_KINDS)[number];
 
 export interface LinkAttributes {
   readonly url: string;
@@ -193,6 +179,7 @@ export interface ApplyRichTextEventsResult {
 export interface BlockTransaction {
   insertText(blockId: BlockId, offset: number, text: string): void;
   deleteText(blockId: BlockId, from: number, to: number): void;
+  /** Insert after a projected block; null anchors after the first block. */
   insertBlock(afterBlockId: BlockId | null, block: BlockInput): BlockId;
   splitBlock(
     blockId: BlockId,

--- a/packages/block-model/src/wire.ts
+++ b/packages/block-model/src/wire.ts
@@ -14,6 +14,7 @@ import {
   METADATA_MARKER,
   TEXT_ESCAPE,
 } from "./constants";
+import { BLOCK_TYPE_SET, MARK_KIND_SET } from "./schema-values";
 import type {
   BlockAttributePatch,
   BlockFieldPatch,
@@ -27,25 +28,11 @@ import type {
   SerializedTextOperation,
 } from "./types";
 
-const BLOCK_TYPES: ReadonlySet<string> = new Set([
-  "paragraph",
-  "h1",
-  "h2",
-  "h3",
-  "quote",
-  "code",
-  "bullet-list",
-  "number-list",
-  "check-list",
-]);
-
-const MARK_KINDS: ReadonlySet<string> = new Set([
-  "bold",
-  "italic",
-  "underline",
-  "strike",
-  "inline-code",
-  "link",
+const SAFE_LINK_PROTOCOLS: ReadonlySet<string> = new Set([
+  "http:",
+  "https:",
+  "mailto:",
+  "tel:",
 ]);
 
 export const DEFAULT_BLOCK_FIELDS: CompleteBlockFields = Object.freeze({
@@ -178,7 +165,7 @@ export const normalizeFields = (
 });
 
 export const assertFieldPatch = (patch: BlockFieldPatch): void => {
-  if (patch.type !== undefined && !BLOCK_TYPES.has(patch.type)) {
+  if (patch.type !== undefined && !BLOCK_TYPE_SET.has(patch.type)) {
     throw new Error(`Unsupported block type ${String(patch.type)}`);
   }
   assertOptionalNullableString(patch.parentId, "parentId");
@@ -196,10 +183,20 @@ export const assertFieldPatch = (patch: BlockFieldPatch): void => {
 };
 
 export const isBlockType = (value: unknown): value is BlockType =>
-  typeof value === "string" && BLOCK_TYPES.has(value);
+  typeof value === "string" && BLOCK_TYPE_SET.has(value);
 
 export const isMarkKind = (value: unknown): value is MarkKind =>
-  typeof value === "string" && MARK_KINDS.has(value);
+  typeof value === "string" && MARK_KIND_SET.has(value);
+
+const isSafeLinkUrl = (url: string): boolean => {
+  try {
+    return SAFE_LINK_PROTOCOLS.has(
+      new URL(url, "https://softmaple.invalid").protocol,
+    );
+  } catch {
+    return false;
+  }
+};
 
 export const isLinkAttributes = (value: unknown): value is LinkAttributes => {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -208,6 +205,7 @@ export const isLinkAttributes = (value: unknown): value is LinkAttributes => {
   const link = value as Record<string, unknown>;
   return (
     typeof link.url === "string" &&
+    isSafeLinkUrl(link.url) &&
     optionalString(link.target) &&
     optionalString(link.rel) &&
     optionalString(link.title)
@@ -455,6 +453,14 @@ const assertEffectCarrier = (
   operation: SerializedTextOperation,
   effect: RichTextEffect,
 ): void => {
+  if (effect.type === "bootstrap") {
+    if (
+      eventId !== BOOTSTRAP_EVENT_ID ||
+      effect.blockId !== BOOTSTRAP_BLOCK_ID
+    ) {
+      throw new Error("Bootstrap effect must use deterministic identities");
+    }
+  }
   if (effect.type === "bootstrap" || effect.type === "block-create") {
     if (operation.type !== "insert" || operation.text !== BLOCK_MARKER) {
       throw new Error(`${effect.type} requires a raw block marker insert`);

--- a/packages/block-model/vitest.config.ts
+++ b/packages/block-model/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -5,13 +6,15 @@ export default defineConfig({
     alias: [
       {
         find: "@softmaple/eg-walker/anchors",
-        replacement: new URL("../eg-walker/src/anchors.ts", import.meta.url)
-          .pathname,
+        replacement: fileURLToPath(
+          new URL("../eg-walker/src/anchors.ts", import.meta.url),
+        ),
       },
       {
         find: "@softmaple/eg-walker",
-        replacement: new URL("../eg-walker/src/index.ts", import.meta.url)
-          .pathname,
+        replacement: fileURLToPath(
+          new URL("../eg-walker/src/index.ts", import.meta.url),
+        ),
       },
     ],
   },

--- a/packages/eg-walker/src/anchors.ts
+++ b/packages/eg-walker/src/anchors.ts
@@ -96,6 +96,13 @@ interface SequenceProjection {
   readonly text: string;
 }
 
+interface CachedProjection {
+  readonly frontierKey: string;
+  readonly projection: SequenceProjection;
+}
+
+const projectionCache = new WeakMap<EgWalkerReplica, CachedProjection>();
+
 /**
  * Bind the anchor helpers to one replica while keeping Lexical/editor state
  * outside the EG-walker package.
@@ -287,7 +294,21 @@ const atomAnchor = (
   affinity,
 });
 
+const frontierKey = (replica: EgWalkerReplica): string =>
+  JSON.stringify([...replica.getFrontier()].sort());
+
 const createProjection = (replica: EgWalkerReplica): SequenceProjection => {
+  const key = frontierKey(replica);
+  const cached = projectionCache.get(replica);
+  if (cached?.frontierKey === key) {
+    return cached.projection;
+  }
+  const projection = buildProjection(replica);
+  projectionCache.set(replica, { frontierKey: key, projection });
+  return projection;
+};
+
+const buildProjection = (replica: EgWalkerReplica): SequenceProjection => {
   assertStableBootstrap(replica);
   const graph = graphFromEvents(replica.exportEventGraph());
   const eventOrder = graph.getBranchPreservingTopologicalOrder();
@@ -377,12 +398,11 @@ const atomsFromRecord = (
   }
 
   if (record.run !== null) {
+    const run = record.run;
     const atoms = Array.from(
       { length: record.content.length },
       (_, offsetInRecord) => ({
-        eventId: `${record.run!.replicaId}:${
-          record.run!.startSequence + offsetInRecord
-        }`,
+        eventId: `${run.replicaId}:${run.startSequence + offsetInRecord}`,
         offset: 0,
         deleted: record.everDeleted,
         codeUnit: record.content[offsetInRecord]!,

--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -1582,7 +1582,8 @@ export class EgWalkerEngine {
     if (
       tail === null ||
       typeof tail.content !== "string" ||
-      tail.run === null
+      tail.run === null ||
+      tail.originRight !== null
     ) {
       return startOrderIndex;
     }

--- a/packages/eg-walker/src/test/anchors.test.ts
+++ b/packages/eg-walker/src/test/anchors.test.ts
@@ -13,6 +13,11 @@ import { NativeSnapshotCodec } from "../core/native-snapshot";
 import { PortableSnapshotCodec } from "../core/portable-snapshot";
 import { EgWalkerReplica } from "../core/replica";
 import type { GraphEvent } from "../types";
+import {
+  bootstrapReplica,
+  cloneEvent,
+  replicaFromEvents,
+} from "./replica-test-helpers";
 
 describe("captureAnchor", () => {
   it("should batch capture and resolution through one immutable projection", () => {
@@ -295,34 +300,19 @@ describe("isSequenceAnchor", () => {
     // Act / Assert
     expect(isSequenceAnchor(wire)).toBe(true);
     expect(isSequenceAnchor(malformed)).toBe(false);
+    expect(
+      isSequenceAnchor({
+        type: "boundary",
+        edge: "start",
+        affinity: "before",
+      }),
+    ).toBe(false);
+    expect(isSequenceAnchor(null)).toBe(false);
+    expect(isSequenceAnchor([])).toBe(false);
   });
 });
 
 // Helpers
-
-const bootstrapReplica = (replicaId: string, text: string): EgWalkerReplica => {
-  const replica = new EgWalkerReplica(replicaId);
-  replica.insert(0, text);
-  return replica;
-};
-
-const replicaFromEvents = (
-  replicaId: string,
-  events: ReadonlyArray<GraphEvent>,
-): EgWalkerReplica => {
-  const replica = new EgWalkerReplica(replicaId);
-  for (const event of events) {
-    replica.applyRemoteEvent(cloneEvent(event));
-  }
-  return replica;
-};
-
-const cloneEvent = (event: GraphEvent): GraphEvent => ({
-  id: event.id,
-  operation: { ...event.operation },
-  parentVersion: new Set(event.parentVersion),
-  timestamp: event.timestamp,
-});
 
 const remoteInsert = (
   id: string,

--- a/packages/eg-walker/src/test/property/anchors.property.test.ts
+++ b/packages/eg-walker/src/test/property/anchors.property.test.ts
@@ -8,6 +8,11 @@ import {
 } from "../../anchors";
 import { EgWalkerReplica } from "../../core/replica";
 import type { GraphEvent } from "../../types";
+import {
+  bootstrapReplica,
+  cloneEvent,
+  replicaFromEvents,
+} from "../replica-test-helpers";
 import { fcParams } from "./run-config";
 
 describe("property: stable sequence anchors", () => {
@@ -105,12 +110,6 @@ describe("property: stable sequence anchors", () => {
 
 // Helpers
 
-const bootstrapReplica = (replicaId: string, text: string): EgWalkerReplica => {
-  const replica = new EgWalkerReplica(replicaId);
-  replica.insert(0, text);
-  return replica;
-};
-
 const codePointBoundaries = (text: string): number[] => {
   const boundaries = [0];
   let index = 0;
@@ -120,21 +119,3 @@ const codePointBoundaries = (text: string): number[] => {
   }
   return boundaries;
 };
-
-const replicaFromEvents = (
-  replicaId: string,
-  events: ReadonlyArray<GraphEvent>,
-): EgWalkerReplica => {
-  const replica = new EgWalkerReplica(replicaId);
-  for (const event of events) {
-    replica.applyRemoteEvent(cloneEvent(event));
-  }
-  return replica;
-};
-
-const cloneEvent = (event: GraphEvent): GraphEvent => ({
-  id: event.id,
-  operation: { ...event.operation },
-  parentVersion: new Set(event.parentVersion),
-  timestamp: event.timestamp,
-});

--- a/packages/eg-walker/src/test/property/deferred-text-materialization.property.test.ts
+++ b/packages/eg-walker/src/test/property/deferred-text-materialization.property.test.ts
@@ -25,6 +25,8 @@ describe("property: deferred cold-replay text materialization", () => {
           edits: [
             { kind: "insert" as const, offsetSeed: 0, text: " " },
             { kind: "insert" as const, offsetSeed: 0, text: "\uE000" },
+            // This seed places the insert beside the reserved-marker run,
+            // exercising the non-null origin-right boundary.
             { kind: "insert" as const, offsetSeed: 0.0625, text: " " },
           ],
         },
@@ -37,18 +39,20 @@ describe("property: deferred cold-replay text materialization", () => {
 
     // Act
     const eagerEngine = new EgWalkerEngine();
-    eagerEngine.generate(eventOrder, params.initialText, {
+    const eager = eagerEngine.generate(eventOrder, params.initialText, {
       eventGraph: graph,
       eventOrder,
     });
     const deferredEngine = new EgWalkerEngine();
-    deferredEngine.generate(eventOrder, params.initialText, {
+    const deferred = deferredEngine.generate(eventOrder, params.initialText, {
       eventGraph: graph,
       eventOrder,
       collectTransformedOperations: false,
     });
 
     // Assert
+    expect(deferred.text).toBe(eager.text);
+    expect(deferred.text).toBe(trace.canonicalText);
     expect(deferredEngine.getSequenceRecords()).toEqual(
       eagerEngine.getSequenceRecords(),
     );

--- a/packages/eg-walker/src/test/replica-test-helpers.ts
+++ b/packages/eg-walker/src/test/replica-test-helpers.ts
@@ -1,0 +1,29 @@
+import { EgWalkerReplica } from "../core/replica";
+import type { GraphEvent } from "../types";
+
+export const cloneEvent = (event: GraphEvent): GraphEvent => ({
+  id: event.id,
+  operation: { ...event.operation },
+  parentVersion: new Set(event.parentVersion),
+  timestamp: event.timestamp,
+});
+
+export const bootstrapReplica = (
+  replicaId: string,
+  text: string,
+): EgWalkerReplica => {
+  const replica = new EgWalkerReplica(replicaId);
+  replica.insert(0, text);
+  return replica;
+};
+
+export const replicaFromEvents = (
+  replicaId: string,
+  events: ReadonlyArray<GraphEvent>,
+): EgWalkerReplica => {
+  const replica = new EgWalkerReplica(replicaId);
+  for (const event of events) {
+    replica.applyRemoteEvent(cloneEvent(event));
+  }
+  return replica;
+};

--- a/packages/eslint-config/__tests__/collaboration-layers.test.js
+++ b/packages/eslint-config/__tests__/collaboration-layers.test.js
@@ -185,10 +185,12 @@ test("block-model patterns allow EG-walker but forbid awareness, bindings, and e
   assert.equal(findRestrictedImportMessages(allowed).length, 0);
 });
 
-test("block-model binding patterns prevent bypassing the model API", () => {
+test("block-model binding patterns prevent model and awareness bypasses", () => {
   for (const specifier of [
     "@softmaple/eg-walker",
     "@softmaple/eg-walker/anchors",
+    "@softmaple/awareness",
+    "@softmaple/awareness/components/live-cursor",
   ]) {
     const messages = lintWithPatterns(
       blockModelBindingCollaborationPatterns,

--- a/packages/eslint-config/collaboration-layers.js
+++ b/packages/eslint-config/collaboration-layers.js
@@ -117,9 +117,13 @@ export const blockModelCollaborationPatterns = [
 
 /**
  * Patterns for a block-model surface binding such as binding-lexical.
- * Surface frameworks are allowed here; importing EG-walker directly is not.
+ * Surface frameworks are allowed here; importing EG-walker directly or
+ * coupling the binding to awareness is not.
  */
-export const blockModelBindingCollaborationPatterns = [...EG_WALKER_PATTERNS];
+export const blockModelBindingCollaborationPatterns = [
+  ...EG_WALKER_PATTERNS,
+  ...AWARENESS_PATTERNS,
+];
 
 /**
  * Concatenate one or more `no-restricted-imports` pattern arrays into


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes # .

Changes proposed in this pull request:

- harden collaboration persistence shutdown, validation, and test cleanup
- preserve Lexical composition, selection, links, and unchanged node identity
- improve block-model and EG-walker validation, replay, anchors, and regressions

Validation pending.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05c08837-c413-40ad-8b43-4555a447c1e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05c08837-c413-40ad-8b43-4555a447c1e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

