### PR TITLE
feat(apps/playground): WebSocket sync for Lexical × EG-walker

### DIFF
--- a/apps/playground/e2e/helpers/lexical-eg-walker.ts
+++ b/apps/playground/e2e/helpers/lexical-eg-walker.ts
@@ -1,0 +1,86 @@
+import {
+  type BrowserContext,
+  expect,
+  type Locator,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+
+export interface RoomPage {
+  readonly demo: Locator;
+  readonly editor: Locator;
+  readonly page: Page;
+  readonly status: Locator;
+}
+
+export const roomFor = (testInfo: TestInfo): string =>
+  `pw-${testInfo.workerIndex}-${testInfo.retry}-${Date.now()}-${crypto
+    .randomUUID()
+    .replaceAll("-", "")
+    .slice(0, 6)}`;
+
+export const openRoom = async (
+  page: Page,
+  roomId: string,
+  transport: "websocket" | "broadcast" = "websocket",
+): Promise<RoomPage> => {
+  await page.goto(
+    `/demo/lexical-eg-walker?room=${roomId}&transport=${transport}`,
+  );
+
+  const demo = page.getByTestId("lexical-eg-walker-demo");
+  const editor = page.getByRole("textbox", { name: "Rich text editor" });
+  const status = page.getByTestId("collaboration-status");
+  await expect(page.getByTestId("lexical-room-ready")).toBeVisible();
+  await expect(editor).toHaveAttribute("contenteditable", "true");
+  await expect(demo).toHaveAttribute("data-room-id", roomId);
+  await expect(demo).toHaveAttribute("data-transport", transport);
+  await expect(status).toHaveAttribute("data-transport", transport);
+  await expect(demo).toHaveAttribute("data-persistence-mode", "persistent");
+  await expect(status).not.toContainText("Unsaved · memory only");
+  await expect(page.getByRole("button", { name: "Undo" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Redo" })).toHaveCount(0);
+
+  return { demo, editor, page, status };
+};
+
+export const appendText = async (
+  roomPage: RoomPage,
+  text: string,
+): Promise<void> => {
+  await roomPage.editor.click();
+  await roomPage.editor.press("End");
+  await roomPage.editor.pressSequentially(text, { delay: 15 });
+};
+
+export const expectDocument = async (
+  roomPage: RoomPage,
+  text: string,
+): Promise<void> => {
+  await expect(roomPage.editor).toHaveText(text);
+  await expect(roomPage.page.getByRole("alert")).toHaveCount(0);
+};
+
+export const storageBytes = async (roomPage: RoomPage): Promise<number> =>
+  Number((await roomPage.demo.getAttribute("data-storage-bytes")) ?? "0");
+
+export const expectDurableAfter = async (
+  roomPage: RoomPage,
+  previousBytes: number,
+): Promise<void> => {
+  await expect(roomPage.demo).toHaveAttribute(
+    "data-persistence-durability",
+    "saved",
+  );
+  await expect
+    .poll(() => storageBytes(roomPage), {
+      message: "the newly acknowledged batch should increase durable storage",
+    })
+    .toBeGreaterThan(previousBytes);
+};
+
+export const openSecondTab = async (
+  context: BrowserContext,
+  roomId: string,
+  transport: "websocket" | "broadcast" = "websocket",
+): Promise<RoomPage> => openRoom(await context.newPage(), roomId, transport);

--- a/apps/playground/e2e/home.spec.ts
+++ b/apps/playground/e2e/home.spec.ts
@@ -3,41 +3,47 @@ import { expect, test } from "@playwright/test";
 test.describe("Home Page", () => {
   test("should load home page successfully", async ({ page }) => {
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
 
-    // Check title
     await expect(page).toHaveTitle(/SoftMaple Playground/);
-
-    // Check main heading
     await expect(
       page.getByRole("heading", { name: /SOFTMAPLE PLAYGROUND/i }),
     ).toBeVisible();
   });
 
-  test("should display feature cards", async ({ page }) => {
+  test("should display SoftMaple demo cards", async ({ page }) => {
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
 
-    // Check for Two-Panel Editor Demo card - it's not a heading, it's a generic element
-    await expect(page.getByText("Two-Panel Editor Demo")).toBeVisible();
-
-    // Check for Collaborative Editor card - use exact match to avoid ambiguity with Online Collaborative Editor
+    await expect(page.getByRole("heading", { name: "Demos" })).toBeVisible();
     await expect(
-      page.getByText("Collaborative Editor", { exact: true }),
+      page.getByRole("link", { name: /Lexical × EG-walker/i }),
     ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Online Collaborative Editor/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Awareness \+ Eg-Walker/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", {
+        name: /Collaborative Editor.*Side-by-side text editors/i,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Two-Panel Editor Demo/i }),
+    ).toBeVisible();
+  });
 
-    // Check for Online Collaborative Editor card
-    await expect(page.getByText("Online Collaborative Editor")).toBeVisible();
+  test("should navigate to Lexical EG-walker demo", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("link", { name: /Open Lexical demo/i }).click();
+    await expect(page).toHaveURL(/\/demo\/lexical-eg-walker/);
   });
 
   test("should navigate to two-panel editor", async ({ page }) => {
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
 
-    // Click on Two-Panel Editor Demo card - link contains full description
     await page.getByRole("link", { name: /Two-Panel Editor Demo/i }).click();
-
-    // Verify navigation
     await expect(page).toHaveURL(/\/demo\/two-panel-editor/);
     await expect(
       page.getByRole("heading", { name: /Two-Panel Text Editor/i }),
@@ -46,16 +52,13 @@ test.describe("Home Page", () => {
 
   test("should navigate to collaborative editor", async ({ page }) => {
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
 
-    // Click on Collaborative Editor card - link contains full description
     await page
       .getByRole("link", {
-        name: /Collaborative Editor.*Real-time collaborative/i,
+        name: /Collaborative Editor.*Side-by-side text editors/i,
       })
       .click();
 
-    // Verify navigation
     await expect(page).toHaveURL(/\/demo\/collaborative-editor/);
     await expect(
       page.getByRole("heading", { name: /Collaborative Text Editor/i }),
@@ -64,16 +67,13 @@ test.describe("Home Page", () => {
 
   test("should navigate to online collaborative editor", async ({ page }) => {
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
 
-    // Click on Online Collaborative Editor card
     await page
       .getByRole("link", {
         name: /Online Collaborative Editor/i,
       })
       .click();
 
-    // Verify navigation
     await expect(page).toHaveURL(/\/demo\/online-collab-editor/);
     await expect(
       page.getByRole("heading", { name: /Online Collaborative Editor/i }),

--- a/apps/playground/e2e/lexical-eg-walker-broadcast.spec.ts
+++ b/apps/playground/e2e/lexical-eg-walker-broadcast.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+import {
+  appendText,
+  expectDocument,
+  openRoom,
+  openSecondTab,
+  roomFor,
+} from "./helpers/lexical-eg-walker";
+
+test.describe("Lexical EG-walker BroadcastChannel transport", () => {
+  test("still syncs via BroadcastChannel when transport=broadcast", async ({
+    context,
+    page,
+  }, testInfo) => {
+    const roomId = roomFor(testInfo);
+    const first = await openRoom(page, roomId, "broadcast");
+    const second = await openSecondTab(context, roomId, "broadcast");
+
+    await expect(first.status).toContainText("Tabs connected");
+    await appendText(first, "Broadcast only");
+    await expectDocument(second, "Broadcast only");
+  });
+});

--- a/apps/playground/e2e/lexical-eg-walker-websocket.spec.ts
+++ b/apps/playground/e2e/lexical-eg-walker-websocket.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+import {
+  appendText,
+  expectDocument,
+  openRoom,
+  roomFor,
+} from "./helpers/lexical-eg-walker";
+
+test.describe("Lexical EG-walker WebSocket cross-browser", () => {
+  test("synchronizes text between two browser contexts over WebSocket", async ({
+    browser,
+  }, testInfo) => {
+    const roomId = roomFor(testInfo);
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const first = await openRoom(pageA, roomId, "websocket");
+      const second = await openRoom(pageB, roomId, "websocket");
+
+      await expect(first.status).toContainText("WebSocket connected");
+      await expect(second.status).toContainText("WebSocket connected");
+
+      await appendText(first, "Hello across browsers");
+      await expectDocument(second, "Hello across browsers");
+
+      await appendText(second, " + reply");
+      await expectDocument(first, "Hello across browsers + reply");
+      await expectDocument(second, "Hello across browsers + reply");
+    } finally {
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+});

--- a/apps/playground/e2e/lexical-eg-walker.spec.ts
+++ b/apps/playground/e2e/lexical-eg-walker.spec.ts
@@ -1,87 +1,13 @@
+import { expect, test } from "@playwright/test";
 import {
-  type BrowserContext,
-  expect,
-  type Locator,
-  type Page,
-  type TestInfo,
-  test,
-} from "@playwright/test";
-
-interface RoomPage {
-  readonly demo: Locator;
-  readonly editor: Locator;
-  readonly page: Page;
-  readonly status: Locator;
-}
-
-const roomFor = (testInfo: TestInfo): string =>
-  `pw-${testInfo.workerIndex}-${testInfo.retry}-${Date.now()}-${crypto
-    .randomUUID()
-    .replaceAll("-", "")
-    .slice(0, 6)}`;
-
-const openRoom = async (
-  page: Page,
-  roomId: string,
-  transport: "websocket" | "broadcast" = "websocket",
-): Promise<RoomPage> => {
-  await page.goto(
-    `/demo/lexical-eg-walker?room=${roomId}&transport=${transport}`,
-  );
-
-  const demo = page.getByTestId("lexical-eg-walker-demo");
-  const editor = page.getByRole("textbox", { name: "Rich text editor" });
-  const status = page.getByTestId("collaboration-status");
-  await expect(page.getByTestId("lexical-room-ready")).toBeVisible();
-  await expect(editor).toHaveAttribute("contenteditable", "true");
-  await expect(demo).toHaveAttribute("data-room-id", roomId);
-  await expect(demo).toHaveAttribute("data-transport", transport);
-  await expect(status).toHaveAttribute("data-transport", transport);
-  await expect(demo).toHaveAttribute("data-persistence-mode", "persistent");
-  await expect(status).not.toContainText("Unsaved · memory only");
-  await expect(page.getByRole("button", { name: "Undo" })).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "Redo" })).toHaveCount(0);
-
-  return { demo, editor, page, status };
-};
-
-const appendText = async (roomPage: RoomPage, text: string): Promise<void> => {
-  await roomPage.editor.click();
-  await roomPage.editor.press("End");
-  await roomPage.editor.pressSequentially(text, { delay: 15 });
-};
-
-const expectDocument = async (
-  roomPage: RoomPage,
-  text: string,
-): Promise<void> => {
-  await expect(roomPage.editor).toHaveText(text);
-  await expect(roomPage.page.getByRole("alert")).toHaveCount(0);
-};
-
-const storageBytes = async (roomPage: RoomPage): Promise<number> =>
-  Number((await roomPage.demo.getAttribute("data-storage-bytes")) ?? "0");
-
-const expectDurableAfter = async (
-  roomPage: RoomPage,
-  previousBytes: number,
-): Promise<void> => {
-  await expect(roomPage.demo).toHaveAttribute(
-    "data-persistence-durability",
-    "saved",
-  );
-  await expect
-    .poll(() => storageBytes(roomPage), {
-      message: "the newly acknowledged batch should increase durable storage",
-    })
-    .toBeGreaterThan(previousBytes);
-};
-
-const openSecondTab = async (
-  context: BrowserContext,
-  roomId: string,
-  transport: "websocket" | "broadcast" = "websocket",
-): Promise<RoomPage> => openRoom(await context.newPage(), roomId, transport);
+  appendText,
+  expectDocument,
+  expectDurableAfter,
+  openRoom,
+  openSecondTab,
+  roomFor,
+  storageBytes,
+} from "./helpers/lexical-eg-walker";
 
 test.describe("Lexical EG-walker cross-tab collaboration", () => {
   test("synchronizes text bidirectionally between two tabs", async ({
@@ -277,48 +203,5 @@ test.describe("Lexical EG-walker cross-tab collaboration", () => {
       "data-persistence-leader",
       "leader",
     );
-  });
-});
-
-test.describe("Lexical EG-walker WebSocket cross-browser", () => {
-  test("synchronizes text between two browser contexts over WebSocket", async ({
-    browser,
-  }, testInfo) => {
-    const roomId = roomFor(testInfo);
-    const contextA = await browser.newContext();
-    const contextB = await browser.newContext();
-    const pageA = await contextA.newPage();
-    const pageB = await contextB.newPage();
-
-    try {
-      const first = await openRoom(pageA, roomId, "websocket");
-      const second = await openRoom(pageB, roomId, "websocket");
-
-      await expect(first.status).toContainText("WebSocket connected");
-      await expect(second.status).toContainText("WebSocket connected");
-
-      await appendText(first, "Hello across browsers");
-      await expectDocument(second, "Hello across browsers");
-
-      await appendText(second, " + reply");
-      await expectDocument(first, "Hello across browsers + reply");
-      await expectDocument(second, "Hello across browsers + reply");
-    } finally {
-      await contextA.close();
-      await contextB.close();
-    }
-  });
-
-  test("still syncs via BroadcastChannel when transport=broadcast", async ({
-    context,
-    page,
-  }, testInfo) => {
-    const roomId = roomFor(testInfo);
-    const first = await openRoom(page, roomId, "broadcast");
-    const second = await openSecondTab(context, roomId, "broadcast");
-
-    await expect(first.status).toContainText("Tabs connected");
-    await appendText(first, "Broadcast only");
-    await expectDocument(second, "Broadcast only");
   });
 });

--- a/apps/playground/e2e/lexical-eg-walker.spec.ts
+++ b/apps/playground/e2e/lexical-eg-walker.spec.ts
@@ -20,8 +20,14 @@ const roomFor = (testInfo: TestInfo): string =>
     .replaceAll("-", "")
     .slice(0, 6)}`;
 
-const openRoom = async (page: Page, roomId: string): Promise<RoomPage> => {
-  await page.goto(`/demo/lexical-eg-walker?room=${roomId}`);
+const openRoom = async (
+  page: Page,
+  roomId: string,
+  transport: "websocket" | "broadcast" = "websocket",
+): Promise<RoomPage> => {
+  await page.goto(
+    `/demo/lexical-eg-walker?room=${roomId}&transport=${transport}`,
+  );
 
   const demo = page.getByTestId("lexical-eg-walker-demo");
   const editor = page.getByRole("textbox", { name: "Rich text editor" });
@@ -29,6 +35,8 @@ const openRoom = async (page: Page, roomId: string): Promise<RoomPage> => {
   await expect(page.getByTestId("lexical-room-ready")).toBeVisible();
   await expect(editor).toHaveAttribute("contenteditable", "true");
   await expect(demo).toHaveAttribute("data-room-id", roomId);
+  await expect(demo).toHaveAttribute("data-transport", transport);
+  await expect(status).toHaveAttribute("data-transport", transport);
   await expect(demo).toHaveAttribute("data-persistence-mode", "persistent");
   await expect(status).not.toContainText("Unsaved · memory only");
   await expect(page.getByRole("button", { name: "Undo" })).toHaveCount(0);
@@ -72,7 +80,8 @@ const expectDurableAfter = async (
 const openSecondTab = async (
   context: BrowserContext,
   roomId: string,
-): Promise<RoomPage> => openRoom(await context.newPage(), roomId);
+  transport: "websocket" | "broadcast" = "websocket",
+): Promise<RoomPage> => openRoom(await context.newPage(), roomId, transport);
 
 test.describe("Lexical EG-walker cross-tab collaboration", () => {
   test("synchronizes text bidirectionally between two tabs", async ({
@@ -268,5 +277,48 @@ test.describe("Lexical EG-walker cross-tab collaboration", () => {
       "data-persistence-leader",
       "leader",
     );
+  });
+});
+
+test.describe("Lexical EG-walker WebSocket cross-browser", () => {
+  test("synchronizes text between two browser contexts over WebSocket", async ({
+    browser,
+  }, testInfo) => {
+    const roomId = roomFor(testInfo);
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const first = await openRoom(pageA, roomId, "websocket");
+      const second = await openRoom(pageB, roomId, "websocket");
+
+      await expect(first.status).toContainText("WebSocket connected");
+      await expect(second.status).toContainText("WebSocket connected");
+
+      await appendText(first, "Hello across browsers");
+      await expectDocument(second, "Hello across browsers");
+
+      await appendText(second, " + reply");
+      await expectDocument(first, "Hello across browsers + reply");
+      await expectDocument(second, "Hello across browsers + reply");
+    } finally {
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+
+  test("still syncs via BroadcastChannel when transport=broadcast", async ({
+    context,
+    page,
+  }, testInfo) => {
+    const roomId = roomFor(testInfo);
+    const first = await openRoom(page, roomId, "broadcast");
+    const second = await openSecondTab(context, roomId, "broadcast");
+
+    await expect(first.status).toContainText("Tabs connected");
+    await appendText(first, "Broadcast only");
+    await expectDocument(second, "Broadcast only");
   });
 });

--- a/apps/playground/playground-port.ts
+++ b/apps/playground/playground-port.ts
@@ -1,0 +1,2 @@
+/** Shared Playwright / SSR fallback port for the playground app. */
+export const PLAYGROUND_PORT = process.env.PLAYGROUND_PORT ?? "3000";

--- a/apps/playground/playwright.config.ts
+++ b/apps/playground/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const port = process.env.PLAYGROUND_PORT ?? "3000";
+const baseURL = `http://localhost:${port}`;
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -24,7 +27,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
   },
@@ -39,8 +42,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "pnpm dev",
-    url: "http://localhost:3000",
+    command: `pnpm exec vite dev --port ${port}`,
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/apps/playground/playwright.config.ts
+++ b/apps/playground/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
+import { PLAYGROUND_PORT } from "./playground-port";
 
-const port = process.env.PLAYGROUND_PORT ?? "3000";
+const port = PLAYGROUND_PORT;
 const baseURL = `http://localhost:${port}`;
 
 /**
@@ -42,7 +43,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: `pnpm exec vite dev --port ${port}`,
+    command: `pnpm exec vite dev --port ${port} --strictPort`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
   },

--- a/apps/playground/server/README.md
+++ b/apps/playground/server/README.md
@@ -1,0 +1,37 @@
+# Collaboration WebSocket servers
+
+Playground Nitro handlers that back Lexical EG-walker and the textarea
+online-collab demos.
+
+| Endpoint | Protocol | Clients |
+|---|---|---|
+| `/api/collab-doc?roomId=` | Persistence channel (`event` / `repair-*` / `durable-ack`) | Lexical EG-walker demo |
+| `/api/presence?roomId=` | Awareness WebSocket frames | Lexical EG-walker presence |
+| `/api/collab-sync` | Textarea `SyncMessage` relay | `/demo/online-collab-editor` |
+
+## Enablement
+
+`vite.config.ts` turns on Nitro WebSockets:
+
+```ts
+nitro({
+  serverDir: "./server",
+  features: { websocket: true },
+})
+```
+
+## Client transport
+
+By default demos connect to same-origin `ws://` / `wss://` endpoints.
+Override with:
+
+- `?transport=broadcast` — BroadcastChannel only (tabs on one origin)
+- `?transport=websocket` — force WebSocket (default)
+- `VITE_COLLAB_TRANSPORT`, `VITE_COLLAB_DOC_WS_URL`,
+  `VITE_COLLAB_PRESENCE_WS_URL`, `VITE_COLLAB_SYNC_WS_URL`
+
+## Demo
+
+Open `/demo/lexical-eg-walker` in two browsers with the same `?room=` id.
+Document batches and presence ride the WebSocket servers above; each browser
+also keeps a local durable copy in `localStorage`.

--- a/apps/playground/server/api/collab-doc.ts
+++ b/apps/playground/server/api/collab-doc.ts
@@ -13,6 +13,7 @@ import { defineWebSocketHandler } from "nitro";
 import type { EventHandler } from "nitro/h3";
 
 const ROOM_TOPIC = "doc";
+const MAX_BATCHES_PER_ROOM = 500;
 
 type WireBatch = {
   readonly batchId: string;
@@ -34,6 +35,7 @@ type DocMessage = {
 
 type RoomState = {
   readonly batches: Map<string, WireBatch>;
+  readonly peers: Set<object>;
 };
 
 const rooms = new Map<string, RoomState>();
@@ -41,13 +43,30 @@ const rooms = new Map<string, RoomState>();
 const getRoom = (roomId: string): RoomState => {
   const existing = rooms.get(roomId);
   if (existing) return existing;
-  const created: RoomState = { batches: new Map() };
+  const created: RoomState = { batches: new Map(), peers: new Set() };
   rooms.set(roomId, created);
   return created;
 };
 
+const putBatch = (room: RoomState, batch: WireBatch): void => {
+  if (room.batches.has(batch.batchId)) {
+    room.batches.set(batch.batchId, batch);
+    return;
+  }
+  while (room.batches.size >= MAX_BATCHES_PER_ROOM) {
+    const oldest = room.batches.keys().next().value;
+    if (oldest === undefined) break;
+    room.batches.delete(oldest);
+  }
+  room.batches.set(batch.batchId, batch);
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) &&
+  value.every((item) => typeof item === "string" && item.length > 0);
 
 const parseDocMessage = (raw: string): DocMessage | null => {
   try {
@@ -59,6 +78,12 @@ const parseDocMessage = (raw: string): DocMessage | null => {
       return null;
     if (typeof parsed.senderId !== "string" || parsed.senderId.length === 0)
       return null;
+    if (
+      parsed.knownBatchIds !== undefined &&
+      !isStringArray(parsed.knownBatchIds)
+    ) {
+      return null;
+    }
     return parsed as unknown as DocMessage;
   } catch {
     return null;
@@ -98,6 +123,7 @@ const handler: EventHandler = defineWebSocketHandler({
       return;
     }
     peer.context.roomId = roomId;
+    getRoom(roomId).peers.add(peer);
     peer.subscribe(ROOM_TOPIC);
   },
 
@@ -113,7 +139,7 @@ const handler: EventHandler = defineWebSocketHandler({
     switch (parsed.type) {
       case "event": {
         if (parsed.batch && typeof parsed.batch.batchId === "string") {
-          room.batches.set(parsed.batch.batchId, parsed.batch);
+          putBatch(room, parsed.batch);
         }
         peer.publish(ROOM_TOPIC, parsed);
         return;
@@ -150,6 +176,14 @@ const handler: EventHandler = defineWebSocketHandler({
 
   close(peer) {
     peer.unsubscribe(ROOM_TOPIC);
+    const roomId = roomIdFromPeer(peer);
+    if (!roomId) return;
+    const room = rooms.get(roomId);
+    if (!room) return;
+    room.peers.delete(peer);
+    if (room.peers.size === 0) {
+      rooms.delete(roomId);
+    }
   },
 });
 

--- a/apps/playground/server/api/collab-doc.ts
+++ b/apps/playground/server/api/collab-doc.ts
@@ -10,6 +10,7 @@
  */
 
 import { defineWebSocketHandler } from "nitro";
+import type { EventHandler } from "nitro/h3";
 
 const ROOM_TOPIC = "doc";
 
@@ -77,7 +78,7 @@ const roomIdFromPeer = (peer: {
   return new URL(url).searchParams.get("roomId");
 };
 
-export default defineWebSocketHandler({
+const handler: EventHandler = defineWebSocketHandler({
   upgrade(request) {
     const url = new URL(request.url);
     const roomId = url.searchParams.get("roomId")?.trim();
@@ -151,3 +152,5 @@ export default defineWebSocketHandler({
     peer.unsubscribe(ROOM_TOPIC);
   },
 });
+
+export default handler;

--- a/apps/playground/server/api/collab-doc.ts
+++ b/apps/playground/server/api/collab-doc.ts
@@ -1,0 +1,153 @@
+/**
+ * WebSocket relay for Lexical EG-walker document sync.
+ *
+ * Speaks the playground persistence-channel protocol
+ * (`apps/playground/src/modules/lexical-eg-walker/persistence/channel.ts`):
+ * event / repair-request / repair-response / durable-ack.
+ *
+ * Keeps an in-memory batch log per room so late joiners can repair even when
+ * no other browser tab is online.
+ */
+
+import { defineWebSocketHandler } from "nitro";
+
+const ROOM_TOPIC = "doc";
+
+type WireBatch = {
+  readonly batchId: string;
+  readonly [key: string]: unknown;
+};
+
+type DocMessage = {
+  readonly protocolVersion: number;
+  readonly type: string;
+  readonly roomId: string;
+  readonly senderId: string;
+  readonly batch?: WireBatch;
+  readonly requestId?: string;
+  readonly recipientId?: string;
+  readonly knownBatchIds?: ReadonlyArray<string>;
+  readonly batches?: ReadonlyArray<WireBatch>;
+  readonly batchIds?: ReadonlyArray<string>;
+};
+
+type RoomState = {
+  readonly batches: Map<string, WireBatch>;
+};
+
+const rooms = new Map<string, RoomState>();
+
+const getRoom = (roomId: string): RoomState => {
+  const existing = rooms.get(roomId);
+  if (existing) return existing;
+  const created: RoomState = { batches: new Map() };
+  rooms.set(roomId, created);
+  return created;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const parseDocMessage = (raw: string): DocMessage | null => {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    if (typeof parsed.protocolVersion !== "number") return null;
+    if (typeof parsed.type !== "string") return null;
+    if (typeof parsed.roomId !== "string" || parsed.roomId.length === 0)
+      return null;
+    if (typeof parsed.senderId !== "string" || parsed.senderId.length === 0)
+      return null;
+    return parsed as unknown as DocMessage;
+  } catch {
+    return null;
+  }
+};
+
+const roomIdFromPeer = (peer: {
+  context: Record<string, unknown>;
+  request?: { url?: string };
+}): string | null => {
+  const fromContext = peer.context.roomId;
+  if (typeof fromContext === "string" && fromContext.length > 0) {
+    return fromContext;
+  }
+  const url = peer.request?.url;
+  if (typeof url !== "string") return null;
+  return new URL(url).searchParams.get("roomId");
+};
+
+export default defineWebSocketHandler({
+  upgrade(request) {
+    const url = new URL(request.url);
+    const roomId = url.searchParams.get("roomId")?.trim();
+    if (!roomId) {
+      throw new Response("roomId query parameter is required", { status: 400 });
+    }
+    return {
+      namespace: `collab-doc:${roomId}`,
+      context: { roomId },
+    };
+  },
+
+  open(peer) {
+    const roomId = roomIdFromPeer(peer);
+    if (!roomId) {
+      peer.close(1008, "Missing roomId");
+      return;
+    }
+    peer.context.roomId = roomId;
+    peer.subscribe(ROOM_TOPIC);
+  },
+
+  message(peer, message) {
+    const roomId = roomIdFromPeer(peer);
+    if (!roomId) return;
+
+    const parsed = parseDocMessage(message.text());
+    if (parsed === null || parsed.roomId !== roomId) return;
+
+    const room = getRoom(roomId);
+
+    switch (parsed.type) {
+      case "event": {
+        if (parsed.batch && typeof parsed.batch.batchId === "string") {
+          room.batches.set(parsed.batch.batchId, parsed.batch);
+        }
+        peer.publish(ROOM_TOPIC, parsed);
+        return;
+      }
+      case "repair-request": {
+        const known = new Set(parsed.knownBatchIds ?? []);
+        const missing = [...room.batches.values()].filter(
+          (batch) => !known.has(batch.batchId),
+        );
+        // Always relay so peer-held history can still help.
+        peer.publish(ROOM_TOPIC, parsed);
+        if (missing.length === 0 || typeof parsed.requestId !== "string") {
+          return;
+        }
+        peer.send({
+          protocolVersion: parsed.protocolVersion,
+          type: "repair-response",
+          roomId,
+          senderId: "server",
+          recipientId: parsed.senderId,
+          requestId: parsed.requestId,
+          batches: missing,
+        });
+        return;
+      }
+      case "repair-response":
+      case "durable-ack":
+        peer.publish(ROOM_TOPIC, parsed);
+        return;
+      default:
+        return;
+    }
+  },
+
+  close(peer) {
+    peer.unsubscribe(ROOM_TOPIC);
+  },
+});

--- a/apps/playground/server/api/collab-sync.ts
+++ b/apps/playground/server/api/collab-sync.ts
@@ -1,0 +1,139 @@
+/**
+ * WebSocket relay for the textarea online-collab `SyncAdapter` protocol
+ * (`apps/playground/src/modules/collab-editor/types.ts`).
+ *
+ * Rooms are isolated by the `roomId` field on each SyncMessage. The server
+ * also keeps a short in-memory event log so sync-request can be answered when
+ * no peer is online.
+ */
+
+import { defineWebSocketHandler } from "nitro";
+
+const ROOM_TOPIC_PREFIX = "sync:";
+
+type WireGraphEvent = {
+  readonly id: string;
+  readonly [key: string]: unknown;
+};
+
+type SyncMessage = {
+  readonly type: string;
+  readonly roomId: string;
+  readonly userId: string;
+  readonly timestamp: number;
+  readonly data?: unknown;
+};
+
+type RoomState = {
+  readonly events: Map<string, WireGraphEvent>;
+  readonly peers: Set<string>;
+};
+
+const rooms = new Map<string, RoomState>();
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const getRoom = (roomId: string): RoomState => {
+  const existing = rooms.get(roomId);
+  if (existing) return existing;
+  const created: RoomState = { events: new Map(), peers: new Set() };
+  rooms.set(roomId, created);
+  return created;
+};
+
+const parseSyncMessage = (raw: string): SyncMessage | null => {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    if (typeof parsed.type !== "string") return null;
+    if (typeof parsed.roomId !== "string" || parsed.roomId.length === 0)
+      return null;
+    if (typeof parsed.userId !== "string") return null;
+    if (typeof parsed.timestamp !== "number") return null;
+    return parsed as unknown as SyncMessage;
+  } catch {
+    return null;
+  }
+};
+
+const topicFor = (roomId: string): string => `${ROOM_TOPIC_PREFIX}${roomId}`;
+
+export default defineWebSocketHandler({
+  open(peer) {
+    peer.context.rooms = new Set<string>();
+  },
+
+  message(peer, message) {
+    const parsed = parseSyncMessage(message.text());
+    if (parsed === null) return;
+
+    const room = getRoom(parsed.roomId);
+    const topic = topicFor(parsed.roomId);
+    const subscribed = peer.context.rooms as Set<string>;
+    if (!subscribed.has(parsed.roomId)) {
+      peer.subscribe(topic);
+      subscribed.add(parsed.roomId);
+    }
+
+    switch (parsed.type) {
+      case "join":
+        room.peers.add(parsed.userId);
+        peer.publish(topic, parsed);
+        return;
+      case "leave":
+        room.peers.delete(parsed.userId);
+        peer.publish(topic, parsed);
+        return;
+      case "event": {
+        if (isRecord(parsed.data) && typeof parsed.data.id === "string") {
+          room.events.set(parsed.data.id, parsed.data as WireGraphEvent);
+        }
+        peer.publish(topic, parsed);
+        return;
+      }
+      case "sync-request": {
+        peer.publish(topic, parsed);
+        if (!isRecord(parsed.data)) return;
+        const known = new Set(
+          Array.isArray(parsed.data.knownEventIds)
+            ? parsed.data.knownEventIds.filter(
+                (id): id is string => typeof id === "string",
+              )
+            : [],
+        );
+        const missing = [...room.events.values()].filter(
+          (event) => !known.has(event.id),
+        );
+        if (missing.length === 0) return;
+        peer.send({
+          type: "sync-response",
+          roomId: parsed.roomId,
+          userId: "server",
+          timestamp: Date.now(),
+          data: {
+            frontier: missing.map((event) => event.id),
+            knownEventIds: [...room.events.keys()],
+            events: missing,
+          },
+        });
+        return;
+      }
+      case "sync-response":
+      case "presence":
+        peer.publish(topic, parsed);
+        return;
+      default:
+        return;
+    }
+  },
+
+  close(peer) {
+    const subscribed = peer.context.rooms as Set<string> | undefined;
+    if (!subscribed) return;
+    for (const roomId of subscribed) {
+      peer.unsubscribe(topicFor(roomId));
+    }
+    subscribed.clear();
+  },
+});

--- a/apps/playground/server/api/collab-sync.ts
+++ b/apps/playground/server/api/collab-sync.ts
@@ -11,6 +11,7 @@ import { defineWebSocketHandler } from "nitro";
 import type { EventHandler } from "nitro/h3";
 
 const ROOM_TOPIC_PREFIX = "sync:";
+const MAX_EVENTS_PER_ROOM = 500;
 
 type WireGraphEvent = {
   readonly id: string;
@@ -27,7 +28,7 @@ type SyncMessage = {
 
 type RoomState = {
   readonly events: Map<string, WireGraphEvent>;
-  readonly peers: Set<string>;
+  readonly connections: Set<object>;
 };
 
 const rooms = new Map<string, RoomState>();
@@ -38,9 +39,22 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const getRoom = (roomId: string): RoomState => {
   const existing = rooms.get(roomId);
   if (existing) return existing;
-  const created: RoomState = { events: new Map(), peers: new Set() };
+  const created: RoomState = { events: new Map(), connections: new Set() };
   rooms.set(roomId, created);
   return created;
+};
+
+const putEvent = (room: RoomState, event: WireGraphEvent): void => {
+  if (room.events.has(event.id)) {
+    room.events.set(event.id, event);
+    return;
+  }
+  while (room.events.size >= MAX_EVENTS_PER_ROOM) {
+    const oldest = room.events.keys().next().value;
+    if (oldest === undefined) break;
+    room.events.delete(oldest);
+  }
+  room.events.set(event.id, event);
 };
 
 const parseSyncMessage = (raw: string): SyncMessage | null => {
@@ -75,20 +89,19 @@ const handler: EventHandler = defineWebSocketHandler({
     if (!subscribed.has(parsed.roomId)) {
       peer.subscribe(topic);
       subscribed.add(parsed.roomId);
+      room.connections.add(peer);
     }
 
     switch (parsed.type) {
       case "join":
-        room.peers.add(parsed.userId);
         peer.publish(topic, parsed);
         return;
       case "leave":
-        room.peers.delete(parsed.userId);
         peer.publish(topic, parsed);
         return;
       case "event": {
         if (isRecord(parsed.data) && typeof parsed.data.id === "string") {
-          room.events.set(parsed.data.id, parsed.data as WireGraphEvent);
+          putEvent(room, parsed.data as WireGraphEvent);
         }
         peer.publish(topic, parsed);
         return;
@@ -134,6 +147,12 @@ const handler: EventHandler = defineWebSocketHandler({
     if (!subscribed) return;
     for (const roomId of subscribed) {
       peer.unsubscribe(topicFor(roomId));
+      const room = rooms.get(roomId);
+      if (!room) continue;
+      room.connections.delete(peer);
+      if (room.connections.size === 0) {
+        rooms.delete(roomId);
+      }
     }
     subscribed.clear();
   },

--- a/apps/playground/server/api/collab-sync.ts
+++ b/apps/playground/server/api/collab-sync.ts
@@ -8,6 +8,7 @@
  */
 
 import { defineWebSocketHandler } from "nitro";
+import type { EventHandler } from "nitro/h3";
 
 const ROOM_TOPIC_PREFIX = "sync:";
 
@@ -59,7 +60,7 @@ const parseSyncMessage = (raw: string): SyncMessage | null => {
 
 const topicFor = (roomId: string): string => `${ROOM_TOPIC_PREFIX}${roomId}`;
 
-export default defineWebSocketHandler({
+const handler: EventHandler = defineWebSocketHandler({
   open(peer) {
     peer.context.rooms = new Set<string>();
   },
@@ -137,3 +138,5 @@ export default defineWebSocketHandler({
     subscribed.clear();
   },
 });
+
+export default handler;

--- a/apps/playground/server/api/presence.ts
+++ b/apps/playground/server/api/presence.ts
@@ -1,0 +1,193 @@
+/**
+ * WebSocket presence server for `@softmaple/awareness` `createWebSocketAdapter`.
+ *
+ * Frame contract matches `packages/awareness/src/adapters/websocket/types.ts`.
+ */
+
+import { defineWebSocketHandler } from "nitro";
+
+const ROOM_TOPIC = "presence";
+
+type PresenceUser = {
+  readonly userId: string;
+  readonly name: string;
+  readonly color: string;
+  readonly [key: string]: unknown;
+};
+
+type PresenceMessage = {
+  readonly type: string;
+  readonly roomId: string;
+  readonly senderId: string;
+  readonly timestamp: number;
+  readonly payload?: unknown;
+};
+
+type PeerContext = {
+  roomId?: string;
+  userId?: string;
+};
+
+const rooms = new Map<string, Map<string, PresenceUser>>();
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const parseMessage = (raw: string): PresenceMessage | null => {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    if (typeof parsed.type !== "string") return null;
+    if (typeof parsed.roomId !== "string") return null;
+    if (typeof parsed.senderId !== "string") return null;
+    if (typeof parsed.timestamp !== "number") return null;
+    return parsed as unknown as PresenceMessage;
+  } catch {
+    return null;
+  }
+};
+
+const getRoomUsers = (roomId: string): Map<string, PresenceUser> => {
+  const existing = rooms.get(roomId);
+  if (existing) return existing;
+  const created = new Map<string, PresenceUser>();
+  rooms.set(roomId, created);
+  return created;
+};
+
+const roomIdFromPeer = (peer: {
+  context: PeerContext;
+  request?: { url?: string };
+}): string | null => {
+  if (typeof peer.context.roomId === "string" && peer.context.roomId.length > 0) {
+    return peer.context.roomId;
+  }
+  const url = peer.request?.url;
+  if (typeof url !== "string") return null;
+  return new URL(url).searchParams.get("roomId");
+};
+
+const send = (
+  peer: { send: (data: unknown) => void },
+  message: PresenceMessage,
+): void => {
+  peer.send(message);
+};
+
+export default defineWebSocketHandler({
+  upgrade(request) {
+    const url = new URL(request.url);
+    const roomId = url.searchParams.get("roomId")?.trim();
+    if (!roomId) {
+      throw new Response("roomId query parameter is required", { status: 400 });
+    }
+    return {
+      namespace: `presence:${roomId}`,
+      context: { roomId } satisfies PeerContext,
+    };
+  },
+
+  open(peer) {
+    const roomId = roomIdFromPeer(peer);
+    if (!roomId) {
+      peer.close(1008, "Missing roomId");
+      return;
+    }
+    peer.context.roomId = roomId;
+    peer.subscribe(ROOM_TOPIC);
+  },
+
+  message(peer, message) {
+    const roomId = roomIdFromPeer(peer);
+    if (!roomId) return;
+
+    const parsed = parseMessage(message.text());
+    if (parsed === null) return;
+
+    // Demo auth handshake — accept any token and ignore the frame.
+    if (parsed.type === "auth") return;
+
+    if (parsed.roomId !== roomId) return;
+
+    const users = getRoomUsers(roomId);
+
+    switch (parsed.type) {
+      case "join": {
+        if (!isRecord(parsed.payload) || !isRecord(parsed.payload.user)) return;
+        const user = parsed.payload.user as PresenceUser;
+        if (typeof user.userId !== "string") return;
+        users.set(user.userId, user);
+        peer.context.userId = user.userId;
+        peer.publish(ROOM_TOPIC, parsed);
+        send(peer, {
+          type: "presence:sync-response",
+          roomId,
+          senderId: "server",
+          timestamp: Date.now(),
+          payload: { users: [...users.values()] },
+        });
+        return;
+      }
+      case "leave": {
+        const userId =
+          isRecord(parsed.payload) && typeof parsed.payload.userId === "string"
+            ? parsed.payload.userId
+            : parsed.senderId;
+        users.delete(userId);
+        peer.publish(ROOM_TOPIC, parsed);
+        return;
+      }
+      case "presence:update": {
+        if (!isRecord(parsed.payload)) return;
+        const userId =
+          typeof parsed.payload.userId === "string"
+            ? parsed.payload.userId
+            : parsed.senderId;
+        const existing = users.get(userId);
+        if (!existing || !isRecord(parsed.payload.updates)) return;
+        users.set(userId, {
+          ...existing,
+          ...(parsed.payload.updates as Partial<PresenceUser>),
+        });
+        peer.publish(ROOM_TOPIC, parsed);
+        return;
+      }
+      case "presence:sync":
+        send(peer, {
+          type: "presence:sync-response",
+          roomId,
+          senderId: "server",
+          timestamp: Date.now(),
+          payload: { users: [...users.values()] },
+        });
+        return;
+      case "heartbeat":
+        send(peer, {
+          type: "heartbeat:ack",
+          roomId,
+          senderId: "server",
+          timestamp: Date.now(),
+        });
+        return;
+      default:
+        return;
+    }
+  },
+
+  close(peer) {
+    const roomId = roomIdFromPeer(peer);
+    const userId = peer.context.userId;
+    peer.unsubscribe(ROOM_TOPIC);
+    if (!roomId || typeof userId !== "string") return;
+    const users = rooms.get(roomId);
+    if (!users?.has(userId)) return;
+    users.delete(userId);
+    peer.publish(ROOM_TOPIC, {
+      type: "leave",
+      roomId,
+      senderId: "server",
+      timestamp: Date.now(),
+      payload: { userId },
+    });
+  },
+});

--- a/apps/playground/server/api/presence.ts
+++ b/apps/playground/server/api/presence.ts
@@ -136,6 +136,9 @@ const handler: EventHandler = defineWebSocketHandler({
             : parsed.senderId;
         users.delete(userId);
         peer.publish(ROOM_TOPIC, parsed);
+        if (users.size === 0) {
+          rooms.delete(roomId);
+        }
         return;
       }
       case "presence:update": {
@@ -190,6 +193,9 @@ const handler: EventHandler = defineWebSocketHandler({
       timestamp: Date.now(),
       payload: { userId },
     });
+    if (users.size === 0) {
+      rooms.delete(roomId);
+    }
   },
 });
 

--- a/apps/playground/server/api/presence.ts
+++ b/apps/playground/server/api/presence.ts
@@ -5,6 +5,7 @@
  */
 
 import { defineWebSocketHandler } from "nitro";
+import type { EventHandler } from "nitro/h3";
 
 const ROOM_TOPIC = "presence";
 
@@ -74,7 +75,7 @@ const send = (
   peer.send(message);
 };
 
-export default defineWebSocketHandler({
+const handler: EventHandler = defineWebSocketHandler({
   upgrade(request) {
     const url = new URL(request.url);
     const roomId = url.searchParams.get("roomId")?.trim();
@@ -191,3 +192,5 @@ export default defineWebSocketHandler({
     });
   },
 });
+
+export default handler;

--- a/apps/playground/src/env.ts
+++ b/apps/playground/src/env.ts
@@ -1,6 +1,17 @@
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
+const wsUrl = z
+  .url()
+  .refine(
+    (value) => {
+      const protocol = new URL(value).protocol;
+      return protocol === "ws:" || protocol === "wss:";
+    },
+    { message: "Must be a ws:// or wss:// URL" },
+  )
+  .optional();
+
 export const env = createEnv({
   server: {
     SERVER_URL: z.string().url().optional(),
@@ -17,11 +28,11 @@ export const env = createEnv({
     /** `websocket` (default) or `broadcast` for Lexical / online collab demos */
     VITE_COLLAB_TRANSPORT: z.enum(["websocket", "broadcast"]).optional(),
     /** Override document-sync WebSocket base URL (no roomId query) */
-    VITE_COLLAB_DOC_WS_URL: z.string().min(1).optional(),
+    VITE_COLLAB_DOC_WS_URL: wsUrl,
     /** Override presence WebSocket base URL (no roomId query) */
-    VITE_COLLAB_PRESENCE_WS_URL: z.string().min(1).optional(),
+    VITE_COLLAB_PRESENCE_WS_URL: wsUrl,
     /** Override textarea SyncAdapter WebSocket URL */
-    VITE_COLLAB_SYNC_WS_URL: z.string().min(1).optional(),
+    VITE_COLLAB_SYNC_WS_URL: wsUrl,
   },
 
   /**

--- a/apps/playground/src/env.ts
+++ b/apps/playground/src/env.ts
@@ -14,6 +14,14 @@ export const env = createEnv({
 
   client: {
     VITE_APP_TITLE: z.string().min(1).optional(),
+    /** `websocket` (default) or `broadcast` for Lexical / online collab demos */
+    VITE_COLLAB_TRANSPORT: z.enum(["websocket", "broadcast"]).optional(),
+    /** Override document-sync WebSocket base URL (no roomId query) */
+    VITE_COLLAB_DOC_WS_URL: z.string().min(1).optional(),
+    /** Override presence WebSocket base URL (no roomId query) */
+    VITE_COLLAB_PRESENCE_WS_URL: z.string().min(1).optional(),
+    /** Override textarea SyncAdapter WebSocket URL */
+    VITE_COLLAB_SYNC_WS_URL: z.string().min(1).optional(),
   },
 
   /**

--- a/apps/playground/src/modules/collab-transport/urls.test.ts
+++ b/apps/playground/src/modules/collab-transport/urls.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildSameOriginEndpoints,
   COLLAB_TRANSPORT,
@@ -11,6 +11,46 @@ import {
   createWebSocketBroadcastChannel,
 } from "./websocket-broadcast-channel";
 
+type FakeSocket = {
+  readyState: number;
+  send: (data: string) => void;
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly addEventListener: (
+    type: string,
+    listener: (event: Event) => void,
+  ) => void;
+  setReadyState: (next: number) => void;
+  dispatch: (type: string, event?: Event) => void;
+};
+
+const createFakeSocket = (): FakeSocket => {
+  const listeners = new Map<string, Set<(event: Event) => void>>();
+  let readyState = 0;
+  return {
+    get readyState() {
+      return readyState;
+    },
+    set readyState(next) {
+      readyState = next;
+    },
+    setReadyState: (next) => {
+      readyState = next;
+    },
+    send: vi.fn(),
+    close: vi.fn(),
+    addEventListener: (type, listener) => {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    dispatch: (type, event = new Event(type)) => {
+      for (const listener of listeners.get(type) ?? []) {
+        listener(event);
+      }
+    },
+  };
+};
+
 describe("collab transport urls", () => {
   it("maps http(s) origins to ws(s)", () => {
     expect(toWebSocketOrigin("http://localhost:3000")).toBe(
@@ -18,6 +58,9 @@ describe("collab transport urls", () => {
     );
     expect(toWebSocketOrigin("https://playground.example/")).toBe(
       "wss://playground.example",
+    );
+    expect(toWebSocketOrigin("wss://secure.example/collab")).toBe(
+      "wss://secure.example",
     );
   });
 
@@ -59,24 +102,15 @@ describe("collab transport urls", () => {
 });
 
 describe("websocket broadcast channel", () => {
-  it("queues messages until the socket opens", () => {
-    const listeners = new Map<string, Set<(event: Event) => void>>();
-    let readyState = 0;
-    const sent: string[] = [];
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
-    const socket = {
-      get readyState() {
-        return readyState;
-      },
-      send: (data: string) => {
-        sent.push(data);
-      },
-      close: vi.fn(),
-      addEventListener: (type: string, listener: (event: Event) => void) => {
-        const set = listeners.get(type) ?? new Set();
-        set.add(listener);
-        listeners.set(type, set);
-      },
+  it("queues messages until the socket opens", () => {
+    const socket = createFakeSocket();
+    const sent: string[] = [];
+    socket.send = (data: string) => {
+      sent.push(data);
     };
 
     const channel = createWebSocketBroadcastChannel({
@@ -88,10 +122,8 @@ describe("websocket broadcast channel", () => {
     channel.postMessage({ type: "event", roomId: "room-1" });
     expect(sent).toEqual([]);
 
-    readyState = 1;
-    for (const listener of listeners.get("open") ?? []) {
-      listener(new Event("open"));
-    }
+    socket.setReadyState(1);
+    socket.dispatch("open");
     expect(sent).toEqual([JSON.stringify({ type: "event", roomId: "room-1" })]);
     channel.close();
   });
@@ -100,5 +132,83 @@ describe("websocket broadcast channel", () => {
     expect(
       buildDocWebSocketUrl("ws://localhost:3000/api/collab-doc", "abc"),
     ).toBe("ws://localhost:3000/api/collab-doc?roomId=abc");
+  });
+
+  it("schedules reconnect after close and stops after channel.close", () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+
+    const channel = createWebSocketBroadcastChannel({
+      url: "ws://localhost:3000/api/collab-doc",
+      roomId: "room-1",
+      reconnectDelayMs: 1_000,
+      webSocketFactory: () => {
+        const next = createFakeSocket();
+        sockets.push(next);
+        return next as unknown as WebSocket;
+      },
+    });
+
+    expect(sockets).toHaveLength(1);
+    sockets[0]?.dispatch("close");
+    vi.advanceTimersByTime(2_000);
+    expect(sockets.length).toBeGreaterThanOrEqual(2);
+
+    const socketsAfterReconnect = sockets.length;
+    channel.close();
+    sockets[socketsAfterReconnect - 1]?.dispatch("close");
+    vi.advanceTimersByTime(60_000);
+    expect(sockets).toHaveLength(socketsAfterReconnect);
+  });
+
+  it("delivers parsed JSON to onmessage and ignores malformed frames", () => {
+    const socket = createFakeSocket();
+    const channel = createWebSocketBroadcastChannel({
+      url: "ws://localhost:3000/api/collab-doc",
+      roomId: "room-1",
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+
+    const received: unknown[] = [];
+    channel.onmessage = (event) => {
+      received.push(event.data);
+    };
+
+    socket.dispatch("message", {
+      data: JSON.stringify({ type: "event", roomId: "room-1" }),
+    } as MessageEvent);
+    expect(received).toEqual([{ type: "event", roomId: "room-1" }]);
+
+    expect(() => {
+      socket.dispatch("message", { data: "not-json{" } as MessageEvent);
+    }).not.toThrow();
+    expect(received).toHaveLength(1);
+    channel.close();
+  });
+
+  it("ignores late close events from replaced sockets", () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+
+    createWebSocketBroadcastChannel({
+      url: "ws://localhost:3000/api/collab-doc",
+      roomId: "room-1",
+      reconnectDelayMs: 1_000,
+      webSocketFactory: () => {
+        const next = createFakeSocket();
+        sockets.push(next);
+        return next as unknown as WebSocket;
+      },
+    });
+
+    const first = sockets[0];
+    first?.dispatch("close");
+    vi.advanceTimersByTime(2_000);
+    expect(sockets.length).toBeGreaterThanOrEqual(2);
+
+    const beforeLateClose = sockets.length;
+    first?.dispatch("close");
+    vi.advanceTimersByTime(60_000);
+    expect(sockets).toHaveLength(beforeLateClose);
   });
 });

--- a/apps/playground/src/modules/collab-transport/urls.test.ts
+++ b/apps/playground/src/modules/collab-transport/urls.test.ts
@@ -9,7 +9,7 @@ import {
 import {
   buildDocWebSocketUrl,
   createWebSocketBroadcastChannel,
-} from "./websocket-broadcast-channel";
+} from "./websocketBroadcastChannel";
 
 type FakeSocket = {
   readyState: number;

--- a/apps/playground/src/modules/collab-transport/urls.test.ts
+++ b/apps/playground/src/modules/collab-transport/urls.test.ts
@@ -186,6 +186,47 @@ describe("websocket broadcast channel", () => {
     channel.close();
   });
 
+  it("fires onopen and connection callbacks across reconnect", () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const opens: number[] = [];
+    const states: string[] = [];
+
+    const channel = createWebSocketBroadcastChannel({
+      url: "ws://localhost:3000/api/collab-doc",
+      roomId: "room-1",
+      reconnectDelayMs: 1_000,
+      webSocketFactory: () => {
+        const next = createFakeSocket();
+        sockets.push(next);
+        return next as unknown as WebSocket;
+      },
+    });
+
+    channel.onconnectionchange = (state) => {
+      states.push(state);
+    };
+    channel.onopen = () => {
+      opens.push(opens.length);
+    };
+
+    sockets[0]?.setReadyState(1);
+    sockets[0]?.dispatch("open");
+    expect(opens).toHaveLength(1);
+    expect(states.at(-1)).toBe("connected");
+
+    sockets[0]?.dispatch("close");
+    expect(states.at(-1)).toBe("reconnecting");
+
+    vi.advanceTimersByTime(2_000);
+    expect(sockets.length).toBeGreaterThanOrEqual(2);
+    sockets[1]?.setReadyState(1);
+    sockets[1]?.dispatch("open");
+    expect(opens).toHaveLength(2);
+    expect(states.at(-1)).toBe("connected");
+    channel.close();
+  });
+
   it("ignores late close events from replaced sockets", () => {
     vi.useFakeTimers();
     const sockets: FakeSocket[] = [];

--- a/apps/playground/src/modules/collab-transport/urls.test.ts
+++ b/apps/playground/src/modules/collab-transport/urls.test.ts
@@ -291,6 +291,7 @@ describe("websocket broadcast channel", () => {
 
   it("closes an existing socket before connect replaces it", () => {
     const sockets: FakeSocket[] = [];
+    const sequence: Array<"factory" | "close"> = [];
     let connectionState: TransportConnectionState = "connecting";
     const lifecycle = createWebSocketLifecycle({
       wsUrl: "ws://localhost:3000/api/collab-doc?roomId=room-1",
@@ -298,6 +299,7 @@ describe("websocket broadcast channel", () => {
       maxReconnectAttempts: 3,
       connectionTimeoutMs: 60_000,
       webSocketFactory: () => {
+        sequence.push("factory");
         const next = createFakeSocket();
         sockets.push(next);
         return next as unknown as WebSocket;
@@ -315,8 +317,14 @@ describe("websocket broadcast channel", () => {
 
     lifecycle.connect();
     expect(sockets).toHaveLength(1);
+    const firstClose = sockets[0]?.close;
+    expect(firstClose).toBeDefined();
+    firstClose?.mockImplementation(() => {
+      sequence.push("close");
+    });
     lifecycle.connect();
-    expect(sockets[0]?.close).toHaveBeenCalled();
+    expect(firstClose).toHaveBeenCalled();
     expect(sockets).toHaveLength(2);
+    expect(sequence).toEqual(["factory", "close", "factory"]);
   });
 });

--- a/apps/playground/src/modules/collab-transport/urls.test.ts
+++ b/apps/playground/src/modules/collab-transport/urls.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSameOriginEndpoints,
+  COLLAB_TRANSPORT,
+  resolveBrowserCollabEndpoints,
+  resolveCollabTransport,
+  toWebSocketOrigin,
+} from "./urls";
+import {
+  buildDocWebSocketUrl,
+  createWebSocketBroadcastChannel,
+} from "./websocket-broadcast-channel";
+
+describe("collab transport urls", () => {
+  it("maps http(s) origins to ws(s)", () => {
+    expect(toWebSocketOrigin("http://localhost:3000")).toBe(
+      "ws://localhost:3000",
+    );
+    expect(toWebSocketOrigin("https://playground.example/")).toBe(
+      "wss://playground.example",
+    );
+  });
+
+  it("prefers query transport over env default", () => {
+    expect(
+      resolveCollabTransport(
+        "?transport=broadcast",
+        COLLAB_TRANSPORT.WebSocket,
+      ),
+    ).toBe(COLLAB_TRANSPORT.Broadcast);
+    expect(resolveCollabTransport("", COLLAB_TRANSPORT.Broadcast)).toBe(
+      COLLAB_TRANSPORT.Broadcast,
+    );
+    expect(resolveCollabTransport("")).toBe(COLLAB_TRANSPORT.WebSocket);
+  });
+
+  it("builds same-origin websocket endpoints", () => {
+    expect(
+      buildSameOriginEndpoints(
+        "http://localhost:3000",
+        COLLAB_TRANSPORT.WebSocket,
+      ),
+    ).toEqual({
+      transport: COLLAB_TRANSPORT.WebSocket,
+      docWsUrl: "ws://localhost:3000/api/collab-doc",
+      presenceWsUrl: "ws://localhost:3000/api/presence",
+      syncWsUrl: "ws://localhost:3000/api/collab-sync",
+    });
+  });
+
+  it("returns null endpoints for broadcast mode", () => {
+    const endpoints = resolveBrowserCollabEndpoints({
+      search: "?transport=broadcast",
+      locationOrigin: "http://localhost:3000",
+    });
+    expect(endpoints.transport).toBe(COLLAB_TRANSPORT.Broadcast);
+    expect(endpoints.docWsUrl).toBeNull();
+  });
+});
+
+describe("websocket broadcast channel", () => {
+  it("queues messages until the socket opens", () => {
+    const listeners = new Map<string, Set<(event: Event) => void>>();
+    let readyState = 0;
+    const sent: string[] = [];
+
+    const socket = {
+      get readyState() {
+        return readyState;
+      },
+      send: (data: string) => {
+        sent.push(data);
+      },
+      close: vi.fn(),
+      addEventListener: (type: string, listener: (event: Event) => void) => {
+        const set = listeners.get(type) ?? new Set();
+        set.add(listener);
+        listeners.set(type, set);
+      },
+    };
+
+    const channel = createWebSocketBroadcastChannel({
+      url: "ws://localhost:3000/api/collab-doc",
+      roomId: "room-1",
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+
+    channel.postMessage({ type: "event", roomId: "room-1" });
+    expect(sent).toEqual([]);
+
+    readyState = 1;
+    for (const listener of listeners.get("open") ?? []) {
+      listener(new Event("open"));
+    }
+    expect(sent).toEqual([JSON.stringify({ type: "event", roomId: "room-1" })]);
+    channel.close();
+  });
+
+  it("appends roomId to the websocket url", () => {
+    expect(
+      buildDocWebSocketUrl("ws://localhost:3000/api/collab-doc", "abc"),
+    ).toBe("ws://localhost:3000/api/collab-doc?roomId=abc");
+  });
+});

--- a/apps/playground/src/modules/collab-transport/urls.test.ts
+++ b/apps/playground/src/modules/collab-transport/urls.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TransportConnectionState } from "@/modules/lexical-eg-walker/persistence/channel";
 import {
   buildSameOriginEndpoints,
   COLLAB_TRANSPORT,
@@ -10,6 +11,7 @@ import {
   buildDocWebSocketUrl,
   createWebSocketBroadcastChannel,
 } from "./websocketBroadcastChannel";
+import { createWebSocketLifecycle } from "./websocketBroadcastChannelLifecycle";
 
 type FakeSocket = {
   readyState: number;
@@ -142,6 +144,7 @@ describe("websocket broadcast channel", () => {
       url: "ws://localhost:3000/api/collab-doc",
       roomId: "room-1",
       reconnectDelayMs: 1_000,
+      connectionTimeoutMs: 60_000,
       webSocketFactory: () => {
         const next = createFakeSocket();
         sockets.push(next);
@@ -235,6 +238,7 @@ describe("websocket broadcast channel", () => {
       url: "ws://localhost:3000/api/collab-doc",
       roomId: "room-1",
       reconnectDelayMs: 1_000,
+      connectionTimeoutMs: 60_000,
       webSocketFactory: () => {
         const next = createFakeSocket();
         sockets.push(next);
@@ -246,10 +250,73 @@ describe("websocket broadcast channel", () => {
     first?.dispatch("close");
     vi.advanceTimersByTime(2_000);
     expect(sockets.length).toBeGreaterThanOrEqual(2);
+    sockets[1]?.setReadyState(1);
+    sockets[1]?.dispatch("open");
 
     const beforeLateClose = sockets.length;
     first?.dispatch("close");
     vi.advanceTimersByTime(60_000);
     expect(sockets).toHaveLength(beforeLateClose);
+  });
+
+  it("closes a hung connecting socket after connectionTimeoutMs and reconnects", () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const states: string[] = [];
+
+    const channel = createWebSocketBroadcastChannel({
+      url: "ws://localhost:3000/api/collab-doc",
+      roomId: "room-1",
+      reconnectDelayMs: 500,
+      connectionTimeoutMs: 1_000,
+      webSocketFactory: () => {
+        const next = createFakeSocket();
+        sockets.push(next);
+        return next as unknown as WebSocket;
+      },
+    });
+    channel.onconnectionchange = (state) => {
+      states.push(state);
+    };
+
+    expect(sockets).toHaveLength(1);
+    vi.advanceTimersByTime(1_000);
+    expect(sockets[0]?.close).toHaveBeenCalled();
+    expect(states).toContain("reconnecting");
+
+    vi.advanceTimersByTime(1_000);
+    expect(sockets.length).toBeGreaterThanOrEqual(2);
+    channel.close();
+  });
+
+  it("closes an existing socket before connect replaces it", () => {
+    const sockets: FakeSocket[] = [];
+    let connectionState: TransportConnectionState = "connecting";
+    const lifecycle = createWebSocketLifecycle({
+      wsUrl: "ws://localhost:3000/api/collab-doc?roomId=room-1",
+      reconnectDelayMs: 1_000,
+      maxReconnectAttempts: 3,
+      connectionTimeoutMs: 60_000,
+      webSocketFactory: () => {
+        const next = createFakeSocket();
+        sockets.push(next);
+        return next as unknown as WebSocket;
+      },
+      isClosed: () => false,
+      getConnectionState: () => connectionState,
+      setConnectionState: (next) => {
+        connectionState = next;
+      },
+      getMessageHandler: () => null,
+      getOpenHandler: () => null,
+      outboundQueue: [],
+      onSocket: () => undefined,
+    });
+
+    lifecycle.connect();
+    expect(sockets).toHaveLength(1);
+    lifecycle.connect();
+    expect(sockets[0]?.close).toHaveBeenCalled();
+    expect(sockets).toHaveLength(2);
   });
 });

--- a/apps/playground/src/modules/collab-transport/urls.ts
+++ b/apps/playground/src/modules/collab-transport/urls.ts
@@ -1,0 +1,104 @@
+/**
+ * Resolve collaboration WebSocket endpoints and transport mode for playground demos.
+ */
+
+export const COLLAB_TRANSPORT = {
+  WebSocket: "websocket",
+  Broadcast: "broadcast",
+} as const;
+
+export type CollabTransport =
+  (typeof COLLAB_TRANSPORT)[keyof typeof COLLAB_TRANSPORT];
+
+export interface CollabEndpoints {
+  readonly transport: CollabTransport;
+  readonly docWsUrl: string | null;
+  readonly presenceWsUrl: string | null;
+  readonly syncWsUrl: string | null;
+}
+
+const trimTrailingSlash = (value: string): string =>
+  value.endsWith("/") ? value.slice(0, -1) : value;
+
+export const toWebSocketOrigin = (httpOrigin: string): string => {
+  const url = new URL(httpOrigin);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return trimTrailingSlash(url.origin);
+};
+
+export const resolveCollabTransport = (
+  search: string | URLSearchParams = "",
+  envTransport?: string | null,
+): CollabTransport => {
+  const params =
+    typeof search === "string" ? new URLSearchParams(search) : search;
+  const fromQuery = params.get("transport");
+  if (
+    fromQuery === COLLAB_TRANSPORT.WebSocket ||
+    fromQuery === COLLAB_TRANSPORT.Broadcast
+  ) {
+    return fromQuery;
+  }
+  if (
+    envTransport === COLLAB_TRANSPORT.WebSocket ||
+    envTransport === COLLAB_TRANSPORT.Broadcast
+  ) {
+    return envTransport;
+  }
+  return COLLAB_TRANSPORT.WebSocket;
+};
+
+export const buildSameOriginEndpoints = (
+  httpOrigin: string,
+  transport: CollabTransport,
+): CollabEndpoints => {
+  if (transport === COLLAB_TRANSPORT.Broadcast) {
+    return {
+      transport,
+      docWsUrl: null,
+      presenceWsUrl: null,
+      syncWsUrl: null,
+    };
+  }
+  const wsOrigin = toWebSocketOrigin(httpOrigin);
+  return {
+    transport,
+    docWsUrl: `${wsOrigin}/api/collab-doc`,
+    presenceWsUrl: `${wsOrigin}/api/presence`,
+    syncWsUrl: `${wsOrigin}/api/collab-sync`,
+  };
+};
+
+export const resolveBrowserCollabEndpoints = (
+  options: {
+    readonly search?: string;
+    readonly envTransport?: string | null;
+    readonly docWsUrl?: string | null;
+    readonly presenceWsUrl?: string | null;
+    readonly syncWsUrl?: string | null;
+    readonly locationOrigin?: string;
+  } = {},
+): CollabEndpoints => {
+  const transport = resolveCollabTransport(
+    options.search ??
+      (typeof window === "undefined" ? "" : window.location.search),
+    options.envTransport,
+  );
+  if (transport === COLLAB_TRANSPORT.Broadcast) {
+    return buildSameOriginEndpoints("http://localhost", transport);
+  }
+
+  const origin =
+    options.locationOrigin ??
+    (typeof window === "undefined"
+      ? "http://localhost:3000"
+      : window.location.origin);
+  const defaults = buildSameOriginEndpoints(origin, transport);
+
+  return {
+    transport,
+    docWsUrl: options.docWsUrl ?? defaults.docWsUrl,
+    presenceWsUrl: options.presenceWsUrl ?? defaults.presenceWsUrl,
+    syncWsUrl: options.syncWsUrl ?? defaults.syncWsUrl,
+  };
+};

--- a/apps/playground/src/modules/collab-transport/urls.ts
+++ b/apps/playground/src/modules/collab-transport/urls.ts
@@ -2,6 +2,8 @@
  * Resolve collaboration WebSocket endpoints and transport mode for playground demos.
  */
 
+import { PLAYGROUND_PORT } from "../../../playground-port";
+
 export const COLLAB_TRANSPORT = {
   WebSocket: "websocket",
   Broadcast: "broadcast",
@@ -17,13 +19,15 @@ export interface CollabEndpoints {
   readonly syncWsUrl: string | null;
 }
 
-const trimTrailingSlash = (value: string): string =>
-  value.endsWith("/") ? value.slice(0, -1) : value;
-
 export const toWebSocketOrigin = (httpOrigin: string): string => {
   const url = new URL(httpOrigin);
-  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-  return trimTrailingSlash(url.origin);
+  if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  } else if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  }
+  // Preserve existing ws:/wss: schemes as-is.
+  return url.origin;
 };
 
 export const resolveCollabTransport = (
@@ -69,13 +73,25 @@ export const buildSameOriginEndpoints = (
   };
 };
 
+const broadcastEndpoints = (): CollabEndpoints => ({
+  transport: COLLAB_TRANSPORT.Broadcast,
+  docWsUrl: null,
+  presenceWsUrl: null,
+  syncWsUrl: null,
+});
+
+const pickEndpoint = (
+  override: string | undefined,
+  fallback: string | null,
+): string | null => (override !== undefined ? override : fallback);
+
 export const resolveBrowserCollabEndpoints = (
   options: {
     readonly search?: string;
     readonly envTransport?: string | null;
-    readonly docWsUrl?: string | null;
-    readonly presenceWsUrl?: string | null;
-    readonly syncWsUrl?: string | null;
+    readonly docWsUrl?: string;
+    readonly presenceWsUrl?: string;
+    readonly syncWsUrl?: string;
     readonly locationOrigin?: string;
   } = {},
 ): CollabEndpoints => {
@@ -85,20 +101,20 @@ export const resolveBrowserCollabEndpoints = (
     options.envTransport,
   );
   if (transport === COLLAB_TRANSPORT.Broadcast) {
-    return buildSameOriginEndpoints("http://localhost", transport);
+    return broadcastEndpoints();
   }
 
   const origin =
     options.locationOrigin ??
     (typeof window === "undefined"
-      ? "http://localhost:3000"
+      ? `http://localhost:${PLAYGROUND_PORT}`
       : window.location.origin);
   const defaults = buildSameOriginEndpoints(origin, transport);
 
   return {
     transport,
-    docWsUrl: options.docWsUrl ?? defaults.docWsUrl,
-    presenceWsUrl: options.presenceWsUrl ?? defaults.presenceWsUrl,
-    syncWsUrl: options.syncWsUrl ?? defaults.syncWsUrl,
+    docWsUrl: pickEndpoint(options.docWsUrl, defaults.docWsUrl),
+    presenceWsUrl: pickEndpoint(options.presenceWsUrl, defaults.presenceWsUrl),
+    syncWsUrl: pickEndpoint(options.syncWsUrl, defaults.syncWsUrl),
   };
 };

--- a/apps/playground/src/modules/collab-transport/websocket-broadcast-channel.ts
+++ b/apps/playground/src/modules/collab-transport/websocket-broadcast-channel.ts
@@ -1,0 +1,146 @@
+/**
+ * `BroadcastChannelLike` backed by a room-scoped WebSocket.
+ *
+ * Drop-in replacement for the native BroadcastChannel factory used by the
+ * Lexical EG-walker persistence channel, so document sync can ride a real
+ * network path instead of same-origin tabs only.
+ */
+
+import type {
+  BroadcastChannelFactory,
+  BroadcastChannelLike,
+  BroadcastMessageEvent,
+} from "@/modules/lexical-eg-walker/persistence/channel";
+
+export interface WebSocketBroadcastChannelOptions {
+  readonly url: string;
+  readonly roomId: string;
+  readonly reconnectDelayMs?: number;
+  readonly webSocketFactory?: (url: string) => WebSocket;
+}
+
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+
+export const buildDocWebSocketUrl = (
+  baseUrl: string,
+  roomId: string,
+): string => {
+  const url = new URL(baseUrl);
+  url.searchParams.set("roomId", roomId);
+  return url.toString();
+};
+
+export const createWebSocketBroadcastChannel = (
+  options: WebSocketBroadcastChannelOptions,
+): BroadcastChannelLike => {
+  const reconnectDelayMs =
+    options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS;
+  const webSocketFactory =
+    options.webSocketFactory ?? ((url: string) => new WebSocket(url));
+  const wsUrl = buildDocWebSocketUrl(options.url, options.roomId);
+
+  let handler: ((event: BroadcastMessageEvent) => void) | null = null;
+  let socket: WebSocket | null = null;
+  let closed = false;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  const outboundQueue: unknown[] = [];
+
+  const clearReconnect = (): void => {
+    if (reconnectTimer === null) return;
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  };
+
+  const flushQueue = (): void => {
+    if (socket === null || socket.readyState !== WebSocket.OPEN) return;
+    while (outboundQueue.length > 0) {
+      const next = outboundQueue.shift();
+      socket.send(JSON.stringify(next));
+    }
+  };
+
+  const scheduleReconnect = (): void => {
+    if (closed || reconnectTimer !== null) return;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, reconnectDelayMs);
+  };
+
+  const connect = (): void => {
+    if (closed) return;
+    clearReconnect();
+    try {
+      socket = webSocketFactory(wsUrl);
+    } catch {
+      scheduleReconnect();
+      return;
+    }
+
+    socket.addEventListener("open", () => {
+      flushQueue();
+    });
+
+    socket.addEventListener("message", (event) => {
+      if (handler === null) return;
+      try {
+        const data =
+          typeof event.data === "string" ? JSON.parse(event.data) : event.data;
+        handler({ data });
+      } catch {
+        // Ignore malformed frames; the persistence channel validates payloads.
+      }
+    });
+
+    socket.addEventListener("close", () => {
+      socket = null;
+      scheduleReconnect();
+    });
+
+    socket.addEventListener("error", () => {
+      // `close` follows and triggers reconnect.
+    });
+  };
+
+  connect();
+
+  return {
+    get onmessage() {
+      return handler;
+    },
+    set onmessage(nextHandler) {
+      handler = nextHandler;
+    },
+    postMessage: (message) => {
+      if (closed) return;
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify(message));
+        return;
+      }
+      outboundQueue.push(message);
+    },
+    close: () => {
+      if (closed) return;
+      closed = true;
+      clearReconnect();
+      outboundQueue.length = 0;
+      handler = null;
+      const current = socket;
+      socket = null;
+      current?.close();
+    },
+  };
+};
+
+export const createWebSocketBroadcastChannelFactory = (
+  baseUrl: string,
+  roomId: string,
+  options: Omit<WebSocketBroadcastChannelOptions, "url" | "roomId"> = {},
+): BroadcastChannelFactory => {
+  return () =>
+    createWebSocketBroadcastChannel({
+      ...options,
+      url: baseUrl,
+      roomId,
+    });
+};

--- a/apps/playground/src/modules/collab-transport/websocket-broadcast-channel.ts
+++ b/apps/playground/src/modules/collab-transport/websocket-broadcast-channel.ts
@@ -16,10 +16,15 @@ export interface WebSocketBroadcastChannelOptions {
   readonly url: string;
   readonly roomId: string;
   readonly reconnectDelayMs?: number;
+  readonly maxReconnectAttempts?: number;
+  readonly maxOutboundQueue?: number;
   readonly webSocketFactory?: (url: string) => WebSocket;
 }
 
 const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
+const DEFAULT_MAX_OUTBOUND_QUEUE = 100;
+const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export const buildDocWebSocketUrl = (
   baseUrl: string,
@@ -35,6 +40,10 @@ export const createWebSocketBroadcastChannel = (
 ): BroadcastChannelLike => {
   const reconnectDelayMs =
     options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS;
+  const maxReconnectAttempts =
+    options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+  const maxOutboundQueue =
+    options.maxOutboundQueue ?? DEFAULT_MAX_OUTBOUND_QUEUE;
   const webSocketFactory =
     options.webSocketFactory ?? ((url: string) => new WebSocket(url));
   const wsUrl = buildDocWebSocketUrl(options.url, options.roomId);
@@ -43,6 +52,7 @@ export const createWebSocketBroadcastChannel = (
   let socket: WebSocket | null = null;
   let closed = false;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectAttempts = 0;
   const outboundQueue: unknown[] = [];
 
   const clearReconnect = (): void => {
@@ -61,28 +71,45 @@ export const createWebSocketBroadcastChannel = (
 
   const scheduleReconnect = (): void => {
     if (closed || reconnectTimer !== null) return;
+    if (reconnectAttempts >= maxReconnectAttempts) return;
+
+    const attempt = reconnectAttempts;
+    reconnectAttempts += 1;
+    const exponential = Math.min(
+      MAX_RECONNECT_DELAY_MS,
+      reconnectDelayMs * 2 ** attempt,
+    );
+    const jitter = Math.floor(
+      Math.random() * Math.min(250, Math.max(1, exponential * 0.2)),
+    );
+    const delay = exponential + jitter;
+
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
       connect();
-    }, reconnectDelayMs);
+    }, delay);
   };
 
   const connect = (): void => {
     if (closed) return;
     clearReconnect();
+    let currentSocket: WebSocket;
     try {
-      socket = webSocketFactory(wsUrl);
+      currentSocket = webSocketFactory(wsUrl);
     } catch {
       scheduleReconnect();
       return;
     }
+    socket = currentSocket;
 
-    socket.addEventListener("open", () => {
+    currentSocket.addEventListener("open", () => {
+      if (socket !== currentSocket) return;
+      reconnectAttempts = 0;
       flushQueue();
     });
 
-    socket.addEventListener("message", (event) => {
-      if (handler === null) return;
+    currentSocket.addEventListener("message", (event) => {
+      if (handler === null || socket !== currentSocket) return;
       try {
         const data =
           typeof event.data === "string" ? JSON.parse(event.data) : event.data;
@@ -92,12 +119,14 @@ export const createWebSocketBroadcastChannel = (
       }
     });
 
-    socket.addEventListener("close", () => {
+    currentSocket.addEventListener("close", () => {
+      if (closed) return;
+      if (socket !== currentSocket) return;
       socket = null;
       scheduleReconnect();
     });
 
-    socket.addEventListener("error", () => {
+    currentSocket.addEventListener("error", () => {
       // `close` follows and triggers reconnect.
     });
   };
@@ -116,6 +145,9 @@ export const createWebSocketBroadcastChannel = (
       if (socket?.readyState === WebSocket.OPEN) {
         socket.send(JSON.stringify(message));
         return;
+      }
+      if (outboundQueue.length >= maxOutboundQueue) {
+        outboundQueue.shift();
       }
       outboundQueue.push(message);
     },

--- a/apps/playground/src/modules/collab-transport/websocket-broadcast-channel.ts
+++ b/apps/playground/src/modules/collab-transport/websocket-broadcast-channel.ts
@@ -10,6 +10,8 @@ import type {
   BroadcastChannelFactory,
   BroadcastChannelLike,
   BroadcastMessageEvent,
+  TransportConnectionListener,
+  TransportConnectionState,
 } from "@/modules/lexical-eg-walker/persistence/channel";
 
 export interface WebSocketBroadcastChannelOptions {
@@ -48,12 +50,21 @@ export const createWebSocketBroadcastChannel = (
     options.webSocketFactory ?? ((url: string) => new WebSocket(url));
   const wsUrl = buildDocWebSocketUrl(options.url, options.roomId);
 
-  let handler: ((event: BroadcastMessageEvent) => void) | null = null;
+  let messageHandler: ((event: BroadcastMessageEvent) => void) | null = null;
+  let openHandler: (() => void) | null = null;
+  let connectionHandler: TransportConnectionListener | null = null;
   let socket: WebSocket | null = null;
   let closed = false;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectAttempts = 0;
+  let connectionState: TransportConnectionState = "connecting";
   const outboundQueue: unknown[] = [];
+
+  const setConnectionState = (next: TransportConnectionState): void => {
+    if (connectionState === next) return;
+    connectionState = next;
+    connectionHandler?.(next);
+  };
 
   const clearReconnect = (): void => {
     if (reconnectTimer === null) return;
@@ -71,8 +82,12 @@ export const createWebSocketBroadcastChannel = (
 
   const scheduleReconnect = (): void => {
     if (closed || reconnectTimer !== null) return;
-    if (reconnectAttempts >= maxReconnectAttempts) return;
+    if (reconnectAttempts >= maxReconnectAttempts) {
+      setConnectionState("error");
+      return;
+    }
 
+    setConnectionState("reconnecting");
     const attempt = reconnectAttempts;
     reconnectAttempts += 1;
     const exponential = Math.min(
@@ -93,6 +108,9 @@ export const createWebSocketBroadcastChannel = (
   const connect = (): void => {
     if (closed) return;
     clearReconnect();
+    if (connectionState !== "reconnecting") {
+      setConnectionState("connecting");
+    }
     let currentSocket: WebSocket;
     try {
       currentSocket = webSocketFactory(wsUrl);
@@ -105,15 +123,17 @@ export const createWebSocketBroadcastChannel = (
     currentSocket.addEventListener("open", () => {
       if (socket !== currentSocket) return;
       reconnectAttempts = 0;
+      setConnectionState("connected");
       flushQueue();
+      openHandler?.();
     });
 
     currentSocket.addEventListener("message", (event) => {
-      if (handler === null || socket !== currentSocket) return;
+      if (messageHandler === null || socket !== currentSocket) return;
       try {
         const data =
           typeof event.data === "string" ? JSON.parse(event.data) : event.data;
-        handler({ data });
+        messageHandler({ data });
       } catch {
         // Ignore malformed frames; the persistence channel validates payloads.
       }
@@ -135,10 +155,24 @@ export const createWebSocketBroadcastChannel = (
 
   return {
     get onmessage() {
-      return handler;
+      return messageHandler;
     },
     set onmessage(nextHandler) {
-      handler = nextHandler;
+      messageHandler = nextHandler;
+    },
+    get onopen() {
+      return openHandler;
+    },
+    set onopen(nextHandler) {
+      openHandler = nextHandler ?? null;
+    },
+    get onconnectionchange() {
+      return connectionHandler;
+    },
+    set onconnectionchange(nextHandler) {
+      connectionHandler = nextHandler ?? null;
+      // Replay current state so subscribers see the latest value immediately.
+      connectionHandler?.(connectionState);
     },
     postMessage: (message) => {
       if (closed) return;
@@ -156,7 +190,10 @@ export const createWebSocketBroadcastChannel = (
       closed = true;
       clearReconnect();
       outboundQueue.length = 0;
-      handler = null;
+      setConnectionState("disconnected");
+      messageHandler = null;
+      openHandler = null;
+      connectionHandler = null;
       const current = socket;
       socket = null;
       current?.close();

--- a/apps/playground/src/modules/collab-transport/websocketBroadcastChannel.ts
+++ b/apps/playground/src/modules/collab-transport/websocketBroadcastChannel.ts
@@ -13,6 +13,7 @@ import type {
   TransportConnectionListener,
   TransportConnectionState,
 } from "@/modules/lexical-eg-walker/persistence/channel";
+import { createWebSocketLifecycle } from "./websocketBroadcastChannelLifecycle";
 
 export interface WebSocketBroadcastChannelOptions {
   readonly url: string;
@@ -26,7 +27,6 @@ export interface WebSocketBroadcastChannelOptions {
 const DEFAULT_RECONNECT_DELAY_MS = 1_000;
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
 const DEFAULT_MAX_OUTBOUND_QUEUE = 100;
-const MAX_RECONNECT_DELAY_MS = 30_000;
 
 export const buildDocWebSocketUrl = (
   baseUrl: string,
@@ -55,8 +55,6 @@ export const createWebSocketBroadcastChannel = (
   let connectionHandler: TransportConnectionListener | null = null;
   let socket: WebSocket | null = null;
   let closed = false;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  let reconnectAttempts = 0;
   let connectionState: TransportConnectionState = "connecting";
   const outboundQueue: unknown[] = [];
 
@@ -66,92 +64,23 @@ export const createWebSocketBroadcastChannel = (
     connectionHandler?.(next);
   };
 
-  const clearReconnect = (): void => {
-    if (reconnectTimer === null) return;
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-  };
+  const lifecycle = createWebSocketLifecycle({
+    wsUrl,
+    reconnectDelayMs,
+    maxReconnectAttempts,
+    webSocketFactory,
+    isClosed: () => closed,
+    getConnectionState: () => connectionState,
+    setConnectionState,
+    getMessageHandler: () => messageHandler,
+    getOpenHandler: () => openHandler,
+    outboundQueue,
+    onSocket: (next) => {
+      socket = next;
+    },
+  });
 
-  const flushQueue = (): void => {
-    if (socket === null || socket.readyState !== WebSocket.OPEN) return;
-    while (outboundQueue.length > 0) {
-      const next = outboundQueue.shift();
-      socket.send(JSON.stringify(next));
-    }
-  };
-
-  const scheduleReconnect = (): void => {
-    if (closed || reconnectTimer !== null) return;
-    if (reconnectAttempts >= maxReconnectAttempts) {
-      setConnectionState("error");
-      return;
-    }
-
-    setConnectionState("reconnecting");
-    const attempt = reconnectAttempts;
-    reconnectAttempts += 1;
-    const exponential = Math.min(
-      MAX_RECONNECT_DELAY_MS,
-      reconnectDelayMs * 2 ** attempt,
-    );
-    const jitter = Math.floor(
-      Math.random() * Math.min(250, Math.max(1, exponential * 0.2)),
-    );
-    const delay = exponential + jitter;
-
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      connect();
-    }, delay);
-  };
-
-  const connect = (): void => {
-    if (closed) return;
-    clearReconnect();
-    if (connectionState !== "reconnecting") {
-      setConnectionState("connecting");
-    }
-    let currentSocket: WebSocket;
-    try {
-      currentSocket = webSocketFactory(wsUrl);
-    } catch {
-      scheduleReconnect();
-      return;
-    }
-    socket = currentSocket;
-
-    currentSocket.addEventListener("open", () => {
-      if (socket !== currentSocket) return;
-      reconnectAttempts = 0;
-      setConnectionState("connected");
-      flushQueue();
-      openHandler?.();
-    });
-
-    currentSocket.addEventListener("message", (event) => {
-      if (messageHandler === null || socket !== currentSocket) return;
-      try {
-        const data =
-          typeof event.data === "string" ? JSON.parse(event.data) : event.data;
-        messageHandler({ data });
-      } catch {
-        // Ignore malformed frames; the persistence channel validates payloads.
-      }
-    });
-
-    currentSocket.addEventListener("close", () => {
-      if (closed) return;
-      if (socket !== currentSocket) return;
-      socket = null;
-      scheduleReconnect();
-    });
-
-    currentSocket.addEventListener("error", () => {
-      // `close` follows and triggers reconnect.
-    });
-  };
-
-  connect();
+  lifecycle.connect();
 
   return {
     get onmessage() {
@@ -188,7 +117,7 @@ export const createWebSocketBroadcastChannel = (
     close: () => {
       if (closed) return;
       closed = true;
-      clearReconnect();
+      lifecycle.clearReconnect();
       outboundQueue.length = 0;
       setConnectionState("disconnected");
       messageHandler = null;

--- a/apps/playground/src/modules/collab-transport/websocketBroadcastChannel.ts
+++ b/apps/playground/src/modules/collab-transport/websocketBroadcastChannel.ts
@@ -21,6 +21,7 @@ export interface WebSocketBroadcastChannelOptions {
   readonly reconnectDelayMs?: number;
   readonly maxReconnectAttempts?: number;
   readonly maxOutboundQueue?: number;
+  readonly connectionTimeoutMs?: number;
   readonly webSocketFactory?: (url: string) => WebSocket;
 }
 
@@ -68,6 +69,7 @@ export const createWebSocketBroadcastChannel = (
     wsUrl,
     reconnectDelayMs,
     maxReconnectAttempts,
+    connectionTimeoutMs: options.connectionTimeoutMs,
     webSocketFactory,
     isClosed: () => closed,
     getConnectionState: () => connectionState,

--- a/apps/playground/src/modules/collab-transport/websocketBroadcastChannelLifecycle.ts
+++ b/apps/playground/src/modules/collab-transport/websocketBroadcastChannelLifecycle.ts
@@ -1,0 +1,130 @@
+import type {
+  BroadcastMessageEvent,
+  TransportConnectionState,
+} from "@/modules/lexical-eg-walker/persistence/channel";
+
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+export interface WebSocketLifecycleOptions {
+  readonly wsUrl: string;
+  readonly reconnectDelayMs: number;
+  readonly maxReconnectAttempts: number;
+  readonly webSocketFactory: (url: string) => WebSocket;
+  readonly isClosed: () => boolean;
+  readonly getConnectionState: () => TransportConnectionState;
+  readonly setConnectionState: (next: TransportConnectionState) => void;
+  readonly getMessageHandler: () =>
+    | ((event: BroadcastMessageEvent) => void)
+    | null;
+  readonly getOpenHandler: () => (() => void) | null;
+  readonly outboundQueue: unknown[];
+  readonly onSocket: (socket: WebSocket | null) => void;
+}
+
+export interface WebSocketLifecycle {
+  readonly connect: () => void;
+  readonly clearReconnect: () => void;
+  readonly scheduleReconnect: () => void;
+}
+
+const flushQueue = (
+  socket: WebSocket | null,
+  outboundQueue: unknown[],
+): void => {
+  if (socket === null || socket.readyState !== WebSocket.OPEN) return;
+  while (outboundQueue.length > 0) {
+    const next = outboundQueue.shift();
+    socket.send(JSON.stringify(next));
+  }
+};
+
+export const createWebSocketLifecycle = (
+  options: WebSocketLifecycleOptions,
+): WebSocketLifecycle => {
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectAttempts = 0;
+  let socket: WebSocket | null = null;
+
+  const clearReconnect = (): void => {
+    if (reconnectTimer === null) return;
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  };
+
+  const scheduleReconnect = (): void => {
+    if (options.isClosed() || reconnectTimer !== null) return;
+    if (reconnectAttempts >= options.maxReconnectAttempts) {
+      options.setConnectionState("error");
+      return;
+    }
+
+    options.setConnectionState("reconnecting");
+    const attempt = reconnectAttempts;
+    reconnectAttempts += 1;
+    const exponential = Math.min(
+      MAX_RECONNECT_DELAY_MS,
+      options.reconnectDelayMs * 2 ** attempt,
+    );
+    const jitter = Math.floor(
+      Math.random() * Math.min(250, Math.max(1, exponential * 0.2)),
+    );
+
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, exponential + jitter);
+  };
+
+  const connect = (): void => {
+    if (options.isClosed()) return;
+    clearReconnect();
+    if (options.getConnectionState() !== "reconnecting") {
+      options.setConnectionState("connecting");
+    }
+
+    let currentSocket: WebSocket;
+    try {
+      currentSocket = options.webSocketFactory(options.wsUrl);
+    } catch {
+      scheduleReconnect();
+      return;
+    }
+
+    socket = currentSocket;
+    options.onSocket(currentSocket);
+
+    currentSocket.addEventListener("open", () => {
+      if (socket !== currentSocket) return;
+      reconnectAttempts = 0;
+      options.setConnectionState("connected");
+      flushQueue(socket, options.outboundQueue);
+      options.getOpenHandler()?.();
+    });
+
+    currentSocket.addEventListener("message", (event) => {
+      const messageHandler = options.getMessageHandler();
+      if (messageHandler === null || socket !== currentSocket) return;
+      try {
+        const data =
+          typeof event.data === "string" ? JSON.parse(event.data) : event.data;
+        messageHandler({ data });
+      } catch {
+        // Ignore malformed frames; the persistence channel validates payloads.
+      }
+    });
+
+    currentSocket.addEventListener("close", () => {
+      if (options.isClosed()) return;
+      if (socket !== currentSocket) return;
+      socket = null;
+      options.onSocket(null);
+      scheduleReconnect();
+    });
+
+    currentSocket.addEventListener("error", () => {
+      // `close` follows and triggers reconnect.
+    });
+  };
+
+  return { connect, clearReconnect, scheduleReconnect };
+};

--- a/apps/playground/src/modules/collab-transport/websocketBroadcastChannelLifecycle.ts
+++ b/apps/playground/src/modules/collab-transport/websocketBroadcastChannelLifecycle.ts
@@ -4,11 +4,13 @@ import type {
 } from "@/modules/lexical-eg-walker/persistence/channel";
 
 const MAX_RECONNECT_DELAY_MS = 30_000;
+export const DEFAULT_CONNECTION_TIMEOUT_MS = 10_000;
 
 export interface WebSocketLifecycleOptions {
   readonly wsUrl: string;
   readonly reconnectDelayMs: number;
   readonly maxReconnectAttempts: number;
+  readonly connectionTimeoutMs?: number;
   readonly webSocketFactory: (url: string) => WebSocket;
   readonly isClosed: () => boolean;
   readonly getConnectionState: () => TransportConnectionState;
@@ -41,14 +43,25 @@ const flushQueue = (
 export const createWebSocketLifecycle = (
   options: WebSocketLifecycleOptions,
 ): WebSocketLifecycle => {
+  const connectionTimeoutMs =
+    options.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let connectionTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectAttempts = 0;
   let socket: WebSocket | null = null;
 
+  const clearConnectionTimeout = (): void => {
+    if (connectionTimer === null) return;
+    clearTimeout(connectionTimer);
+    connectionTimer = null;
+  };
+
   const clearReconnect = (): void => {
-    if (reconnectTimer === null) return;
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    clearConnectionTimeout();
   };
 
   const scheduleReconnect = (): void => {
@@ -75,11 +88,24 @@ export const createWebSocketLifecycle = (
     }, exponential + jitter);
   };
 
+  const detachSocket = (current: WebSocket): void => {
+    if (socket === current) {
+      socket = null;
+      options.onSocket(null);
+    }
+  };
+
   const connect = (): void => {
     if (options.isClosed()) return;
     clearReconnect();
     if (options.getConnectionState() !== "reconnecting") {
       options.setConnectionState("connecting");
+    }
+
+    if (socket !== null) {
+      const previous = socket;
+      detachSocket(previous);
+      previous.close();
     }
 
     let currentSocket: WebSocket;
@@ -93,8 +119,19 @@ export const createWebSocketLifecycle = (
     socket = currentSocket;
     options.onSocket(currentSocket);
 
+    connectionTimer = setTimeout(() => {
+      connectionTimer = null;
+      if (options.isClosed()) return;
+      if (socket !== currentSocket) return;
+      if (currentSocket.readyState === WebSocket.OPEN) return;
+      detachSocket(currentSocket);
+      currentSocket.close();
+      scheduleReconnect();
+    }, connectionTimeoutMs);
+
     currentSocket.addEventListener("open", () => {
       if (socket !== currentSocket) return;
+      clearConnectionTimeout();
       reconnectAttempts = 0;
       options.setConnectionState("connected");
       flushQueue(socket, options.outboundQueue);
@@ -116,8 +153,8 @@ export const createWebSocketLifecycle = (
     currentSocket.addEventListener("close", () => {
       if (options.isClosed()) return;
       if (socket !== currentSocket) return;
-      socket = null;
-      options.onSocket(null);
+      clearConnectionTimeout();
+      detachSocket(currentSocket);
       scheduleReconnect();
     });
 

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
@@ -18,7 +18,11 @@ import {
 import { useRoomPresence } from "./presence";
 import { RemoteSelectionLayer } from "./RemoteSelectionLayer";
 import { createRoomId, resolveRoomId } from "./room";
-import { type PersistenceDisplayState, StatusRail } from "./StatusRail";
+import {
+  mergeConnectionStates,
+  type PersistenceDisplayState,
+  StatusRail,
+} from "./StatusRail";
 import { toPresenceSelection, useLexicalRoom } from "./useLexicalRoom";
 
 export interface LexicalEgWalkerDemoProps {
@@ -132,7 +136,10 @@ export function LexicalEgWalkerDemo({
     >
       <StatusRail
         roomId={roomId}
-        connectionState={presence.connectionState}
+        connectionState={mergeConnectionStates(
+          presence.connectionState,
+          room.persistence?.syncConnectionState,
+        )}
         transportMode={presence.transportMode}
         persistenceState={persistenceState}
         pendingCount={room.persistence?.pendingBatchIds.length ?? 0}

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
@@ -124,6 +124,7 @@ export function LexicalEgWalkerDemo({
       className="flex min-h-[100svh] flex-col overflow-hidden bg-[#EEF3F7] text-[#17253D]"
       data-testid="lexical-eg-walker-demo"
       data-room-id={roomId}
+      data-transport={presence.transportMode}
       data-persistence-mode={room.persistence?.mode ?? "initializing"}
       data-persistence-durability={room.persistence?.durability ?? "loading"}
       data-persistence-leader={room.persistence?.leader.status ?? "stopped"}
@@ -132,6 +133,7 @@ export function LexicalEgWalkerDemo({
       <StatusRail
         roomId={roomId}
         connectionState={presence.connectionState}
+        transportMode={presence.transportMode}
         persistenceState={persistenceState}
         pendingCount={room.persistence?.pendingBatchIds.length ?? 0}
         storageBytes={room.persistence?.storageBytes ?? 0}
@@ -143,14 +145,18 @@ export function LexicalEgWalkerDemo({
         <div className="min-w-0">
           <div className="mb-1.5 flex items-center gap-2 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[#475BD8]">
             <GitFork className="size-3.5" />
-            Causal canvas · local first
+            Causal canvas ·{" "}
+            {presence.transportMode === "websocket"
+              ? "WebSocket"
+              : "local first"}
           </div>
           <h1 className="font-serif text-2xl leading-tight tracking-[-0.025em] md:text-3xl">
             EG-walker × Lexical
           </h1>
           <p className="mt-1 max-w-xl text-xs leading-relaxed text-[#67758B] md:text-sm">
-            One document, any number of tabs. Changes converge through stable
-            sequence anchors and remain on this device after every tab closes.
+            {presence.transportMode === "websocket"
+              ? "One document across browsers. Document events and presence sync over WebSocket; a local copy remains on this device."
+              : "One document, any number of tabs. Changes converge through stable sequence anchors and remain on this device after every tab closes. Add ?transport=websocket for cross-browser sync."}
           </p>
         </div>
         <a

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
@@ -9,14 +9,33 @@ import {
   Database,
   LoaderCircle,
   Radio,
+  WifiOff,
 } from "lucide-react";
 import type { ReactNode } from "react";
+import type { TransportConnectionState } from "./persistence/channel";
 
 export type PersistenceDisplayState =
   | "loading"
   | "pending"
   | "saved"
   | "unsaved";
+
+const CONNECTION_RANK = {
+  error: 0,
+  disconnected: 1,
+  reconnecting: 2,
+  connecting: 3,
+  connected: 4,
+} as const satisfies Record<AdapterConnectionState, number>;
+
+/** Prefer the more degraded of presence + document sync states. */
+export const mergeConnectionStates = (
+  presence: AdapterConnectionState,
+  sync: TransportConnectionState | null | undefined,
+): AdapterConnectionState => {
+  if (sync == null) return presence;
+  return CONNECTION_RANK[presence] <= CONNECTION_RANK[sync] ? presence : sync;
+};
 
 export interface StatusRailProps {
   readonly roomId: string;
@@ -62,10 +81,11 @@ const connectionLabel = (
         ? "WebSocket connected"
         : "Tabs connected";
     case "connecting":
+      return `Connecting via ${channel}…`;
     case "reconnecting":
-      return `Connecting via ${channel}`;
+      return `Reconnecting via ${channel}…`;
     case "error":
-      return `${channel} unavailable`;
+      return `${channel} unavailable — refresh to retry`;
     case "disconnected":
       return transportMode === "websocket"
         ? "WebSocket offline"
@@ -73,20 +93,45 @@ const connectionLabel = (
   }
 };
 
+const isDegradedConnection = (state: AdapterConnectionState): boolean =>
+  state === "disconnected" ||
+  state === "reconnecting" ||
+  state === "connecting" ||
+  state === "error";
+
 const StatusItem = ({
   icon,
   children,
+  tone = "default",
 }: {
   icon: ReactNode;
   children: ReactNode;
-}) => (
-  <span className="inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap">
-    <span aria-hidden className="text-[#475BD8]">
-      {icon}
+  tone?: "default" | "warn" | "danger";
+}) => {
+  const toneClass =
+    tone === "danger"
+      ? "text-[#B42318]"
+      : tone === "warn"
+        ? "text-[#B54708]"
+        : "text-[#526078]";
+  const iconClass =
+    tone === "danger"
+      ? "text-[#E45D6F]"
+      : tone === "warn"
+        ? "text-[#F79009]"
+        : "text-[#475BD8]";
+
+  return (
+    <span
+      className={`inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap ${toneClass}`}
+    >
+      <span aria-hidden className={iconClass}>
+        {icon}
+      </span>
+      <span className="truncate">{children}</span>
     </span>
-    <span className="truncate">{children}</span>
-  </span>
-);
+  );
+};
 
 export function StatusRail({
   roomId,
@@ -107,11 +152,32 @@ export function StatusRail({
       <LoaderCircle className="size-3.5 motion-safe:animate-spin" />
     );
 
+  const connectionTone =
+    connectionState === "error" || connectionState === "disconnected"
+      ? "danger"
+      : connectionState === "reconnecting" || connectionState === "connecting"
+        ? "warn"
+        : "default";
+
+  const connectionIcon =
+    connectionState === "error" || connectionState === "disconnected" ? (
+      <WifiOff className="size-3.5" />
+    ) : connectionState === "reconnecting" ||
+      connectionState === "connecting" ? (
+      <LoaderCircle className="size-3.5 motion-safe:animate-spin" />
+    ) : (
+      <Radio className="size-3.5" />
+    );
+
   return (
+    // biome-ignore lint/a11y/useSemanticElements: transport status live region; <output> is for form-calculated values.
     <div
       className="relative z-20 flex min-h-10 flex-wrap items-center gap-x-4 gap-y-2 border-b border-[#CBD6E2] bg-white/92 px-3 py-2 text-[11px] font-medium tracking-[0.02em] text-[#526078] backdrop-blur md:px-5"
       data-testid="collaboration-status"
       data-transport={transportMode}
+      data-connection-state={connectionState}
+      role="status"
+      aria-live="polite"
     >
       <span
         aria-hidden
@@ -127,9 +193,15 @@ export function StatusRail({
         <Copy className="size-3 opacity-50 transition-opacity group-hover:opacity-100" />
       </button>
 
-      <StatusItem icon={<Radio className="size-3.5" />}>
+      <StatusItem icon={connectionIcon} tone={connectionTone}>
         {connectionLabel(connectionState, transportMode)}
       </StatusItem>
+      {isDegradedConnection(connectionState) &&
+      transportMode === "websocket" ? (
+        <span className="rounded-md border border-[#FEDF89] bg-[#FFFAEB] px-2 py-0.5 text-[10px] font-semibold text-[#B54708]">
+          Sync paused until reconnect
+        </span>
+      ) : null}
       <StatusItem icon={persistenceIcon}>
         {persistenceLabel(persistenceState, pendingCount)}
       </StatusItem>

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
@@ -21,6 +21,7 @@ export type PersistenceDisplayState =
 export interface StatusRailProps {
   readonly roomId: string;
   readonly connectionState: AdapterConnectionState;
+  readonly transportMode?: "websocket" | "broadcast";
   readonly persistenceState: PersistenceDisplayState;
   readonly pendingCount: number;
   readonly storageBytes: number;
@@ -49,17 +50,26 @@ const persistenceLabel = (
   }
 };
 
-const connectionLabel = (state: AdapterConnectionState): string => {
+const connectionLabel = (
+  state: AdapterConnectionState,
+  transportMode: "websocket" | "broadcast" = "broadcast",
+): string => {
+  const channel =
+    transportMode === "websocket" ? "WebSocket" : "BroadcastChannel";
   switch (state) {
     case "connected":
-      return "Tabs connected";
+      return transportMode === "websocket"
+        ? "WebSocket connected"
+        : "Tabs connected";
     case "connecting":
     case "reconnecting":
-      return "Connecting tabs";
+      return `Connecting via ${channel}`;
     case "error":
-      return "Tab channel unavailable";
+      return `${channel} unavailable`;
     case "disconnected":
-      return "Working in this tab";
+      return transportMode === "websocket"
+        ? "WebSocket offline"
+        : "Working in this tab";
   }
 };
 
@@ -81,6 +91,7 @@ const StatusItem = ({
 export function StatusRail({
   roomId,
   connectionState,
+  transportMode = "broadcast",
   persistenceState,
   pendingCount,
   storageBytes,
@@ -100,6 +111,7 @@ export function StatusRail({
     <div
       className="relative z-20 flex min-h-10 flex-wrap items-center gap-x-4 gap-y-2 border-b border-[#CBD6E2] bg-white/92 px-3 py-2 text-[11px] font-medium tracking-[0.02em] text-[#526078] backdrop-blur md:px-5"
       data-testid="collaboration-status"
+      data-transport={transportMode}
     >
       <span
         aria-hidden
@@ -116,7 +128,7 @@ export function StatusRail({
       </button>
 
       <StatusItem icon={<Radio className="size-3.5" />}>
-        {connectionLabel(connectionState)}
+        {connectionLabel(connectionState, transportMode)}
       </StatusItem>
       <StatusItem icon={persistenceIcon}>
         {persistenceLabel(persistenceState, pendingCount)}

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
@@ -93,11 +93,8 @@ const connectionLabel = (
   }
 };
 
-const isDegradedConnection = (state: AdapterConnectionState): boolean =>
-  state === "disconnected" ||
-  state === "reconnecting" ||
-  state === "connecting" ||
-  state === "error";
+const isReconnectWarningState = (state: AdapterConnectionState): boolean =>
+  state === "disconnected" || state === "reconnecting" || state === "error";
 
 const StatusItem = ({
   icon,
@@ -196,7 +193,7 @@ export function StatusRail({
       <StatusItem icon={connectionIcon} tone={connectionTone}>
         {connectionLabel(connectionState, transportMode)}
       </StatusItem>
-      {isDegradedConnection(connectionState) &&
+      {isReconnectWarningState(connectionState) &&
       transportMode === "websocket" ? (
         <span className="rounded-md border border-[#FEDF89] bg-[#FFFAEB] px-2 py-0.5 text-[10px] font-semibold text-[#B54708]">
           Sync paused until reconnect

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/channel.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/channel.test.ts
@@ -34,6 +34,8 @@ class MockBroadcastNetwork {
 
 class MockBroadcastChannel implements BroadcastChannelLike {
   onmessage: BroadcastChannelLike["onmessage"] = null;
+  onopen: BroadcastChannelLike["onopen"] = null;
+  onconnectionchange: BroadcastChannelLike["onconnectionchange"] = null;
 
   constructor(
     readonly name: string,
@@ -211,5 +213,42 @@ describe("persistence BroadcastChannel protocol", () => {
 
     a.publishBatch(createBatch("batch-1", "hello"));
     expect(b.getKnownBatches()).toEqual([]);
+  });
+
+  it("requests repair when the transport fires onopen after reconnect", () => {
+    const network = new MockBroadcastNetwork();
+    let transport: MockBroadcastChannel | undefined;
+    const createChannel: BroadcastChannelFactory = (name) => {
+      const channel = network.createChannel(name) as MockBroadcastChannel;
+      transport = channel;
+      return channel;
+    };
+
+    const peer = createPersistenceChannel({
+      roomId: "room-a",
+      peerId: "a",
+      channelFactory: createChannel,
+      createId: () => "repair-reconnect",
+    });
+
+    const sent: unknown[] = [];
+    expect(transport).toBeDefined();
+    const originalPost = transport?.postMessage.bind(transport);
+    transport!.postMessage = (message: unknown) => {
+      sent.push(message);
+      originalPost(message);
+    };
+
+    transport?.onopen?.();
+
+    expect(sent).toContainEqual({
+      protocolVersion: PERSISTENCE_CHANNEL_PROTOCOL_VERSION,
+      type: PERSISTENCE_CHANNEL_MESSAGE_TYPE.RepairRequest,
+      roomId: "room-a",
+      senderId: "a",
+      requestId: "repair-reconnect",
+      knownBatchIds: [],
+    });
+    peer.close();
   });
 });

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/channel.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/channel.test.ts
@@ -233,13 +233,14 @@ describe("persistence BroadcastChannel protocol", () => {
 
     const sent: unknown[] = [];
     expect(transport).toBeDefined();
-    const originalPost = transport?.postMessage.bind(transport);
-    transport!.postMessage = (message: unknown) => {
+    if (transport === undefined) throw new Error("expected transport channel");
+    const originalPost = transport.postMessage.bind(transport);
+    transport.postMessage = (message: unknown) => {
       sent.push(message);
       originalPost(message);
     };
 
-    transport?.onopen?.();
+    transport.onopen?.();
 
     expect(sent).toContainEqual({
       protocolVersion: PERSISTENCE_CHANNEL_PROTOCOL_VERSION,

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/channel.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/channel.ts
@@ -65,10 +65,29 @@ export interface BroadcastMessageEvent {
   readonly data: unknown;
 }
 
+/** Transport lifecycle for WebSocket-backed channels (BroadcastChannel stays connected). */
+export type TransportConnectionState =
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected"
+  | "error";
+
+export type TransportConnectionListener = (
+  state: TransportConnectionState,
+) => void;
+
 export interface BroadcastChannelLike {
   onmessage: ((event: BroadcastMessageEvent) => void) | null;
   postMessage(message: unknown): void;
   close(): void;
+  /**
+   * Optional. Fired when the underlying transport is ready, including after
+   * reconnect. Persistence uses this to request repair.
+   */
+  onopen?: (() => void) | null;
+  /** Optional. Connection lifecycle for UI / diagnostics. */
+  onconnectionchange?: TransportConnectionListener | null;
 }
 
 export type BroadcastChannelFactory = (name: string) => BroadcastChannelLike;
@@ -81,8 +100,10 @@ export interface PersistenceChannel {
   getKnownBatches(): ReadonlyArray<WireBatch>;
   getKnownBatchIds(): ReadonlySet<string>;
   getDurableBatchIds(): ReadonlySet<string>;
+  getConnectionState(): TransportConnectionState;
   subscribeBatches(listener: BatchListener): () => void;
   subscribeDurableAcks(listener: DurableAckListener): () => void;
+  subscribeConnection(listener: TransportConnectionListener): () => void;
   subscribeErrors(listener: ChannelErrorListener): () => void;
   close(): void;
 }
@@ -112,6 +133,8 @@ const createNativeBroadcastChannel: BroadcastChannelFactory = (name) => {
     set onmessage(nextHandler) {
       handler = nextHandler;
     },
+    onopen: null,
+    onconnectionchange: null,
     postMessage: (message) => nativeChannel.postMessage(message),
     close: () => nativeChannel.close(),
   };
@@ -131,11 +154,19 @@ export const createPersistenceChannel = ({
   const durableBatchIds = new Set<string>();
   const batchListeners = new Set<BatchListener>();
   const durableAckListeners = new Set<DurableAckListener>();
+  const connectionListeners = new Set<TransportConnectionListener>();
   const errorListeners = new Set<ChannelErrorListener>();
   let closed = false;
+  let connectionState: TransportConnectionState = "connected";
 
   const notifyError = (error: Error): void => {
     for (const listener of errorListeners) listener(error);
+  };
+
+  const setConnectionState = (next: TransportConnectionState): void => {
+    if (connectionState === next) return;
+    connectionState = next;
+    for (const listener of connectionListeners) listener(next);
   };
 
   const acceptBatch = (
@@ -238,6 +269,31 @@ export const createPersistenceChannel = ({
     }
   };
 
+  const requestRepair = (): string => {
+    const requestId = createId();
+    postMessage({
+      protocolVersion: PERSISTENCE_CHANNEL_PROTOCOL_VERSION,
+      type: PERSISTENCE_CHANNEL_MESSAGE_TYPE.RepairRequest,
+      roomId,
+      senderId: peerId,
+      requestId,
+      knownBatchIds: [...knownBatches.keys()],
+    });
+    return requestId;
+  };
+
+  channel.onconnectionchange = (state) => {
+    if (closed) return;
+    setConnectionState(state);
+  };
+
+  channel.onopen = () => {
+    if (closed) return;
+    setConnectionState("connected");
+    // Catch up on anything missed while the transport was down.
+    requestRepair();
+  };
+
   return {
     publishBatch: (candidate) => {
       const batch = acceptBatch(candidate, "local");
@@ -254,18 +310,7 @@ export const createPersistenceChannel = ({
     seedBatches: (batches) => {
       for (const batch of batches) acceptBatch(batch, "storage");
     },
-    requestRepair: () => {
-      const requestId = createId();
-      postMessage({
-        protocolVersion: PERSISTENCE_CHANNEL_PROTOCOL_VERSION,
-        type: PERSISTENCE_CHANNEL_MESSAGE_TYPE.RepairRequest,
-        roomId,
-        senderId: peerId,
-        requestId,
-        knownBatchIds: [...knownBatches.keys()],
-      });
-      return requestId;
-    },
+    requestRepair,
     broadcastDurableAck: (batchIds) => {
       const newlyDurable = markDurable(batchIds);
       if (newlyDurable.length === 0) return;
@@ -280,6 +325,7 @@ export const createPersistenceChannel = ({
     getKnownBatches: () => [...knownBatches.values()],
     getKnownBatchIds: () => new Set(knownBatches.keys()),
     getDurableBatchIds: () => new Set(durableBatchIds),
+    getConnectionState: () => connectionState,
     subscribeBatches: (listener) => {
       batchListeners.add(listener);
       return () => batchListeners.delete(listener);
@@ -287,6 +333,11 @@ export const createPersistenceChannel = ({
     subscribeDurableAcks: (listener) => {
       durableAckListeners.add(listener);
       return () => durableAckListeners.delete(listener);
+    },
+    subscribeConnection: (listener) => {
+      connectionListeners.add(listener);
+      listener(connectionState);
+      return () => connectionListeners.delete(listener);
     },
     subscribeErrors: (listener) => {
       errorListeners.add(listener);
@@ -296,9 +347,12 @@ export const createPersistenceChannel = ({
       if (closed) return;
       closed = true;
       channel.onmessage = null;
+      channel.onopen = null;
+      channel.onconnectionchange = null;
       channel.close();
       batchListeners.clear();
       durableAckListeners.clear();
+      connectionListeners.clear();
       errorListeners.clear();
     },
   };

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator.test.ts
@@ -41,6 +41,8 @@ class MockBroadcastNetwork {
 
 class MockBroadcastChannel implements BroadcastChannelLike {
   onmessage: BroadcastChannelLike["onmessage"] = null;
+  onopen: BroadcastChannelLike["onopen"] = null;
+  onconnectionchange: BroadcastChannelLike["onconnectionchange"] = null;
 
   constructor(
     readonly name: string,

--- a/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/persistence/coordinator.ts
@@ -8,6 +8,7 @@ import {
   type BatchListener,
   type BroadcastChannelFactory,
   createPersistenceChannel,
+  type TransportConnectionState,
 } from "./channel";
 import {
   createLeaderElection,
@@ -66,6 +67,7 @@ export interface PersistenceCoordinatorSnapshot {
   readonly storageBytes: number;
   readonly failureReason: FailureReason;
   readonly errorMessage: string | null;
+  readonly syncConnectionState: TransportConnectionState;
 }
 
 export interface PersistenceCoordinator {
@@ -248,12 +250,18 @@ export const createPersistenceCoordinator = async (
     storageBytes,
     failureReason,
     errorMessage: lastErrorMessage,
+    syncConnectionState: channel.getConnectionState(),
   });
 
   const notifyState = (): void => {
     const snapshot = getSnapshot();
     for (const listener of stateListeners) listener(snapshot);
   };
+
+  const unsubscribeSyncConnection = channel.subscribeConnection(() => {
+    if (closed) return;
+    notifyState();
+  });
 
   const notifyError = (error: Error): void => {
     lastErrorMessage = error.message;
@@ -508,6 +516,7 @@ export const createPersistenceCoordinator = async (
       unsubscribeBatches();
       unsubscribeAcks();
       unsubscribeChannelErrors();
+      unsubscribeSyncConnection();
       sourceEventApi?.removeEventListener("storage", handleStorageEvent);
       await flushPromise;
       await election.stop();

--- a/apps/playground/src/modules/lexical-eg-walker/presence.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/presence.test.ts
@@ -18,6 +18,14 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+const useBroadcastTransport = (): void => {
+  vi.stubGlobal("location", {
+    ...window.location,
+    search: "?transport=broadcast",
+    origin: "http://localhost:3000",
+  });
+};
+
 describe("room presence", () => {
   it("derives a stable label and palette color from a tab id", () => {
     expect(createRoomIdentity("a-fixed-1234")).toEqual({
@@ -31,6 +39,7 @@ describe("room presence", () => {
   });
 
   it("uses an isolated presence channel for each room", () => {
+    useBroadcastTransport();
     const identity = createRoomIdentity("peer-a");
     const first = createRoomPresenceAdapter("room-a", identity);
     const second = createRoomPresenceAdapter("room-b", identity);
@@ -41,6 +50,7 @@ describe("room presence", () => {
   });
 
   it("does not expose users from the previous room during a room switch", async () => {
+    useBroadcastTransport();
     vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
     const renders: Array<{
       readonly roomId: string;

--- a/apps/playground/src/modules/lexical-eg-walker/presence.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/presence.ts
@@ -1,11 +1,14 @@
-import {
-  type AdapterConnectionState,
-  createBroadcastChannelAdapter,
-  type DirectionalSelectionRange,
-  type PresenceAdapter,
-  type PresenceUser,
+import type {
+  AdapterConnectionState,
+  DirectionalSelectionRange,
+  PresenceAdapter,
+  PresenceUser,
 } from "@softmaple/awareness";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type LexicalCollabTransportMode,
+  resolveLexicalRoomTransport,
+} from "./transport";
 
 const PRESENCE_COLORS = [
   "#475BD8",
@@ -22,18 +25,14 @@ export interface RoomIdentity {
 }
 
 export interface RoomPresence {
-  readonly adapter: PresenceAdapter;
+  readonly adapter: PresenceAdapter | null;
   readonly connectionState: AdapterConnectionState;
   readonly identity: RoomIdentity;
   readonly users: ReadonlyArray<PresenceUser>;
+  readonly transportMode: LexicalCollabTransportMode;
   readonly updateSelection: (
     selection: DirectionalSelectionRange | null,
   ) => void;
-}
-
-interface AdapterValue<T> {
-  readonly adapter: PresenceAdapter;
-  readonly value: T;
 }
 
 const randomId = (): string => crypto.randomUUID();
@@ -64,49 +63,73 @@ export const createRoomPresenceAdapter = (
   roomId: string,
   identity: RoomIdentity,
 ): PresenceAdapter =>
-  createBroadcastChannelAdapter({
-    roomId: `lexical-eg-walker:${roomId}`,
-    userInfo: identity,
-    heartbeatIntervalMs: 2_000,
-    offlineTimeoutMs: 7_000,
-    idleTimeoutMs: 30_000,
-  });
+  resolveLexicalRoomTransport(roomId).createPresenceAdapter(identity);
 
 export const useRoomPresence = (roomId: string): RoomPresence => {
   const [identity] = useState(createRoomIdentity);
-  const adapter = useMemo(
-    () => createRoomPresenceAdapter(roomId, identity),
-    [identity, roomId],
+  const transport = useMemo(
+    () => resolveLexicalRoomTransport(roomId),
+    [roomId],
   );
-  const [connectionStateState, setConnectionStateState] =
-    useState<AdapterValue<AdapterConnectionState> | null>(null);
-  const [usersState, setUsersState] = useState<AdapterValue<
-    ReadonlyArray<PresenceUser>
-  > | null>(null);
+  const sessionKey = roomId;
+  const [adapterState, setAdapterState] = useState<{
+    readonly sessionKey: string;
+    readonly adapter: PresenceAdapter;
+  } | null>(null);
+  const [connectionStateState, setConnectionStateState] = useState<{
+    readonly sessionKey: string;
+    readonly value: AdapterConnectionState;
+  } | null>(null);
+  const [usersState, setUsersState] = useState<{
+    readonly sessionKey: string;
+    readonly value: ReadonlyArray<PresenceUser>;
+  } | null>(null);
+  const adapterRef = useRef<PresenceAdapter | null>(null);
+
+  const adapter =
+    adapterState?.sessionKey === sessionKey ? adapterState.adapter : null;
   const connectionState =
-    connectionStateState?.adapter === adapter
+    connectionStateState?.sessionKey === sessionKey
       ? connectionStateState.value
       : "disconnected";
-  const users = usersState?.adapter === adapter ? usersState.value : [];
+  const users = usersState?.sessionKey === sessionKey ? usersState.value : [];
 
   useEffect(() => {
     let cancelled = false;
-    const unsubscribeConnection = adapter.onConnectionChange((value) => {
+    // Fresh adapter per effect instance avoids connect/disconnect races when
+    // React Strict Mode remounts and would otherwise close a shared socket.
+    const nextAdapter = transport.createPresenceAdapter(identity);
+    adapterRef.current = nextAdapter;
+
+    const unsubscribeConnection = nextAdapter.onConnectionChange((value) => {
       if (cancelled) return;
-      setConnectionStateState({ adapter, value });
+      setConnectionStateState({ sessionKey, value });
     });
-    const unsubscribePresence = adapter.onPresenceChange((presence) => {
+    const unsubscribePresence = nextAdapter.onPresenceChange((presence) => {
       if (cancelled) return;
-      setUsersState({ adapter, value: Array.from(presence.values()) });
+      setUsersState({
+        sessionKey,
+        value: Array.from(presence.values()),
+      });
     });
-    const unsubscribeError = adapter.onError(() => {
+    const unsubscribeError = nextAdapter.onError(() => {
       if (cancelled) return;
-      setConnectionStateState({ adapter, value: "error" });
+      setConnectionStateState({ sessionKey, value: "error" });
     });
 
-    void adapter.connect().catch(() => {
+    setAdapterState({ sessionKey, adapter: nextAdapter });
+    setConnectionStateState({
+      sessionKey,
+      value: nextAdapter.getConnectionState(),
+    });
+    setUsersState({
+      sessionKey,
+      value: Array.from(nextAdapter.getPresence().values()),
+    });
+
+    void nextAdapter.connect().catch(() => {
       if (cancelled) return;
-      setConnectionStateState({ adapter, value: "error" });
+      setConnectionStateState({ sessionKey, value: "error" });
     });
 
     return () => {
@@ -114,15 +137,20 @@ export const useRoomPresence = (roomId: string): RoomPresence => {
       unsubscribeError();
       unsubscribePresence();
       unsubscribeConnection();
-      void adapter.disconnect();
+      if (adapterRef.current === nextAdapter) {
+        adapterRef.current = null;
+      }
+      void nextAdapter.disconnect();
     };
-  }, [adapter]);
+  }, [identity, sessionKey, transport]);
 
   const updateSelection = useCallback(
     (selection: DirectionalSelectionRange | null) => {
-      adapter.updatePresence({ selection: selection ?? undefined });
+      adapterRef.current?.updatePresence({
+        selection: selection ?? undefined,
+      });
     },
-    [adapter],
+    [],
   );
 
   return {
@@ -130,6 +158,7 @@ export const useRoomPresence = (roomId: string): RoomPresence => {
     connectionState,
     identity,
     users,
+    transportMode: transport.mode,
     updateSelection,
   };
 };

--- a/apps/playground/src/modules/lexical-eg-walker/transport.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/transport.ts
@@ -16,7 +16,7 @@ import {
   type CollabEndpoints,
   resolveBrowserCollabEndpoints,
 } from "@/modules/collab-transport/urls";
-import { createWebSocketBroadcastChannelFactory } from "@/modules/collab-transport/websocket-broadcast-channel";
+import { createWebSocketBroadcastChannelFactory } from "@/modules/collab-transport/websocketBroadcastChannel";
 import type { BroadcastChannelFactory } from "@/modules/lexical-eg-walker/persistence/channel";
 import type { RoomIdentity } from "./presence";
 

--- a/apps/playground/src/modules/lexical-eg-walker/transport.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/transport.ts
@@ -1,0 +1,80 @@
+/**
+ * Transport selection for the Lexical EG-walker demo.
+ *
+ * Document sync and presence both default to same-origin WebSocket servers
+ * under `/api/collab-doc` and `/api/presence`. Pass `?transport=broadcast` to
+ * fall back to BroadcastChannel (same-origin tabs only).
+ */
+
+import {
+  createBroadcastChannelAdapter,
+  createWebSocketAdapter,
+  type PresenceAdapter,
+} from "@softmaple/awareness";
+import {
+  COLLAB_TRANSPORT,
+  type CollabEndpoints,
+  resolveBrowserCollabEndpoints,
+} from "@/modules/collab-transport/urls";
+import { createWebSocketBroadcastChannelFactory } from "@/modules/collab-transport/websocket-broadcast-channel";
+import type { BroadcastChannelFactory } from "@/modules/lexical-eg-walker/persistence/channel";
+import type { RoomIdentity } from "./presence";
+
+export type LexicalCollabTransportMode = CollabEndpoints["transport"];
+
+export interface LexicalRoomTransport {
+  readonly mode: LexicalCollabTransportMode;
+  readonly channelFactory: BroadcastChannelFactory | undefined;
+  readonly createPresenceAdapter: (identity: RoomIdentity) => PresenceAdapter;
+}
+
+const presenceRoomId = (roomId: string): string =>
+  `lexical-eg-walker:${roomId}`;
+
+export const resolveLexicalRoomTransport = (
+  roomId: string,
+  endpoints: CollabEndpoints = resolveBrowserCollabEndpoints({
+    envTransport: import.meta.env.VITE_COLLAB_TRANSPORT,
+    docWsUrl: import.meta.env.VITE_COLLAB_DOC_WS_URL,
+    presenceWsUrl: import.meta.env.VITE_COLLAB_PRESENCE_WS_URL,
+  }),
+): LexicalRoomTransport => {
+  if (
+    endpoints.transport === COLLAB_TRANSPORT.WebSocket &&
+    endpoints.docWsUrl !== null &&
+    endpoints.presenceWsUrl !== null
+  ) {
+    const docWsUrl = endpoints.docWsUrl;
+    const presenceWsUrl = endpoints.presenceWsUrl;
+    return {
+      mode: COLLAB_TRANSPORT.WebSocket,
+      channelFactory: createWebSocketBroadcastChannelFactory(docWsUrl, roomId),
+      createPresenceAdapter: (identity) =>
+        createWebSocketAdapter({
+          url: presenceWsUrl,
+          roomId: presenceRoomId(roomId),
+          userInfo: identity,
+          heartbeatIntervalMs: 2_000,
+          reconnect: {
+            enabled: true,
+            baseDelayMs: 500,
+            maxDelayMs: 8_000,
+            maxAttempts: 50,
+          },
+        }),
+    };
+  }
+
+  return {
+    mode: COLLAB_TRANSPORT.Broadcast,
+    channelFactory: undefined,
+    createPresenceAdapter: (identity) =>
+      createBroadcastChannelAdapter({
+        roomId: presenceRoomId(roomId),
+        userInfo: identity,
+        heartbeatIntervalMs: 2_000,
+        offlineTimeoutMs: 7_000,
+        idleTimeoutMs: 30_000,
+      }),
+  };
+};

--- a/apps/playground/src/modules/lexical-eg-walker/useLexicalRoom.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/useLexicalRoom.test.ts
@@ -24,6 +24,7 @@ const snapshot: PersistenceCoordinatorSnapshot = {
   storageBytes: 0,
   failureReason: null,
   errorMessage: null,
+  syncConnectionState: "connected",
 };
 
 const createCoordinator = (): PersistenceCoordinator => ({

--- a/apps/playground/src/modules/lexical-eg-walker/useLexicalRoom.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/useLexicalRoom.ts
@@ -8,17 +8,19 @@ import {
   parseRichTextEventBatch,
   type RichTextEventBatch,
 } from "@softmaple/block-model";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   createPersistenceCoordinator,
   type PersistenceCoordinator,
   type PersistenceCoordinatorSnapshot,
 } from "./persistence/coordinator";
 import { type WireBatch, WireBatchSchema } from "./persistence/schema";
+import { resolveLexicalRoomTransport } from "./transport";
 
 export interface LexicalRoomState {
   readonly replica: BlockReplica | null;
   readonly persistence: PersistenceCoordinatorSnapshot | null;
+  readonly transportMode: "websocket" | "broadcast";
   readonly error: Error | null;
   readonly onBindingChange: (binding: LexicalBinding | null) => void;
   readonly flush: () => Promise<void>;
@@ -49,6 +51,10 @@ export const useLexicalRoom = (
     useState<SessionValue<PersistenceCoordinatorSnapshot> | null>(null);
   const [errorState, setErrorState] = useState<SessionValue<Error> | null>(
     null,
+  );
+  const transport = useMemo(
+    () => resolveLexicalRoomTransport(roomId),
+    [roomId],
   );
   const bindingRef = useRef<SessionValue<LexicalBinding> | null>(null);
   const coordinatorRef = useRef<SessionValue<PersistenceCoordinator> | null>(
@@ -82,6 +88,7 @@ export const useLexicalRoom = (
         roomId,
         peerId,
         parseBatch: parsePersistenceBatch,
+        channelFactory: transport.channelFactory,
       });
       if (cancelled) {
         await coordinator.close();
@@ -169,7 +176,7 @@ export const useLexicalRoom = (
         void coordinator.flushPending().finally(() => coordinator?.close());
       }
     };
-  }, [peerId, roomId, sessionKey]);
+  }, [peerId, roomId, sessionKey, transport]);
 
   const flush = useCallback(async () => {
     const coordinatorState = coordinatorRef.current;
@@ -184,7 +191,14 @@ export const useLexicalRoom = (
     persistenceState?.sessionKey === sessionKey ? persistenceState.value : null;
   const error = errorState?.sessionKey === sessionKey ? errorState.value : null;
 
-  return { replica, persistence, error, onBindingChange, flush };
+  return {
+    replica,
+    persistence,
+    transportMode: transport.mode,
+    error,
+    onBindingChange,
+    flush,
+  };
 };
 
 export const toPresenceSelection = (

--- a/apps/playground/src/routes/demo/online-collab-editor.tsx
+++ b/apps/playground/src/routes/demo/online-collab-editor.tsx
@@ -47,6 +47,12 @@ function OnlineCollabEditor() {
   // No need for a callback here - useCollabEditor already handles text updates
   const { handleTextChange } = useTextChange(roomManager);
 
+  const writeRoomToUrl = useCallback((roomId: string) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("room", roomId);
+    window.history.replaceState(null, "", `${url.pathname}${url.search}`);
+  }, []);
+
   // Check URL params for room ID
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -62,15 +68,10 @@ function OnlineCollabEditor() {
       const roomId = await createRoom(roomName, userName);
       if (roomId) {
         setHasJoined(true);
-        // Update URL with room ID
-        window.history.replaceState(
-          null,
-          "",
-          `${window.location.pathname}?room=${roomId}`,
-        );
+        writeRoomToUrl(roomId);
       }
     },
-    [createRoom, roomName, userName],
+    [createRoom, roomName, userName, writeRoomToUrl],
   );
 
   const handleJoinRoom = useCallback(
@@ -79,22 +80,18 @@ function OnlineCollabEditor() {
       const success = await joinRoom(joinRoomId, userName);
       if (success) {
         setHasJoined(true);
-        // Update URL with room ID
-        window.history.replaceState(
-          null,
-          "",
-          `${window.location.pathname}?room=${joinRoomId}`,
-        );
+        writeRoomToUrl(joinRoomId);
       }
     },
-    [joinRoom, joinRoomId, userName],
+    [joinRoom, joinRoomId, userName, writeRoomToUrl],
   );
 
   const handleLeaveRoom = useCallback(async () => {
     await leaveRoom();
     setHasJoined(false);
-    // Clear URL params
-    window.history.replaceState(null, "", window.location.pathname);
+    const url = new URL(window.location.href);
+    url.searchParams.delete("room");
+    window.history.replaceState(null, "", `${url.pathname}${url.search}`);
   }, [leaveRoom]);
 
   const handleTextAreaChange = useCallback(

--- a/apps/playground/src/routes/demo/online-collab-editor.tsx
+++ b/apps/playground/src/routes/demo/online-collab-editor.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { CollabTextEditor } from "@/components/collab-editor/CollabTextEditor";
 import { JoinRoomForm } from "@/components/collab-editor/JoinRoomForm";
@@ -9,6 +9,7 @@ import { RoomHeader } from "@/components/collab-editor/RoomHeader";
 import { useCollabEditor } from "@/modules/collab-editor/hooks/use-collab-editor";
 import { useRecentRooms } from "@/modules/collab-editor/hooks/use-recent-rooms";
 import { useTextChange } from "@/modules/collab-editor/hooks/use-text-change";
+import { resolveBrowserCollabEndpoints } from "@/modules/collab-transport/urls";
 import "@/styles/guofeng.css";
 
 export const Route = createFileRoute("/demo/online-collab-editor")({
@@ -22,6 +23,14 @@ function OnlineCollabEditor() {
   const [hasJoined, setHasJoined] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const syncWsUrl = useMemo(() => {
+    const endpoints = resolveBrowserCollabEndpoints({
+      envTransport: import.meta.env.VITE_COLLAB_TRANSPORT,
+      syncWsUrl: import.meta.env.VITE_COLLAB_SYNC_WS_URL,
+    });
+    return endpoints.syncWsUrl ?? undefined;
+  }, []);
+
   const {
     roomManager,
     currentRoom,
@@ -32,7 +41,7 @@ function OnlineCollabEditor() {
     createRoom,
     joinRoom,
     leaveRoom,
-  } = useCollabEditor();
+  } = useCollabEditor(syncWsUrl);
 
   const { recentRooms, isLoadingRooms } = useRecentRooms();
   // No need for a callback here - useCollabEditor already handles text updates

--- a/apps/playground/src/routes/index.tsx
+++ b/apps/playground/src/routes/index.tsx
@@ -59,6 +59,13 @@ function App() {
       link: "/demo/awareness-collab",
     },
     {
+      icon: <Globe className="w-12 h-12 text-cyan-400" />,
+      title: "Lexical × EG-walker (WebSocket)",
+      description:
+        "Rich-text collaboration with Lexical, block-model CRDT, WebSocket document sync, and presence. Open the same room link in two browsers to verify.",
+      link: "/demo/lexical-eg-walker",
+    },
+    {
       icon: <Zap className="w-12 h-12 text-cyan-400" />,
       title: "Powerful Server Functions",
       description:

--- a/apps/playground/src/routes/index.tsx
+++ b/apps/playground/src/routes/index.tsx
@@ -4,127 +4,78 @@ import {
   CardHeader,
   CardTitle,
 } from "@softmaple/ui/components/card";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import {
+  FilePenLine,
   Globe,
-  Route as RouteIcon,
-  Server,
-  Shield,
+  Network,
   Sparkle,
-  Sparkles,
   SplitSquareHorizontal,
   Users,
-  Waves,
-  Zap,
 } from "lucide-react";
 
 export const Route = createFileRoute("/")({ component: App });
 
-interface Feature {
+interface DemoCard {
   readonly icon: React.ReactNode;
   readonly title: string;
   readonly description: string;
   readonly link: string;
-  readonly external?: boolean;
+  readonly badge?: string;
 }
 
-function App() {
-  const features: ReadonlyArray<Feature> = [
-    {
-      icon: <SplitSquareHorizontal className="w-12 h-12 text-cyan-400" />,
-      title: "Two-Panel Editor Demo",
-      description:
-        "Independent text editors side-by-side. Perfect for comparing, note-taking, or dual-language editing.",
-      link: "/demo/two-panel-editor",
-    },
-    {
-      icon: <Users className="w-12 h-12 text-cyan-400" />,
-      title: "Collaborative Editor",
-      description:
-        "Real-time collaborative text editing powered by Eg-Walker CRDT algorithm. Type in either editor to see instant synchronization.",
-      link: "/demo/collaborative-editor",
-    },
-    {
-      icon: <Globe className="w-12 h-12 text-cyan-400" />,
-      title: "Online Collaborative Editor",
-      description:
-        "Create or join rooms to collaborate with multiple users in real-time. Share room links for instant collaboration.",
-      link: "/demo/online-collab-editor",
-    },
-    {
-      icon: <Sparkle className="w-12 h-12 text-cyan-400" />,
-      title: "Awareness + Eg-Walker",
-      description:
-        "Pick a Pokémon trainer and collaborate with live cursors, selection highlights, and presence indicators powered by the @softmaple/awareness package.",
-      link: "/demo/awareness-collab",
-    },
-    {
-      icon: <Globe className="w-12 h-12 text-cyan-400" />,
-      title: "Lexical × EG-walker (WebSocket)",
-      description:
-        "Rich-text collaboration with Lexical, block-model CRDT, WebSocket document sync, and presence. Open the same room link in two browsers to verify.",
-      link: "/demo/lexical-eg-walker",
-    },
-    {
-      icon: <Zap className="w-12 h-12 text-cyan-400" />,
-      title: "Powerful Server Functions",
-      description:
-        "Write server-side code that seamlessly integrates with your client components. Type-safe, secure, and simple.",
-      link: "https://tanstack.com/start",
-      external: true,
-    },
-    {
-      icon: <Server className="w-12 h-12 text-cyan-400" />,
-      title: "Flexible Server Side Rendering",
-      description:
-        "Full-document SSR, streaming, and progressive enhancement out of the box. Control exactly what renders where.",
-      link: "https://tanstack.com/start",
-      external: true,
-    },
-    {
-      icon: <RouteIcon className="w-12 h-12 text-cyan-400" />,
-      title: "API Routes",
-      description:
-        "Build type-safe API endpoints alongside your application. No separate backend needed.",
-      link: "https://tanstack.com/start",
-      external: true,
-    },
-    {
-      icon: <Shield className="w-12 h-12 text-cyan-400" />,
-      title: "Strongly Typed Everything",
-      description:
-        "End-to-end type safety from server to client. Catch errors before they reach production.",
-      link: "https://tanstack.com/start",
-      external: true,
-    },
-    {
-      icon: <Waves className="w-12 h-12 text-cyan-400" />,
-      title: "Full Streaming Support",
-      description:
-        "Stream data from server to client progressively. Perfect for AI applications and real-time updates.",
-      link: "https://tanstack.com/start",
-      external: true,
-    },
-    {
-      icon: <Sparkles className="w-12 h-12 text-cyan-400" />,
-      title: "Next Generation Ready",
-      description:
-        "Built from the ground up for modern web applications. Deploy anywhere JavaScript runs.",
-      link: "https://tanstack.com/start",
-      external: true,
-    },
-  ];
+const demos: ReadonlyArray<DemoCard> = [
+  {
+    icon: <FilePenLine className="w-12 h-12 text-cyan-400" />,
+    title: "Lexical × EG-walker",
+    description:
+      "Rich-text collaboration with Lexical, block-model CRDT, WebSocket document sync, and live presence. Open the same room in two browsers to verify.",
+    link: "/demo/lexical-eg-walker",
+    badge: "WebSocket",
+  },
+  {
+    icon: <Globe className="w-12 h-12 text-cyan-400" />,
+    title: "Online Collaborative Editor",
+    description:
+      "Create or join rooms and sync plain-text editing over WebSocket. Share the room link to collaborate across browsers.",
+    link: "/demo/online-collab-editor",
+    badge: "WebSocket",
+  },
+  {
+    icon: <Sparkle className="w-12 h-12 text-cyan-400" />,
+    title: "Awareness + Eg-Walker",
+    description:
+      "Pick a Pokémon trainer and collaborate with live cursors, selection highlights, and presence indicators from @softmaple/awareness.",
+    link: "/demo/awareness-collab",
+  },
+  {
+    icon: <Users className="w-12 h-12 text-cyan-400" />,
+    title: "Collaborative Editor",
+    description:
+      "Side-by-side text editors powered by the Eg-Walker CRDT. Type in either panel to see instant local synchronization.",
+    link: "/demo/collaborative-editor",
+  },
+  {
+    icon: <SplitSquareHorizontal className="w-12 h-12 text-cyan-400" />,
+    title: "Two-Panel Editor Demo",
+    description:
+      "Independent text editors side-by-side. Useful for comparing drafts, note-taking, or dual-language editing.",
+    link: "/demo/two-panel-editor",
+  },
+];
 
+function App() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 via-slate-800 to-slate-900">
       <section className="relative py-20 px-6 text-center overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-r from-cyan-500/10 via-blue-500/10 to-purple-500/10"></div>
+        <div className="absolute inset-0 bg-gradient-to-r from-cyan-500/10 via-sky-500/10 to-blue-500/10" />
         <div className="relative max-w-5xl mx-auto">
           <div className="flex items-center justify-center gap-6 mb-6">
-            <div className="w-24 h-24 md:w-32 md:h-32 rounded-full bg-gradient-to-br from-cyan-400 to-blue-500 flex items-center justify-center">
-              <span className="text-white font-bold text-4xl md:text-5xl">
-                S
-              </span>
+            <div className="w-24 h-24 md:w-32 md:h-32 rounded-full bg-gradient-to-br from-cyan-400 to-blue-500 flex items-center justify-center shadow-lg shadow-cyan-500/30">
+              <Network
+                className="w-12 h-12 md:w-16 md:h-16 text-white"
+                aria-hidden
+              />
             </div>
             <h1 className="text-6xl md:text-7xl font-black text-white [letter-spacing:-0.08em]">
               <span className="text-gray-300">SOFTMAPLE</span>{" "}
@@ -134,59 +85,67 @@ function App() {
             </h1>
           </div>
           <p className="text-2xl md:text-3xl text-gray-300 mb-4 font-light">
-            Interactive demos and experimentation space
+            Try SoftMaple collaboration live
           </p>
           <p className="text-lg text-gray-400 max-w-3xl mx-auto mb-8">
-            Explore and test SoftMaple's features including collaborative
-            editing, CRDT algorithms, and real-time synchronization. Built with
-            TanStack Start.
+            Interactive demos for CRDT sync, rich-text editing, presence, and
+            WebSocket rooms — open a demo, share the room link, and collaborate.
           </p>
-          <div className="flex flex-col items-center gap-4">
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <Link
+              to="/demo/lexical-eg-walker"
+              className="px-8 py-3 bg-cyan-500 hover:bg-cyan-600 text-white font-semibold rounded-lg transition-colors shadow-lg shadow-cyan-500/50"
+            >
+              Open Lexical demo
+            </Link>
             <a
               href="https://docs.softmaple.ink"
               target="_blank"
               rel="noopener noreferrer"
-              className="px-8 py-3 bg-cyan-500 hover:bg-cyan-600 text-white font-semibold rounded-lg transition-colors shadow-lg shadow-cyan-500/50"
+              className="px-8 py-3 border border-slate-600 hover:border-cyan-500/60 text-gray-200 font-semibold rounded-lg transition-colors"
             >
               Documentation
             </a>
-            <p className="text-gray-400 text-sm mt-2">
-              Explore the demos below or start by editing{" "}
-              <code className="px-2 py-1 bg-slate-700 rounded text-cyan-400">
-                /src/routes/index.tsx
-              </code>
-            </p>
           </div>
         </div>
       </section>
 
       <section className="py-16 px-6 max-w-7xl mx-auto">
+        <div className="mb-10 max-w-2xl">
+          <h2 className="text-2xl font-semibold text-white mb-2">Demos</h2>
+          <p className="text-gray-400">
+            Start with Lexical × EG-walker for cross-browser rich-text sync, or
+            explore the other collaboration experiments below.
+          </p>
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {features.map((feature) => (
+          {demos.map((demo) => (
             <Card
-              key={feature.title}
+              key={demo.title}
               className="bg-slate-800/50 border-slate-700 hover:bg-slate-800/70 hover:border-cyan-500/50 transition-all duration-200 cursor-pointer group"
             >
-              <a
-                href={feature.link}
-                target={feature.external ? "_blank" : "_self"}
-                rel={feature.external ? "noopener noreferrer" : undefined}
-                className="block h-full"
-              >
+              <Link to={demo.link} className="block h-full">
                 <CardHeader>
-                  <div className="mb-4 group-hover:scale-110 transition-transform duration-200">
-                    {feature.icon}
+                  <div className="mb-4 flex items-start justify-between gap-3">
+                    <div className="group-hover:scale-110 transition-transform duration-200">
+                      {demo.icon}
+                    </div>
+                    {demo.badge ? (
+                      <span className="shrink-0 rounded-md border border-cyan-500/40 bg-cyan-500/10 px-2 py-0.5 text-xs font-medium text-cyan-300">
+                        {demo.badge}
+                      </span>
+                    ) : null}
                   </div>
                   <CardTitle className="text-white text-xl">
-                    {feature.title}
+                    {demo.title}
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <p className="text-gray-400 leading-relaxed">
-                    {feature.description}
+                    {demo.description}
                   </p>
                 </CardContent>
-              </a>
+              </Link>
             </Card>
           ))}
         </div>

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -13,7 +13,17 @@ const config = defineConfig(({ mode }) => ({
   },
   plugins: [
     // Only load dev tools and nitro in non-test mode to prevent hanging processes
-    ...(mode !== "test" ? [devtools(), nitro()] : []),
+    ...(mode !== "test"
+      ? [
+          devtools(),
+          nitro({
+            serverDir: "./server",
+            features: {
+              websocket: true,
+            },
+          }),
+        ]
+      : []),
     // this is the plugin that enables path aliases
     viteTsConfigPaths({
       projects: ["./tsconfig.json"],

--- a/docs/design/surface-bindings.md
+++ b/docs/design/surface-bindings.md
@@ -190,7 +190,7 @@ Update this page whenever any of the following change:
 |---|---|---|---|
 | `<textarea>` | sequence | `apps/playground/src/modules/collaborative-editor/` | in-app |
 | (future) CodeMirror | sequence | `apps/playground/src/surface-bindings/` | not yet started |
-| Lexical | block | `packages/binding-lexical/` | standalone v1 binding |
+| Lexical | block | `packages/binding-lexical/` + playground WebSocket demo | standalone v1 binding; WS sync in `/demo/lexical-eg-walker` |
 
 This table is illustrative and will drift. The authoritative source
 is the directory layout.

--- a/packages/awareness/src/adapters/message-edge-cases.test.ts
+++ b/packages/awareness/src/adapters/message-edge-cases.test.ts
@@ -691,7 +691,7 @@ describe("WebSocket adapter extra branches", () => {
     await expect(connectPromise).rejects.toThrow(/Connection timeout/);
   });
 
-  it("close event after open transitions to disconnected and schedules reconnect when enabled", async () => {
+  it("close event after open transitions to reconnecting when reconnect is enabled", async () => {
     const { createWebSocketAdapter } = await import("./websocket/websocket");
     const connection = vi.fn();
     const adapter = createWebSocketAdapter({
@@ -712,8 +712,8 @@ describe("WebSocket adapter extra branches", () => {
     await connectPromise;
 
     fakeSockets[0]?.emitClose();
-    expect(adapter.getConnectionState()).toBe("disconnected");
-    expect(connection).toHaveBeenCalledWith("disconnected");
+    expect(adapter.getConnectionState()).toBe("reconnecting");
+    expect(connection).toHaveBeenCalledWith("reconnecting");
   });
 
   it("emits errors when the underlying socket fires error", async () => {

--- a/packages/awareness/src/adapters/websocket/websocket.test.ts
+++ b/packages/awareness/src/adapters/websocket/websocket.test.ts
@@ -73,6 +73,11 @@ class FakeWebSocket {
     this.emit("open", new Event("open"));
   };
 
+  emitClose = (): void => {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit("close", new Event("close"));
+  };
+
   emitMessage = (data: string): void => {
     this.emit("message", new MessageEvent("message", { data }));
   };
@@ -519,6 +524,38 @@ describe("WebSocket adapter public API", () => {
     expect(typeof adapter.connect).toBe("function");
     expect(typeof adapter.disconnect).toBe("function");
     expect(adapter.getConnectionState()).toBe("disconnected");
+  });
+
+  it("publishes reconnecting after an unexpected close and recovers", async () => {
+    vi.useFakeTimers();
+    const adapter = createWebSocketAdapter({
+      ...baseConfig,
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 100,
+        maxDelayMs: 100,
+      },
+    });
+    const connection = vi.fn();
+    adapter.onConnectionChange(connection);
+
+    const connectPromise = adapter.connect();
+    fakeSockets[0]?.emitOpen();
+    await connectPromise;
+    expect(adapter.getConnectionState()).toBe("connected");
+
+    fakeSockets[0]?.emitClose();
+    expect(adapter.getConnectionState()).toBe("reconnecting");
+    expect(connection).toHaveBeenCalledWith("reconnecting");
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(fakeSockets.length).toBeGreaterThanOrEqual(2);
+    fakeSockets[1]?.emitOpen();
+    expect(adapter.getConnectionState()).toBe("connected");
+
+    await adapter.disconnect();
+    vi.useRealTimers();
   });
 });
 

--- a/packages/awareness/src/adapters/websocket/websocket.ts
+++ b/packages/awareness/src/adapters/websocket/websocket.ts
@@ -19,6 +19,7 @@ import type {
 } from "../types";
 import { DEFAULT_RECONNECT_CONFIG } from "../types";
 import {
+  cancelReconnect,
   cleanupWebSocket,
   clearConnectionTimeout,
   resetReconnectState,
@@ -218,10 +219,26 @@ export const createWebSocketAdapter = (
     }
   };
 
+  const beginReconnect = (): void => {
+    const { enabled, maxAttempts } = internal.reconnect.config;
+    if (enabled && internal.reconnect.attempts < maxAttempts) {
+      setState({ connectionState: "reconnecting" });
+      scheduleReconnect(internal, subscriptions, connectInternal);
+      return;
+    }
+    if (enabled) {
+      setState({ connectionState: "error" });
+      subscriptions.notifyError(
+        new Error(`Max reconnect attempts (${maxAttempts}) reached`),
+      );
+      return;
+    }
+    setState({ connectionState: "disconnected" });
+  };
+
   const handleClose = (): void => {
     stopHeartbeat(internal);
-    setState({ connectionState: "disconnected" });
-    scheduleReconnect(internal, subscriptions, connectInternal);
+    beginReconnect();
   };
 
   const handleError = (): void => {
@@ -237,7 +254,12 @@ export const createWebSocketAdapter = (
 
   const connectInternal = (): void => {
     cleanupWebSocket(internal, handlers);
-    setState({ connectionState: "connecting" });
+    setState({
+      connectionState:
+        internal.reconnect.isReconnecting || internal.reconnect.attempts > 0
+          ? "reconnecting"
+          : "connecting",
+    });
 
     // Build URL with roomId only (auth handled via message after connect)
     const wsUrl = buildUrl(config.url, config.roomId);
@@ -248,10 +270,13 @@ export const createWebSocketAdapter = (
     internal.socket.addEventListener("error", handleError);
 
     internal.connectionTimeoutId = setTimeout(() => {
-      if (internal.state.connectionState === "connecting") {
+      if (
+        internal.state.connectionState === "connecting" ||
+        internal.state.connectionState === "reconnecting"
+      ) {
         subscriptions.notifyError(new Error("Connection timeout"));
         cleanupWebSocket(internal, handlers);
-        scheduleReconnect(internal, subscriptions, connectInternal);
+        beginReconnect();
       }
     }, connectionTimeoutMs);
   };
@@ -290,11 +315,17 @@ export const createWebSocketAdapter = (
       }),
 
     disconnect: async (): Promise<void> => {
+      cancelReconnect(internal);
+
       if (
         internal.socket === null ||
         internal.socket.readyState === WebSocket.CLOSED
       ) {
-        setState({ connectionState: "disconnected" });
+        cleanupWebSocket(internal, handlers);
+        setState(
+          { connectionState: "disconnected", self: null, presence: new Map() },
+          true,
+        );
         return;
       }
 

--- a/packages/awareness/src/adapters/websocket/websocket.ts
+++ b/packages/awareness/src/adapters/websocket/websocket.ts
@@ -238,6 +238,7 @@ export const createWebSocketAdapter = (
 
   const handleClose = (): void => {
     stopHeartbeat(internal);
+    clearConnectionTimeout(internal);
     beginReconnect();
   };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds real WebSocket transport for Lexical + EG-walker collaboration (document batches + presence), with a playground demo you can verify across browsers.

## What changed

- **Nitro WebSocket servers** — `/api/collab-doc`, `/api/presence`, `/api/collab-sync`
- **Reconnect** — doc channel repairs on reopen; presence emits `reconnecting` / `error`; StatusRail shows offline UI
- **WS lifecycle** — `connectionTimeoutMs` for hung connecting sockets; close prior socket before `connect()` replaces it; camelCase modules under 200 lines
- **Homepage** — SoftMaple demo grid led by Lexical × EG-walker

## How to verify

```bash
pnpm --filter @softmaple/playground typecheck
pnpm --filter @softmaple/playground test
pnpm --filter @softmaple/awareness typecheck
pnpm --filter @softmaple/awareness test:coverage
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe8af37e-0b7d-4534-8c6b-6d0163ee4f5f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe8af37e-0b7d-4534-8c6b-6d0163ee4f5f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket collaboration for the Lexical EG-walker demo, with BroadcastChannel available for local, multi-tab collaboration.
  * Added room synchronization, presence, durable persistence, repair support, and automatic reconnection.
  * Added transport-aware status indicators and reconnect warnings.
  * Redesigned the playground homepage with collaboration demo cards and direct navigation.
* **Bug Fixes**
  * Improved room joining, leaving, URL handling, and connection lifecycle behavior.
* **Documentation**
  * Added local collaboration server setup and testing guidance.
* **Tests**
  * Expanded synchronization, persistence, navigation, and reconnection coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->