### PR TITLE
fix(apps/playground): opaque Lexical block-format dropdown over editor

### DIFF
--- a/apps/playground/e2e/lexical-block-format-dropdown.spec.ts
+++ b/apps/playground/e2e/lexical-block-format-dropdown.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Lexical block format dropdown", () => {
+  test("dropdown has opaque surface over the editor", async ({ page }) => {
+    await page.goto("/demo/lexical-eg-walker");
+    await page.locator('[data-testid="lexical-room-ready"]').waitFor();
+    await page.locator('[aria-label="Text block format"]').click();
+
+    const content = page.locator('[data-slot="select-content"]');
+    await expect(content).toBeVisible();
+
+    const backgroundColor = await content.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
+    // Must not be transparent — otherwise editor placeholder shows through.
+    expect(backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(backgroundColor).not.toBe("transparent");
+
+    await expect(
+      content.getByRole("option", { name: /Heading 1/i }),
+    ).toBeVisible();
+    await expect(page.getByText("Enter some rich text...")).toBeVisible();
+
+    // Hit-test the middle of the Heading 1 option — topmost element should
+    // belong to the select, not the editor placeholder.
+    const option = content.getByRole("option", { name: /Heading 1/i });
+    const box = await option.boundingBox();
+    expect(box).toBeTruthy();
+    if (!box) {
+      return;
+    }
+    const top = await page.evaluate(
+      ({ x, y }) => {
+        const el = document.elementFromPoint(x, y);
+        return {
+          slot: el?.closest("[data-slot]")?.getAttribute("data-slot") ?? null,
+          text: (el?.textContent ?? "").trim().slice(0, 40),
+        };
+      },
+      { x: box.x + box.width / 2, y: box.y + box.height / 2 },
+    );
+    expect(top.slot === "select-item" || top.slot === "select-content").toBe(
+      true,
+    );
+    expect(top.text).not.toContain("Enter some rich text");
+  });
+});

--- a/apps/playground/src/styles.css
+++ b/apps/playground/src/styles.css
@@ -2,6 +2,11 @@
 
 @import 'tw-animate-css';
 
+/* Scan workspace UI/editor sources so shadcn utilities (bg-popover, etc.)
+   used only inside those packages are generated for the playground. */
+@source '../../../packages/ui/src/**/*.{js,jsx,ts,tsx}';
+@source '../../../packages/editor/src/**/*.{js,jsx,ts,tsx}';
+
 @custom-variant dark (&:is(.dark *));
 
 body {

--- a/packages/editor/src/components/core/plugins/ToolbarPlugin/BlockFormatDropdown.tsx
+++ b/packages/editor/src/components/core/plugins/ToolbarPlugin/BlockFormatDropdown.tsx
@@ -29,7 +29,7 @@ import {
   formatQuote,
   formatCode,
 } from "@softmaple/editor/components/core/plugins/ToolbarPlugin/utils";
-import type { blockTypeToBlockName } from "@softmaple/editor/constants/toolbar";
+import { blockTypeToBlockName } from "@softmaple/editor/constants/toolbar";
 
 type BlockFormatType = {
   key: string;
@@ -155,22 +155,20 @@ export const BlockFormatDropdown: FC<BlockFormatDropdownProps> = (props) => {
           className="h-8 min-w-[130px] gap-1"
         >
           <Type className="size-4 md:size-4.5" />
-          <SelectValue placeholder="Format" />
+          <SelectValue placeholder="Format">
+            {ITEMS.find((item) => item.value === blockType)?.label ??
+              blockTypeToBlockName[blockType]}
+          </SelectValue>
         </SelectTrigger>
         <SelectContent>
           {ITEMS.map(({ key, value, label, shortcut, icon }) => (
-            <div
-              key={key}
-              className="flex gap-1 md:gap-2 items-center justify-between"
-            >
+            <SelectItem key={key} value={value}>
               <span className="text-muted-foreground">{icon}</span>
-              <SelectItem key={key} value={value}>
-                <span>{label}</span>
-              </SelectItem>
-              <span className="text-sm text-muted-foreground hidden md:inline">
+              <span>{label}</span>
+              <span className="text-muted-foreground ml-auto hidden text-xs md:inline">
                 {shortcut}
               </span>
-            </div>
+            </SelectItem>
           ))}
         </SelectContent>
       </Select>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the Lexical EG-walker block-format Select is open over the contenteditable, editor placeholder text showed through the menu and item icons looked misaligned.

### Root cause
Playground Tailwind only scanned its own app sources. Classes used solely in `@softmaple/ui` / `@softmaple/editor` (notably `bg-popover`) were never generated, so `SelectContent` painted with a **transparent** background over the editor.

### Fix
1. Add `@source` for `packages/ui` and `packages/editor` in `apps/playground/src/styles.css`
2. Put BlockFormatDropdown icons/shortcuts **inside** `SelectItem` (Radix expects item content as children, not sibling wrappers)
3. Add an e2e that asserts opaque select surface + hit-testing over the placeholder

### Validation
- `PLAYGROUND_PORT=3001 pnpm exec playwright test e2e/lexical-block-format-dropdown.spec.ts` — passed

### Test plan
- [x] Dropdown e2e (opaque bg + stacking)
- [ ] Manual: open `/demo/lexical-eg-walker`, open Paragraph select — menu should fully cover editor placeholder; icons aligned in each row

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c58db5a8-64b6-4af9-a1e0-b12e2839d328?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c58db5a8-64b6-4af9-a1e0-b12e2839d328&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

