### PR TITLE
feat(playground): collaboration lab UI for Lexical demo & homepage

### DIFF
--- a/apps/playground/e2e/helpers/lexical-eg-walker.ts
+++ b/apps/playground/e2e/helpers/lexical-eg-walker.ts
@@ -37,7 +37,7 @@ export const openRoom = async (
   await expect(demo).toHaveAttribute("data-transport", transport);
   await expect(status).toHaveAttribute("data-transport", transport);
   await expect(demo).toHaveAttribute("data-persistence-mode", "persistent");
-  await expect(status).not.toContainText("Unsaved · memory only");
+  await expect(status).not.toContainText("Changes are only stored in memory");
   await expect(page.getByRole("button", { name: "Undo" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Redo" })).toHaveCount(0);
 

--- a/apps/playground/e2e/home.spec.ts
+++ b/apps/playground/e2e/home.spec.ts
@@ -6,14 +6,16 @@ test.describe("Home Page", () => {
 
     await expect(page).toHaveTitle(/SoftMaple Playground/);
     await expect(
-      page.getByRole("heading", { name: /SOFTMAPLE PLAYGROUND/i }),
+      page.getByRole("heading", { name: /^SoftMaple$/i }),
     ).toBeVisible();
+    await expect(page.getByTestId("home-sync-preview")).toBeVisible();
   });
 
   test("should display SoftMaple demo cards", async ({ page }) => {
     await page.goto("/");
 
     await expect(page.getByRole("heading", { name: "Demos" })).toBeVisible();
+    await expect(page.getByTestId("featured-demo-card")).toBeVisible();
     await expect(
       page.getByRole("link", { name: /Lexical × EG-walker/i }),
     ).toBeVisible();
@@ -36,7 +38,7 @@ test.describe("Home Page", () => {
   test("should navigate to Lexical EG-walker demo", async ({ page }) => {
     await page.goto("/");
 
-    await page.getByRole("link", { name: /Open Lexical demo/i }).click();
+    await page.getByRole("link", { name: /Open playground/i }).click();
     await expect(page).toHaveURL(/\/demo\/lexical-eg-walker/);
   });
 

--- a/apps/playground/e2e/lexical-eg-walker-broadcast.spec.ts
+++ b/apps/playground/e2e/lexical-eg-walker-broadcast.spec.ts
@@ -16,7 +16,7 @@ test.describe("Lexical EG-walker BroadcastChannel transport", () => {
     const first = await openRoom(page, roomId, "broadcast");
     const second = await openSecondTab(context, roomId, "broadcast");
 
-    await expect(first.status).toContainText("Tabs connected");
+    await expect(first.status).toContainText("Synced");
     await appendText(first, "Broadcast only");
     await expectDocument(second, "Broadcast only");
   });

--- a/apps/playground/e2e/lexical-eg-walker-websocket.spec.ts
+++ b/apps/playground/e2e/lexical-eg-walker-websocket.spec.ts
@@ -20,8 +20,8 @@ test.describe("Lexical EG-walker WebSocket cross-browser", () => {
       const first = await openRoom(pageA, roomId, "websocket");
       const second = await openRoom(pageB, roomId, "websocket");
 
-      await expect(first.status).toContainText("WebSocket connected");
-      await expect(second.status).toContainText("WebSocket connected");
+      await expect(first.status).toContainText("Synced");
+      await expect(second.status).toContainText("Synced");
 
       await appendText(first, "Hello across browsers");
       await expectDocument(second, "Hello across browsers");

--- a/apps/playground/src/components/home/DemoList.tsx
+++ b/apps/playground/src/components/home/DemoList.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowUpRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
-import { demos } from "@/lib/demos";
+import { experimentDemos, featuredDemo } from "@/lib/demos";
 
 const spring = { type: "spring" as const, stiffness: 320, damping: 30 };
 
@@ -9,67 +9,123 @@ export function DemoList() {
   const reduceMotion = useReducedMotion();
 
   return (
-    <section id="demos" className="mx-auto max-w-6xl px-6 py-20 md:py-28">
-      <div className="mb-12 max-w-2xl">
+    <section id="demos" className="mx-auto max-w-6xl px-6 py-16 md:py-24">
+      <div className="mb-10 max-w-2xl">
         <h2 className="font-[family-name:var(--font-display)] text-3xl font-bold tracking-[-0.03em] text-[var(--pg-ink)] md:text-4xl">
           Demos
         </h2>
         <p className="mt-3 text-base text-[var(--pg-ink-muted)] md:text-lg">
-          Start with Lexical × EG-walker for cross-browser rich-text sync, or
-          explore the other collaboration experiments below.
+          Lexical × EG-walker is the mainline collaboration lab. Everything else
+          is a supporting experiment.
         </p>
       </div>
 
-      <ul className="divide-y divide-[var(--pg-line)] border-y border-[var(--pg-line)]">
-        {demos.map((demo, index) => (
-          <motion.li
-            key={demo.id}
-            initial={reduceMotion ? false : { opacity: 0, y: 16 }}
-            whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-40px" }}
-            transition={{ ...spring, delay: index * 0.04 }}
-          >
-            <Link
-              to={demo.link}
-              className="group relative flex flex-col gap-4 py-7 transition-colors md:flex-row md:items-start md:gap-8 md:py-9"
-            >
-              <span className="absolute inset-x-[-1rem] inset-y-0 -z-10 rounded-sm bg-[var(--pg-surface)] opacity-0 transition-opacity duration-200 group-hover:opacity-100 md:inset-x-[-1.5rem]" />
-
-              <span className="font-[family-name:var(--font-mono)] text-sm text-[var(--pg-ink-muted)] tabular-nums">
-                {demo.id}
-              </span>
-
-              <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-3">
-                  <span
-                    className="h-2 w-2 shrink-0 rounded-[1px]"
-                    style={{ backgroundColor: demo.accent }}
-                    aria-hidden
-                  />
-                  <h3 className="font-[family-name:var(--font-display)] text-xl font-semibold tracking-[-0.02em] text-[var(--pg-ink)] md:text-2xl">
-                    {demo.title}
-                  </h3>
-                  {demo.badge ? (
-                    <span className="font-[family-name:var(--font-mono)] text-[10px] tracking-wider text-[var(--pg-ink-muted)] uppercase">
-                      {demo.badge}
-                    </span>
-                  ) : null}
-                </div>
-                <p className="mt-2 max-w-2xl text-sm leading-relaxed text-[var(--pg-ink-muted)] md:text-base">
-                  {demo.description}
-                </p>
+      <motion.div
+        initial={reduceMotion ? false : { opacity: 0, y: 16 }}
+        whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-40px" }}
+        transition={spring}
+        className="mb-14"
+      >
+        <p className="mb-3 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.18em] text-[var(--pg-accent)] uppercase">
+          Featured
+        </p>
+        <Link
+          to={featuredDemo.link}
+          className="group relative block border border-[var(--pg-line)] bg-[var(--pg-surface)] p-6 transition-colors hover:border-[var(--pg-ink)] md:p-8"
+          data-testid="featured-demo-card"
+        >
+          <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+            <div className="min-w-0 max-w-2xl">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className="h-2 w-2 shrink-0"
+                  style={{ backgroundColor: featuredDemo.accent }}
+                  aria-hidden
+                />
+                {featuredDemo.badge ? (
+                  <span className="font-[family-name:var(--font-mono)] text-[10px] tracking-wider text-[var(--pg-accent)] uppercase">
+                    {featuredDemo.badge}
+                  </span>
+                ) : null}
               </div>
+              <h3 className="mt-3 font-[family-name:var(--font-display)] text-2xl font-semibold tracking-[-0.02em] text-[var(--pg-ink)] md:text-3xl">
+                {featuredDemo.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[var(--pg-ink-muted)] md:text-base">
+                {featuredDemo.description}
+              </p>
+              {featuredDemo.tags ? (
+                <ul className="mt-4 flex flex-wrap gap-x-4 gap-y-1 font-[family-name:var(--font-mono)] text-[11px] text-[var(--pg-ink-muted)]">
+                  {featuredDemo.tags.map((tag) => (
+                    <li key={tag}>{tag}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+            <span className="inline-flex items-center gap-2 bg-[var(--pg-ink)] px-5 py-3 text-sm font-semibold text-[var(--pg-paper)] transition-transform group-hover:-translate-y-0.5">
+              Open room
+              <ArrowUpRight size={16} aria-hidden />
+            </span>
+          </div>
+        </Link>
+      </motion.div>
 
-              <span
-                className="inline-flex h-10 w-10 shrink-0 items-center justify-center border border-[var(--pg-line)] text-[var(--pg-ink)] transition-all duration-200 group-hover:border-[var(--pg-ink)] group-hover:bg-[var(--pg-ink)] group-hover:text-[var(--pg-paper)] group-hover:scale-105"
-                aria-hidden
+      <div>
+        <p className="mb-3 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.18em] text-[var(--pg-ink-muted)] uppercase">
+          Experiments
+        </p>
+        <ul className="divide-y divide-[var(--pg-line)] border-y border-[var(--pg-line)]">
+          {experimentDemos.map((demo, index) => (
+            <motion.li
+              key={demo.id}
+              initial={reduceMotion ? false : { opacity: 0, y: 12 }}
+              whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-40px" }}
+              transition={{ ...spring, delay: index * 0.04 }}
+            >
+              <Link
+                to={demo.link}
+                className="group relative flex flex-col gap-3 py-5 transition-colors md:flex-row md:items-start md:gap-8 md:py-6"
               >
-                <ArrowUpRight size={18} />
-              </span>
-            </Link>
-          </motion.li>
-        ))}
-      </ul>
+                <span className="absolute inset-x-[-1rem] inset-y-0 -z-10 bg-[var(--pg-surface)] opacity-0 transition-opacity duration-200 group-hover:opacity-100 md:inset-x-[-1.5rem]" />
+
+                <span className="font-[family-name:var(--font-mono)] text-sm text-[var(--pg-ink-muted)] tabular-nums">
+                  {demo.id}
+                </span>
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span
+                      className="h-2 w-2 shrink-0"
+                      style={{ backgroundColor: demo.accent }}
+                      aria-hidden
+                    />
+                    <h3 className="font-[family-name:var(--font-display)] text-lg font-semibold tracking-[-0.02em] text-[var(--pg-ink)] md:text-xl">
+                      {demo.title}
+                    </h3>
+                    {demo.badge ? (
+                      <span className="font-[family-name:var(--font-mono)] text-[10px] tracking-wider text-[var(--pg-ink-muted)] uppercase">
+                        {demo.badge}
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-[var(--pg-ink-muted)]">
+                    {demo.description}
+                  </p>
+                </div>
+
+                <span
+                  className="inline-flex h-9 w-9 shrink-0 items-center justify-center border border-[var(--pg-line)] text-[var(--pg-ink)] transition-all duration-200 group-hover:border-[var(--pg-ink)] group-hover:bg-[var(--pg-ink)] group-hover:text-[var(--pg-paper)]"
+                  aria-hidden
+                >
+                  <ArrowUpRight size={16} />
+                </span>
+              </Link>
+            </motion.li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/apps/playground/src/components/home/HomeHero.tsx
+++ b/apps/playground/src/components/home/HomeHero.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useState } from "react";
 import { SyncField } from "@/components/home/SyncField";
+import { SyncPreview } from "@/components/home/SyncPreview";
 
 const spring = { type: "spring" as const, stiffness: 280, damping: 28 };
 
@@ -18,58 +19,54 @@ export function HomeHero() {
     !ready || reduceMotion
       ? {}
       : {
-          initial: { opacity: 0, y: 28 },
+          initial: { opacity: 0, y: 22 },
           animate: { opacity: 1, y: 0 },
           transition: { ...spring, delay },
         };
 
   return (
-    <section className="relative min-h-[min(92vh,920px)] overflow-hidden border-b border-[var(--pg-line)]">
+    <section className="relative min-h-[min(68vh,720px)] overflow-hidden border-b border-[var(--pg-line)]">
       <SyncField />
 
-      <div className="relative z-10 mx-auto flex min-h-[min(92vh,920px)] max-w-6xl flex-col justify-end px-6 pb-16 pt-16 md:pb-24 md:pt-20">
-        <motion.p
-          className="mb-5 font-[family-name:var(--font-mono)] text-xs tracking-[0.22em] text-[var(--pg-ink-muted)] uppercase"
-          {...reveal(0)}
-        >
-          SoftMaple Labs
-        </motion.p>
-
-        <motion.h1
-          className="max-w-4xl font-[family-name:var(--font-display)] text-[clamp(3.25rem,12vw,7.5rem)] leading-[0.92] font-bold tracking-[-0.04em] text-[var(--pg-ink)]"
-          {...reveal(0.06)}
-        >
-          SoftMaple
-          <br />
-          <span className="text-[var(--pg-accent)]">Playground</span>
-        </motion.h1>
-
-        <motion.p
-          className="mt-6 max-w-xl text-lg text-[var(--pg-ink-muted)] md:text-xl"
-          {...reveal(0.12)}
-        >
-          Live CRDT demos — open a room, share the link, and watch edits sync
-          across browsers.
-        </motion.p>
-
-        <motion.div
-          className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center"
-          {...reveal(0.18)}
-        >
-          <Link
-            to="/demo/lexical-eg-walker"
-            className="inline-flex items-center justify-center bg-[var(--pg-ink)] px-7 py-3.5 text-sm font-semibold text-[var(--pg-paper)] transition-transform hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
+      <div className="relative z-10 mx-auto flex min-h-[min(68vh,720px)] max-w-6xl flex-col justify-end gap-10 px-6 pb-12 pt-16 md:flex-row md:items-end md:justify-between md:pb-16 md:pt-20">
+        <div className="max-w-xl">
+          <motion.h1
+            className="font-[family-name:var(--font-display)] text-[clamp(2.75rem,9vw,5.5rem)] leading-[0.94] font-bold tracking-[-0.04em] text-[var(--pg-ink)]"
+            {...reveal(0)}
           >
-            Open Lexical demo
-          </Link>
-          <a
-            href="https://docs.softmaple.ink"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center border border-[var(--pg-ink)]/20 bg-transparent px-7 py-3.5 text-sm font-semibold text-[var(--pg-ink)] transition-colors hover:border-[var(--pg-ink)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
+            SoftMaple
+          </motion.h1>
+
+          <motion.p
+            className="mt-4 max-w-md text-base text-[var(--pg-ink-muted)] md:text-lg"
+            {...reveal(0.06)}
           >
-            Documentation
-          </a>
+            Local-first collaboration primitives.
+          </motion.p>
+
+          <motion.div
+            className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center"
+            {...reveal(0.12)}
+          >
+            <Link
+              to="/demo/lexical-eg-walker"
+              className="inline-flex items-center justify-center bg-[var(--pg-ink)] px-7 py-3.5 text-sm font-semibold text-[var(--pg-paper)] transition-transform hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
+            >
+              Open playground
+            </Link>
+            <a
+              href="https://github.com/softmaple/softmaple"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center border border-[var(--pg-ink)]/20 bg-transparent px-7 py-3.5 text-sm font-semibold text-[var(--pg-ink)] transition-colors hover:border-[var(--pg-ink)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
+            >
+              GitHub
+            </a>
+          </motion.div>
+        </div>
+
+        <motion.div className="w-full md:max-w-xl" {...reveal(0.16)}>
+          <SyncPreview />
         </motion.div>
       </div>
     </section>

--- a/apps/playground/src/components/home/SyncPreview.tsx
+++ b/apps/playground/src/components/home/SyncPreview.tsx
@@ -1,0 +1,131 @@
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
+
+const DEMO_TEXT = "Hello collab";
+const STEP_MS = 90;
+const HOLD_MS = 1_600;
+const RESET_MS = 900;
+
+/**
+ * Lightweight dual-pane sync preview for the homepage hero.
+ * Animates typing on the left and mirrored appearance on the right.
+ */
+export function SyncPreview() {
+  const reduceMotion = useReducedMotion();
+  const [chars, setChars] = useState(reduceMotion ? DEMO_TEXT.length : 0);
+  const [phase, setPhase] = useState<"typing" | "hold" | "reset">(
+    reduceMotion ? "hold" : "typing",
+  );
+
+  useEffect(() => {
+    if (reduceMotion) {
+      setChars(DEMO_TEXT.length);
+      setPhase("hold");
+      return;
+    }
+
+    if (phase === "typing") {
+      if (chars >= DEMO_TEXT.length) {
+        const timer = window.setTimeout(() => setPhase("hold"), HOLD_MS);
+        return () => window.clearTimeout(timer);
+      }
+      const timer = window.setTimeout(() => setChars((n) => n + 1), STEP_MS);
+      return () => window.clearTimeout(timer);
+    }
+
+    if (phase === "hold") {
+      const timer = window.setTimeout(() => setPhase("reset"), HOLD_MS);
+      return () => window.clearTimeout(timer);
+    }
+
+    const timer = window.setTimeout(() => {
+      setChars(0);
+      setPhase("typing");
+    }, RESET_MS);
+    return () => window.clearTimeout(timer);
+  }, [chars, phase, reduceMotion]);
+
+  const visible = DEMO_TEXT.slice(0, chars);
+  const showCaret = phase === "typing";
+
+  return (
+    <div
+      className="w-full max-w-xl"
+      data-testid="home-sync-preview"
+      aria-hidden
+    >
+      <div className="grid gap-3 sm:grid-cols-[1fr_auto_1fr] sm:items-stretch sm:gap-2">
+        <PreviewPane
+          name="Adam"
+          accent="#0D9488"
+          text={visible}
+          caret={showCaret}
+        />
+        <motion.div
+          className="hidden items-center justify-center px-1 font-[family-name:var(--font-mono)] text-lg text-[var(--pg-accent)] sm:flex"
+          animate={
+            reduceMotion
+              ? undefined
+              : { opacity: [0.35, 1, 0.35], x: [0, 2, 0] }
+          }
+          transition={{
+            duration: 1.6,
+            repeat: Number.POSITIVE_INFINITY,
+            ease: "easeInOut",
+          }}
+        >
+          →
+        </motion.div>
+        <PreviewPane
+          name="Peer 2"
+          accent="#EA580C"
+          text={visible}
+          caret={false}
+          dimmed={chars === 0}
+        />
+      </div>
+      <p className="mt-3 text-center font-[family-name:var(--font-mono)] text-[10px] tracking-[0.16em] text-[var(--pg-ink-muted)] uppercase">
+        EG-walker · Lexical · WebSocket
+      </p>
+    </div>
+  );
+}
+
+function PreviewPane({
+  name,
+  accent,
+  text,
+  caret,
+  dimmed = false,
+}: {
+  name: string;
+  accent: string;
+  text: string;
+  caret: boolean;
+  dimmed?: boolean;
+}) {
+  return (
+    <div
+      className={`border border-[var(--pg-line)] bg-[var(--pg-surface)]/90 text-left shadow-sm backdrop-blur-sm transition-opacity ${
+        dimmed ? "opacity-55" : "opacity-100"
+      }`}
+    >
+      <div className="flex items-center gap-2 border-b border-[var(--pg-line)] px-3 py-1.5">
+        <span
+          className="size-2 shrink-0"
+          style={{ backgroundColor: accent }}
+          aria-hidden
+        />
+        <span className="font-[family-name:var(--font-mono)] text-[10px] tracking-wider text-[var(--pg-ink-muted)] uppercase">
+          {name}
+        </span>
+      </div>
+      <div className="min-h-[4.5rem] px-3 py-3 font-[family-name:var(--font-mono)] text-sm text-[var(--pg-ink)]">
+        {text}
+        {caret ? (
+          <span className="ml-px inline-block h-4 w-px translate-y-0.5 bg-[var(--pg-ink)] motion-safe:animate-pulse" />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/lib/demos.ts
+++ b/apps/playground/src/lib/demos.ts
@@ -7,18 +7,23 @@ export interface DemoItem {
   readonly link: FileRouteTypes["to"];
   readonly badge?: string;
   readonly accent: string;
+  readonly tags?: ReadonlyArray<string>;
+  readonly featured?: boolean;
 }
 
-export const demos: ReadonlyArray<DemoItem> = [
-  {
-    id: "01",
-    title: "Lexical × EG-walker",
-    description:
-      "Rich-text collaboration with Lexical, block-model CRDT, WebSocket document sync, and live presence. Open the same room in two browsers to verify.",
-    link: "/demo/lexical-eg-walker",
-    badge: "WebSocket",
-    accent: "#0D9488",
-  },
+export const featuredDemo: DemoItem = {
+  id: "01",
+  title: "Lexical × EG-walker",
+  description:
+    "Rich-text collaboration with Lexical, block-model CRDT, WebSocket document sync, and live presence. Open the same room in two browsers to verify.",
+  link: "/demo/lexical-eg-walker",
+  badge: "Recommended",
+  accent: "#0D9488",
+  tags: ["Cross-browser", "WebSocket", "Rich text"],
+  featured: true,
+};
+
+export const experimentDemos: ReadonlyArray<DemoItem> = [
   {
     id: "02",
     title: "Online Collaborative Editor",
@@ -52,4 +57,10 @@ export const demos: ReadonlyArray<DemoItem> = [
     link: "/demo/two-panel-editor",
     accent: "#7C3AED",
   },
+];
+
+/** Flat list for nav / legacy consumers. */
+export const demos: ReadonlyArray<DemoItem> = [
+  featuredDemo,
+  ...experimentDemos,
 ];

--- a/apps/playground/src/modules/lexical-eg-walker/CollaborationLab.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/CollaborationLab.tsx
@@ -1,0 +1,156 @@
+import type { AdapterConnectionState } from "@softmaple/awareness";
+import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import { toast } from "sonner";
+import { copyText } from "./roomLink";
+import {
+  connectionDetailLabel,
+  formatStorageSize,
+  type PersistenceDisplayState,
+} from "./syncStatus";
+
+export interface CollaborationLabProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly roomId: string;
+  readonly replicaId: string;
+  readonly connectionState: AdapterConnectionState;
+  readonly transportMode: "websocket" | "broadcast";
+  readonly persistenceState: PersistenceDisplayState;
+  readonly pendingCount: number;
+  readonly durableBatchCount: number;
+  readonly storageBytes: number;
+}
+
+const LabRow = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-baseline justify-between gap-3 py-1 text-xs">
+    <span className="text-[var(--pg-ink-muted)]">{label}</span>
+    <span className="font-[family-name:var(--font-mono)] text-[var(--pg-ink)]">
+      {value}
+    </span>
+  </div>
+);
+
+export function CollaborationLab({
+  open,
+  onOpenChange,
+  roomId,
+  replicaId,
+  connectionState,
+  transportMode,
+  persistenceState,
+  pendingCount,
+  durableBatchCount,
+  storageBytes,
+}: CollaborationLabProps) {
+  const transportLabel =
+    transportMode === "websocket" ? "WebSocket" : "BroadcastChannel";
+  const connected = connectionState === "connected";
+
+  const exportTrace = async () => {
+    const trace = JSON.stringify(
+      {
+        roomId,
+        replicaId,
+        transport: transportLabel,
+        connectionState,
+        persistenceState,
+        pendingCount,
+        durableBatchCount,
+        storageBytes,
+        exportedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    );
+    const copied = await copyText(trace);
+    toast[copied ? "success" : "error"](
+      copied ? "Debug trace copied" : "Failed to copy debug trace",
+    );
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="absolute top-3 right-3 z-10 inline-flex items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-surface)]/95 px-2.5 py-1.5 text-[11px] font-semibold text-[var(--pg-ink-muted)] backdrop-blur outline-none transition-colors hover:border-[var(--pg-ink)] hover:text-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+        onClick={() => onOpenChange(true)}
+        data-testid="collaboration-lab-open"
+      >
+        <PanelRightOpen className="size-3.5" aria-hidden />
+        Lab
+      </button>
+    );
+  }
+
+  return (
+    <aside
+      className="flex w-full shrink-0 flex-col border-t border-[var(--pg-line)] bg-[var(--pg-surface)] md:w-[280px] md:border-t-0 md:border-l"
+      data-testid="collaboration-lab"
+      aria-label="Collaboration Lab"
+    >
+      <div className="flex items-center justify-between border-b border-[var(--pg-line)] px-3 py-2">
+        <h2 className="font-[family-name:var(--font-display)] text-sm font-semibold tracking-[-0.02em]">
+          Collaboration Lab
+        </h2>
+        <button
+          type="button"
+          className="inline-flex size-7 items-center justify-center text-[var(--pg-ink-muted)] outline-none hover:text-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+          onClick={() => onOpenChange(false)}
+          aria-label="Hide Collaboration Lab"
+          data-testid="collaboration-lab-close"
+        >
+          <PanelRightClose className="size-4" aria-hidden />
+        </button>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-5 overflow-y-auto p-3">
+        <section>
+          <h3 className="mb-1 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.14em] text-[var(--pg-ink-muted)] uppercase">
+            Network
+          </h3>
+          <LabRow
+            label="Status"
+            value={
+              connected
+                ? "● Connected"
+                : `○ ${connectionDetailLabel(connectionState)}`
+            }
+          />
+          <LabRow label="Transport" value={transportLabel} />
+          <LabRow label="Latency" value={connected ? "— ms" : "n/a"} />
+        </section>
+
+        <section>
+          <h3 className="mb-1 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.14em] text-[var(--pg-ink-muted)] uppercase">
+            Replica
+          </h3>
+          <LabRow label="Peer" value={replicaId.slice(0, 10)} />
+          <LabRow label="Durable batches" value={String(durableBatchCount)} />
+          <LabRow label="Pending" value={String(pendingCount)} />
+          <LabRow
+            label="Local storage"
+            value={formatStorageSize(storageBytes)}
+          />
+          <LabRow label="Protocol" value="v1 · EG-walker" />
+        </section>
+
+        <section className="mt-auto flex flex-col gap-2">
+          <p className="text-[11px] leading-relaxed text-[var(--pg-ink-muted)]">
+            Offline, latency, and drop-message simulators land next. Export a
+            trace to inspect room state now.
+          </p>
+          <button
+            type="button"
+            className="border border-[var(--pg-line)] bg-[var(--pg-paper)] px-3 py-2 text-left text-xs font-semibold outline-none transition-colors hover:border-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+            onClick={() => {
+              void exportTrace();
+            }}
+            data-testid="lab-export-trace"
+          >
+            Export debug trace
+          </button>
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/DiagnosticsSheet.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/DiagnosticsSheet.tsx
@@ -1,0 +1,177 @@
+import type { AdapterConnectionState } from "@softmaple/awareness";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@softmaple/ui/components/sheet";
+import { toast } from "sonner";
+import { clearRoomLocalData, copyText } from "./roomLink";
+import {
+  connectionDetailLabel,
+  formatStorageSize,
+  type PersistenceDisplayState,
+  persistenceLabel,
+} from "./syncStatus";
+
+export interface DiagnosticsSheetProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly roomId: string;
+  readonly replicaId: string;
+  readonly connectionState: AdapterConnectionState;
+  readonly presenceState: AdapterConnectionState;
+  readonly documentSyncState: AdapterConnectionState | null;
+  readonly transportMode: "websocket" | "broadcast";
+  readonly persistenceState: PersistenceDisplayState;
+  readonly pendingCount: number;
+  readonly storageBytes: number;
+}
+
+const DetailRow = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-baseline justify-between gap-4 py-1.5">
+    <dt className="text-[var(--pg-ink-muted)]">{label}</dt>
+    <dd className="text-right font-[family-name:var(--font-mono)] text-[var(--pg-ink)]">
+      {value}
+    </dd>
+  </div>
+);
+
+export function DiagnosticsSheet({
+  open,
+  onOpenChange,
+  roomId,
+  replicaId,
+  connectionState,
+  presenceState,
+  documentSyncState,
+  transportMode,
+  persistenceState,
+  pendingCount,
+  storageBytes,
+}: DiagnosticsSheetProps) {
+  const transportLabel =
+    transportMode === "websocket" ? "WebSocket" : "BroadcastChannel";
+
+  const copyDebugReport = async () => {
+    const report = [
+      "SoftMaple Lexical diagnostics",
+      `room: ${roomId}`,
+      `replica: ${replicaId}`,
+      `transport: ${transportLabel}`,
+      `connection: ${connectionState}`,
+      `presence: ${presenceState}`,
+      `documentSync: ${documentSyncState ?? "n/a"}`,
+      `persistence: ${persistenceState}`,
+      `pendingBatches: ${pendingCount}`,
+      `localStorage: ${formatStorageSize(storageBytes)}`,
+      `protocol: v1`,
+      `url: ${window.location.href}`,
+    ].join("\n");
+    const copied = await copyText(report);
+    if (copied) {
+      toast.success("Debug report copied");
+    } else {
+      toast.error("Failed to copy debug report");
+    }
+  };
+
+  const clearLocal = () => {
+    const removed = clearRoomLocalData(roomId);
+    toast.success(
+      removed > 0 ? "Local data cleared" : "No local data for this room",
+    );
+    window.location.reload();
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full border-[var(--pg-line)] bg-[var(--pg-paper)] text-[var(--pg-ink)] sm:max-w-md"
+        data-testid="diagnostics-sheet"
+      >
+        <SheetHeader className="border-b border-[var(--pg-line)]">
+          <SheetTitle className="font-[family-name:var(--font-display)] tracking-[-0.02em]">
+            Diagnostics
+          </SheetTitle>
+          <SheetDescription className="text-[var(--pg-ink-muted)]">
+            Transport, pending events, and local durability for this room.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-4 py-5 text-sm">
+          <section>
+            <h3 className="mb-2 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.16em] text-[var(--pg-ink-muted)] uppercase">
+              Connection
+            </h3>
+            <dl className="border-y border-[var(--pg-line)]">
+              <DetailRow
+                label="Document sync"
+                value={connectionDetailLabel(
+                  documentSyncState ?? connectionState,
+                )}
+              />
+              <DetailRow
+                label="Presence"
+                value={connectionDetailLabel(presenceState)}
+              />
+              <DetailRow label="Transport" value={transportLabel} />
+              <DetailRow
+                label="Merged state"
+                value={connectionDetailLabel(connectionState)}
+              />
+            </dl>
+          </section>
+
+          <section>
+            <h3 className="mb-2 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.16em] text-[var(--pg-ink-muted)] uppercase">
+              Local state
+            </h3>
+            <dl className="border-y border-[var(--pg-line)]">
+              <DetailRow label="Pending batches" value={String(pendingCount)} />
+              <DetailRow
+                label="Local storage"
+                value={formatStorageSize(storageBytes)}
+              />
+              <DetailRow label="Replica ID" value={replicaId.slice(0, 12)} />
+              <DetailRow label="Room" value={roomId} />
+              <DetailRow
+                label="Durability"
+                value={persistenceLabel(persistenceState, pendingCount)}
+              />
+              <DetailRow label="Protocol" value="v1 · EG-walker × Lexical" />
+            </dl>
+          </section>
+
+          <section>
+            <h3 className="mb-2 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.16em] text-[var(--pg-ink-muted)] uppercase">
+              Actions
+            </h3>
+            <div className="flex flex-col gap-2">
+              <button
+                type="button"
+                className="border border-[var(--pg-line)] bg-[var(--pg-surface)] px-3 py-2 text-left text-sm font-semibold outline-none transition-colors hover:border-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+                onClick={() => {
+                  void copyDebugReport();
+                }}
+                data-testid="diagnostics-copy-report"
+              >
+                Copy debug report
+              </button>
+              <button
+                type="button"
+                className="border border-rose-200 bg-rose-50 px-3 py-2 text-left text-sm font-semibold text-rose-800 outline-none transition-colors hover:border-rose-400 focus-visible:ring-2 focus-visible:ring-rose-400"
+                onClick={clearLocal}
+                data-testid="diagnostics-clear-local"
+              >
+                Clear local data
+              </button>
+            </div>
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
@@ -6,7 +6,6 @@ import { LexicalEgWalkerPlugin } from "@softmaple/binding-lexical/react";
 import { CoreEditor } from "@softmaple/editor/components/core/CoreEditor";
 import { LEXICAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
 import type { LexicalEditor } from "lexical";
-import { ArrowLeft, GitFork, ShieldCheck } from "lucide-react";
 import {
   type SetStateAction,
   useCallback,
@@ -15,9 +14,11 @@ import {
   useRef,
   useState,
 } from "react";
+import { CollaborationLab } from "./CollaborationLab";
 import { useRoomPresence } from "./presence";
 import { RemoteSelectionLayer } from "./RemoteSelectionLayer";
 import { createRoomId, resolveRoomId } from "./room";
+import { SoloCollabHint } from "./SoloCollabHint";
 import {
   mergeConnectionStates,
   type PersistenceDisplayState,
@@ -49,6 +50,8 @@ export function LexicalEgWalkerDemo({
     useState<RoomSessionValue<LexicalBinding | null> | null>(null);
   const [bindingErrorState, setBindingErrorState] =
     useState<RoomSessionValue<Error> | null>(null);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [labOpen, setLabOpen] = useState(false);
   const activeEditor =
     activeEditorState?.sessionKey === sessionKey
       ? activeEditorState.value
@@ -76,11 +79,6 @@ export function LexicalEgWalkerDemo({
     window.history.replaceState(null, "", url);
   }, [requestedRoom, roomId]);
 
-  const copyRoomLink = useCallback(() => {
-    const url = new URL(window.location.href);
-    url.searchParams.set("room", roomId);
-    void navigator.clipboard?.writeText(url.toString()).catch(() => undefined);
-  }, [roomId]);
   const updatePresenceSelection = useCallback(
     (selection: StableBlockSelection | null) => {
       presence.updateSelection(toPresenceSelection(selection));
@@ -122,6 +120,16 @@ export function LexicalEgWalkerDemo({
   const persistenceState: PersistenceDisplayState =
     room.persistence?.durability ?? "loading";
   const visibleError = bindingError ?? room.error;
+  const documentSyncState = room.persistence?.syncConnectionState ?? null;
+  const connectionState = mergeConnectionStates(
+    presence.connectionState,
+    documentSyncState,
+  );
+  const pendingCount = room.persistence?.pendingBatchIds.length ?? 0;
+  const storageBytes = room.persistence?.storageBytes ?? 0;
+  const durableBatchCount = room.persistence?.durableBatchIds.length ?? 0;
+  const showSoloHint =
+    room.replica !== null && presence.users.length <= 1 && !labOpen;
 
   return (
     <main
@@ -132,65 +140,34 @@ export function LexicalEgWalkerDemo({
       data-persistence-mode={room.persistence?.mode ?? "initializing"}
       data-persistence-durability={room.persistence?.durability ?? "loading"}
       data-persistence-leader={room.persistence?.leader.status ?? "stopped"}
-      data-storage-bytes={room.persistence?.storageBytes ?? 0}
+      data-storage-bytes={storageBytes}
     >
       <StatusRail
         roomId={roomId}
-        connectionState={mergeConnectionStates(
-          presence.connectionState,
-          room.persistence?.syncConnectionState,
-        )}
+        replicaId={presence.identity.userId}
+        connectionState={connectionState}
+        presenceState={presence.connectionState}
+        documentSyncState={documentSyncState}
         transportMode={presence.transportMode}
         persistenceState={persistenceState}
-        pendingCount={room.persistence?.pendingBatchIds.length ?? 0}
-        storageBytes={room.persistence?.storageBytes ?? 0}
+        pendingCount={pendingCount}
+        storageBytes={storageBytes}
         users={presence.users}
-        onCopyRoomLink={copyRoomLink}
+        shareOpen={shareOpen}
+        onShareOpenChange={setShareOpen}
+        labOpen={labOpen}
+        onLabOpenChange={setLabOpen}
       />
 
-      <header className="flex items-start justify-between gap-4 px-4 pt-4 pb-3 md:px-8 md:pt-6 md:pb-4">
-        <div className="min-w-0">
-          <div className="mb-1.5 flex items-center gap-2 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.18em] text-[var(--pg-accent)] uppercase">
-            <GitFork className="size-3.5" />
-            Causal canvas ·{" "}
-            {presence.transportMode === "websocket"
-              ? "WebSocket"
-              : "local first"}
-          </div>
-          <h1 className="font-[family-name:var(--font-display)] text-2xl leading-tight font-bold tracking-[-0.03em] md:text-3xl">
-            EG-walker × Lexical
-          </h1>
-          <p className="mt-1 max-w-xl text-xs leading-relaxed text-[var(--pg-ink-muted)] md:text-sm">
-            {presence.transportMode === "websocket"
-              ? "One document across browsers. Document events and presence sync over WebSocket; a local copy remains on this device."
-              : "One document, any number of tabs. Changes converge through stable sequence anchors and remain on this device after every tab closes. Add ?transport=websocket for cross-browser sync."}
-          </p>
-        </div>
-        <a
-          href="/"
-          className="inline-flex shrink-0 items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-surface)] px-2.5 py-2 text-xs font-semibold text-[var(--pg-ink-muted)] outline-none transition-colors hover:border-[var(--pg-ink)] hover:text-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
-        >
-          <ArrowLeft className="size-3.5" />
-          <span className="hidden sm:inline">Playground</span>
-        </a>
-      </header>
-
-      <section className="relative mx-auto flex w-full max-w-[1120px] flex-1 px-3 pb-3 md:px-8 md:pb-8">
-        <div className="pg-panel relative flex min-h-[540px] w-full flex-col overflow-hidden">
-          <div className="pg-panel-header flex items-center justify-between px-4 py-2 font-[family-name:var(--font-mono)] text-[10px] font-medium tracking-[0.14em] text-[var(--pg-ink-muted)] uppercase">
-            <span>Collaborative manuscript</span>
-            <span className="inline-flex items-center gap-1.5 text-teal-700">
-              <ShieldCheck className="size-3.5" />
-              v1 schema
-            </span>
-          </div>
+      <section className="relative flex min-h-0 flex-1 flex-col md:flex-row">
+        <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
           {room.replica === null ? (
             <div
               className="grid flex-1 place-items-center p-8 text-center"
               data-testid="lexical-room-loading"
             >
               <div>
-                <div className="mx-auto mb-4 flex size-10 items-center justify-center border border-[var(--pg-line)] bg-[var(--pg-paper)]">
+                <div className="mx-auto mb-4 flex size-10 items-center justify-center border border-[var(--pg-line)] bg-[var(--pg-surface)]">
                   <span className="size-2 bg-[var(--pg-accent)] motion-safe:animate-pulse" />
                 </div>
                 <p className="font-[family-name:var(--font-display)] text-lg font-semibold">
@@ -204,7 +181,7 @@ export function LexicalEgWalkerDemo({
           ) : (
             <div
               ref={editorHostRef}
-              className="relative flex-1"
+              className="relative min-h-0 flex-1 overflow-auto"
               data-testid="lexical-room-ready"
             >
               <CoreEditor
@@ -213,7 +190,7 @@ export function LexicalEgWalkerDemo({
                 setActiveEditor={setActiveEditor}
                 historyMode="disabled"
                 lexicalConfig={lexicalConfig}
-                layoutClassName="mx-0 my-0 max-w-none min-h-full font-normal leading-[1.7] [&_.flex-auto]:w-full [&_.flex-auto]:flex-1 [&_[contenteditable=true]]:min-h-[440px] [&_[contenteditable=true]]:w-full [&_[contenteditable=true]]:px-6 [&_[contenteditable=true]]:py-8 [&_[aria-hidden=true]>div]:left-6 [&_[aria-hidden=true]>div]:right-6 [&_[aria-hidden=true]>div]:top-8 md:[&_[contenteditable=true]]:px-14 md:[&_[contenteditable=true]]:py-12 md:[&_[aria-hidden=true]>div]:left-14 md:[&_[aria-hidden=true]>div]:right-14 md:[&_[aria-hidden=true]>div]:top-12"
+                layoutClassName="mx-0 my-0 max-w-none min-h-full font-normal leading-[1.7] [&_.flex-auto]:w-full [&_.flex-auto]:flex-1 [&_[contenteditable=true]]:min-h-[min(70svh,640px)] [&_[contenteditable=true]]:w-full [&_[contenteditable=true]]:px-6 [&_[contenteditable=true]]:py-8 [&_[aria-hidden=true]>div]:left-6 [&_[aria-hidden=true]>div]:right-6 [&_[aria-hidden=true]>div]:top-8 md:[&_[contenteditable=true]]:px-14 md:[&_[contenteditable=true]]:py-12 md:[&_[aria-hidden=true]>div]:left-14 md:[&_[aria-hidden=true]>div]:right-14 md:[&_[aria-hidden=true]>div]:top-12"
               >
                 <LexicalEgWalkerPlugin
                   replica={room.replica}
@@ -228,6 +205,12 @@ export function LexicalEgWalkerDemo({
                 selfId={presence.identity.userId}
                 users={presence.users}
               />
+              {showSoloHint ? (
+                <SoloCollabHint
+                  roomId={roomId}
+                  onShare={() => setShareOpen(true)}
+                />
+              ) : null}
             </div>
           )}
           {visibleError !== null ? (
@@ -239,6 +222,19 @@ export function LexicalEgWalkerDemo({
             </div>
           ) : null}
         </div>
+
+        <CollaborationLab
+          open={labOpen}
+          onOpenChange={setLabOpen}
+          roomId={roomId}
+          replicaId={presence.identity.userId}
+          connectionState={connectionState}
+          transportMode={presence.transportMode}
+          persistenceState={persistenceState}
+          pendingCount={pendingCount}
+          durableBatchCount={durableBatchCount}
+          storageBytes={storageBytes}
+        />
       </section>
     </main>
   );

--- a/apps/playground/src/modules/lexical-eg-walker/ShareRoomDialog.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/ShareRoomDialog.tsx
@@ -1,0 +1,77 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@softmaple/ui/components/dialog";
+import { Copy, ExternalLink } from "lucide-react";
+import { useEffect, useState } from "react";
+import { buildRoomUrl, copyRoomLink, openAnotherWindow } from "./roomLink";
+
+export interface ShareRoomDialogProps {
+  readonly roomId: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+export function ShareRoomDialog({
+  roomId,
+  open,
+  onOpenChange,
+}: ShareRoomDialogProps) {
+  const [link, setLink] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setLink(buildRoomUrl(roomId));
+  }, [open, roomId]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="border-[var(--pg-line)] bg-[var(--pg-paper)] text-[var(--pg-ink)] sm:max-w-md"
+        data-testid="share-room-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle className="font-[family-name:var(--font-display)] tracking-[-0.02em]">
+            Invite someone to this room
+          </DialogTitle>
+          <DialogDescription className="text-[var(--pg-ink-muted)]">
+            Open the link in another browser or window to watch edits sync live.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="overflow-hidden border border-[var(--pg-line)] bg-[var(--pg-surface)] px-3 py-2.5 font-[family-name:var(--font-mono)] text-xs break-all text-[var(--pg-ink)]">
+          {link || "…"}
+        </div>
+
+        <DialogFooter className="gap-2 sm:justify-start">
+          <button
+            type="button"
+            className="inline-flex items-center justify-center gap-1.5 bg-[var(--pg-ink)] px-3.5 py-2 text-sm font-semibold text-[var(--pg-paper)] outline-none transition-colors hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+            onClick={() => {
+              void copyRoomLink(roomId);
+            }}
+            data-testid="share-copy-link"
+          >
+            <Copy className="size-3.5" aria-hidden />
+            Copy link
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-surface)] px-3.5 py-2 text-sm font-semibold text-[var(--pg-ink)] outline-none transition-colors hover:border-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+            onClick={() => {
+              openAnotherWindow(roomId);
+            }}
+            data-testid="share-open-window"
+          >
+            <ExternalLink className="size-3.5" aria-hidden />
+            Open another window
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/SoloCollabHint.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/SoloCollabHint.tsx
@@ -1,0 +1,62 @@
+import { ExternalLink, Share2, X } from "lucide-react";
+import { useState } from "react";
+import { openAnotherWindow } from "./roomLink";
+
+export interface SoloCollabHintProps {
+  readonly roomId: string;
+  readonly onShare: () => void;
+}
+
+export function SoloCollabHint({ roomId, onShare }: SoloCollabHintProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      className="pointer-events-auto absolute right-3 bottom-3 left-3 z-10 max-w-sm border border-[var(--pg-line)] bg-[var(--pg-surface)]/96 p-3 shadow-sm backdrop-blur md:left-auto"
+      data-testid="solo-collab-hint"
+    >
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-[var(--pg-ink)]">
+            You’re the only person here.
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-[var(--pg-ink-muted)]">
+            Open another window or share this room to test collaboration.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 bg-[var(--pg-ink)] px-2.5 py-1.5 text-xs font-semibold text-[var(--pg-paper)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+              onClick={() => {
+                openAnotherWindow(roomId);
+              }}
+              data-testid="solo-open-window"
+            >
+              <ExternalLink className="size-3.5" aria-hidden />
+              Open another window
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 border border-[var(--pg-line)] px-2.5 py-1.5 text-xs font-semibold text-[var(--pg-ink)] outline-none hover:border-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+              onClick={onShare}
+              data-testid="solo-share"
+            >
+              <Share2 className="size-3.5" aria-hidden />
+              Share room
+            </button>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="shrink-0 p-0.5 text-[var(--pg-ink-muted)] outline-none hover:text-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+        >
+          <X className="size-3.5" aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatStorageSize, persistenceLabel } from "./StatusRail";
+import {
+  formatStorageSize,
+  persistenceLabel,
+  syncStatusView,
+} from "./syncStatus";
 
 describe("collaboration status labels", () => {
   it("reports bytes and kibibytes compactly", () => {
@@ -7,8 +11,54 @@ describe("collaboration status labels", () => {
     expect(formatStorageSize(1_536)).toBe("1.5 KB");
   });
 
-  it("never describes memory-only state as saved", () => {
-    expect(persistenceLabel("unsaved", 2)).toBe("Unsaved · memory only");
-    expect(persistenceLabel("pending", 2)).toBe("2 changes pending");
+  it("never describes memory-only state as remotely synced", () => {
+    expect(persistenceLabel("unsaved", 2)).toBe(
+      "Changes are only stored in memory",
+    );
+    expect(
+      syncStatusView({
+        connectionState: "connected",
+        persistenceState: "unsaved",
+        pendingCount: 0,
+      }).label,
+    ).toBe("Changes are only stored in memory");
+  });
+
+  it("uses product sync copy for connected and offline paths", () => {
+    expect(
+      syncStatusView({
+        connectionState: "connected",
+        persistenceState: "saved",
+        pendingCount: 0,
+        transportMode: "websocket",
+      }).label,
+    ).toBe("Synced");
+
+    expect(
+      syncStatusView({
+        connectionState: "connected",
+        persistenceState: "pending",
+        pendingCount: 2,
+        transportMode: "websocket",
+      }).label,
+    ).toBe("Saving changes…");
+
+    expect(
+      syncStatusView({
+        connectionState: "disconnected",
+        persistenceState: "saved",
+        pendingCount: 4,
+        transportMode: "websocket",
+      }).label,
+    ).toBe("Offline · 4 changes waiting");
+
+    expect(
+      syncStatusView({
+        connectionState: "disconnected",
+        persistenceState: "saved",
+        pendingCount: 0,
+        transportMode: "websocket",
+      }).label,
+    ).toBe("Offline · changes saved locally");
   });
 });

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
@@ -2,230 +2,195 @@ import type {
   AdapterConnectionState,
   PresenceUser,
 } from "@softmaple/awareness";
+import { Link } from "@tanstack/react-router";
 import {
-  Check,
-  CloudOff,
-  Copy,
-  Database,
   LoaderCircle,
+  MoreHorizontal,
   Radio,
+  Share2,
   WifiOff,
 } from "lucide-react";
-import type { ReactNode } from "react";
-import type { TransportConnectionState } from "./persistence/channel";
+import { useState } from "react";
+import { DiagnosticsSheet } from "./DiagnosticsSheet";
+import { ShareRoomDialog } from "./ShareRoomDialog";
+import { type PersistenceDisplayState, syncStatusView } from "./syncStatus";
 
-export type PersistenceDisplayState =
-  | "loading"
-  | "pending"
-  | "saved"
-  | "unsaved";
-
-const CONNECTION_RANK = {
-  error: 0,
-  disconnected: 1,
-  reconnecting: 2,
-  connecting: 3,
-  connected: 4,
-} as const satisfies Record<AdapterConnectionState, number>;
-
-/** Prefer the more degraded of presence + document sync states. */
-export const mergeConnectionStates = (
-  presence: AdapterConnectionState,
-  sync: TransportConnectionState | null | undefined,
-): AdapterConnectionState => {
-  if (sync == null) return presence;
-  return CONNECTION_RANK[presence] <= CONNECTION_RANK[sync] ? presence : sync;
-};
+export type { PersistenceDisplayState } from "./syncStatus";
+export {
+  formatStorageSize,
+  mergeConnectionStates,
+  persistenceLabel,
+  syncStatusView,
+} from "./syncStatus";
 
 export interface StatusRailProps {
   readonly roomId: string;
+  readonly replicaId: string;
   readonly connectionState: AdapterConnectionState;
+  readonly presenceState: AdapterConnectionState;
+  readonly documentSyncState: AdapterConnectionState | null;
   readonly transportMode?: "websocket" | "broadcast";
   readonly persistenceState: PersistenceDisplayState;
   readonly pendingCount: number;
   readonly storageBytes: number;
   readonly users: ReadonlyArray<PresenceUser>;
-  readonly onCopyRoomLink: () => void;
+  readonly shareOpen?: boolean;
+  readonly onShareOpenChange?: (open: boolean) => void;
+  readonly labOpen?: boolean;
+  readonly onLabOpenChange?: (open: boolean) => void;
 }
-
-const formatStorageSize = (bytes: number): string => {
-  if (bytes < 1_024) return `${bytes} B`;
-  return `${(bytes / 1_024).toFixed(1)} KB`;
-};
-
-const persistenceLabel = (
-  state: PersistenceDisplayState,
-  pendingCount: number,
-): string => {
-  switch (state) {
-    case "loading":
-      return "Loading local history";
-    case "pending":
-      return `${pendingCount} change${pendingCount === 1 ? "" : "s"} pending`;
-    case "saved":
-      return "Saved on this device";
-    case "unsaved":
-      return "Unsaved · memory only";
-  }
-};
-
-const connectionLabel = (
-  state: AdapterConnectionState,
-  transportMode: "websocket" | "broadcast" = "broadcast",
-): string => {
-  const channel =
-    transportMode === "websocket" ? "WebSocket" : "BroadcastChannel";
-  switch (state) {
-    case "connected":
-      return transportMode === "websocket"
-        ? "WebSocket connected"
-        : "Tabs connected";
-    case "connecting":
-      return `Connecting via ${channel}…`;
-    case "reconnecting":
-      return `Reconnecting via ${channel}…`;
-    case "error":
-      return `${channel} unavailable — refresh to retry`;
-    case "disconnected":
-      return transportMode === "websocket"
-        ? "WebSocket offline"
-        : "Working in this tab";
-  }
-};
-
-const isReconnectWarningState = (state: AdapterConnectionState): boolean =>
-  state === "disconnected" || state === "reconnecting" || state === "error";
-
-const StatusItem = ({
-  icon,
-  children,
-  tone = "default",
-}: {
-  icon: ReactNode;
-  children: ReactNode;
-  tone?: "default" | "warn" | "danger";
-}) => {
-  const toneClass =
-    tone === "danger"
-      ? "text-rose-700"
-      : tone === "warn"
-        ? "text-amber-700"
-        : "text-[var(--pg-ink-muted)]";
-  const iconClass =
-    tone === "danger"
-      ? "text-rose-500"
-      : tone === "warn"
-        ? "text-amber-500"
-        : "text-[var(--pg-accent)]";
-
-  return (
-    <span
-      className={`inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap ${toneClass}`}
-    >
-      <span aria-hidden className={iconClass}>
-        {icon}
-      </span>
-      <span className="truncate">{children}</span>
-    </span>
-  );
-};
 
 export function StatusRail({
   roomId,
+  replicaId,
   connectionState,
+  presenceState,
+  documentSyncState,
   transportMode = "broadcast",
   persistenceState,
   pendingCount,
   storageBytes,
   users,
-  onCopyRoomLink,
+  shareOpen: shareOpenProp,
+  onShareOpenChange,
+  labOpen = false,
+  onLabOpenChange,
 }: StatusRailProps) {
-  const persistenceIcon =
-    persistenceState === "saved" ? (
-      <Check className="size-3.5" />
-    ) : persistenceState === "unsaved" ? (
-      <CloudOff className="size-3.5 text-rose-500" />
-    ) : (
-      <LoaderCircle className="size-3.5 motion-safe:animate-spin" />
-    );
+  const [shareOpenUncontrolled, setShareOpenUncontrolled] = useState(false);
+  const shareOpen = shareOpenProp ?? shareOpenUncontrolled;
+  const setShareOpen = onShareOpenChange ?? setShareOpenUncontrolled;
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const status = syncStatusView({
+    connectionState,
+    persistenceState,
+    pendingCount,
+    transportMode,
+  });
 
-  const connectionTone =
-    connectionState === "error" || connectionState === "disconnected"
-      ? "danger"
-      : connectionState === "reconnecting" || connectionState === "connecting"
-        ? "warn"
-        : "default";
-
-  const connectionIcon =
-    connectionState === "error" || connectionState === "disconnected" ? (
+  const statusIcon =
+    status.tone === "danger" ? (
       <WifiOff className="size-3.5" />
-    ) : connectionState === "reconnecting" ||
-      connectionState === "connecting" ? (
+    ) : status.tone === "warn" ? (
       <LoaderCircle className="size-3.5 motion-safe:animate-spin" />
     ) : (
       <Radio className="size-3.5" />
     );
 
+  const toneClass =
+    status.tone === "danger"
+      ? "text-rose-700"
+      : status.tone === "warn"
+        ? "text-amber-700"
+        : "text-[var(--pg-ink)]";
+
+  const peopleLabel =
+    users.length === 1 ? "1 person online" : `${users.length} people online`;
+
   return (
-    // biome-ignore lint/a11y/useSemanticElements: transport status live region; <output> is for form-calculated values.
-    <div
-      className="relative z-20 flex min-h-10 flex-wrap items-center gap-x-4 gap-y-2 border-b border-[var(--pg-line)] bg-[var(--pg-surface)]/92 px-3 py-2 font-[family-name:var(--font-mono)] text-[11px] font-medium tracking-[0.02em] text-[var(--pg-ink-muted)] backdrop-blur md:px-5"
-      data-testid="collaboration-status"
-      data-transport={transportMode}
-      data-connection-state={connectionState}
-      role="status"
-      aria-live="polite"
-    >
-      <span
-        aria-hidden
-        className="absolute inset-y-0 left-0 w-[3px] bg-gradient-to-b from-[var(--pg-accent)] via-teal-500 to-orange-500"
-      />
-      <button
-        type="button"
-        className="group inline-flex max-w-48 items-center gap-1.5 px-1.5 py-1 text-[var(--pg-ink)] outline-none transition-colors hover:bg-[var(--pg-paper)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
-        onClick={onCopyRoomLink}
-        aria-label={`Copy link for room ${roomId}`}
+    <>
+      {/* biome-ignore lint/a11y/useSemanticElements: transport status live region; <output> is for form-calculated values. */}
+      <div
+        className="relative z-20 flex min-h-12 flex-wrap items-center gap-x-3 gap-y-2 border-b border-[var(--pg-line)] bg-[var(--pg-surface)]/94 px-3 py-2 backdrop-blur md:px-5"
+        data-testid="collaboration-status"
+        data-transport={transportMode}
+        data-connection-state={connectionState}
+        data-sync-label={status.label}
+        role="status"
+        aria-live="polite"
       >
-        <span className="truncate font-mono">room/{roomId}</span>
-        <Copy className="size-3 opacity-50 transition-opacity group-hover:opacity-100" />
-      </button>
-
-      <StatusItem icon={connectionIcon} tone={connectionTone}>
-        {connectionLabel(connectionState, transportMode)}
-      </StatusItem>
-      {isReconnectWarningState(connectionState) &&
-      transportMode === "websocket" ? (
-        <span className="border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-800">
-          Sync paused until reconnect
-        </span>
-      ) : null}
-      <StatusItem icon={persistenceIcon}>
-        {persistenceLabel(persistenceState, pendingCount)}
-      </StatusItem>
-      <StatusItem icon={<Database className="size-3.5" />}>
-        {formatStorageSize(storageBytes)}
-      </StatusItem>
-
-      <div className="ml-auto flex items-center pl-1">
-        {users.slice(0, 5).map((user, index) => (
-          <span
-            key={user.userId}
-            className="grid size-6 place-items-center border-2 border-[var(--pg-surface)] text-[9px] font-bold text-white shadow-sm"
-            style={{
-              backgroundColor: user.color,
-              marginLeft: index === 0 ? 0 : -5,
-            }}
-            title={user.name}
-          >
-            {user.name.slice(0, 2).toUpperCase()}
+        <Link
+          to="/"
+          className="inline-flex min-w-0 items-baseline gap-1.5 font-[family-name:var(--font-display)] text-sm font-bold tracking-[-0.03em] text-[var(--pg-ink)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+        >
+          SoftMaple
+          <span className="truncate font-normal text-[var(--pg-ink-muted)]">
+            / Lexical
           </span>
-        ))}
-        <span className="ml-2 whitespace-nowrap text-[var(--pg-ink-muted)]">
-          {users.length} online
-        </span>
+        </Link>
+
+        <button
+          type="button"
+          className={`mx-auto inline-flex max-w-[min(100%,18rem)] items-center gap-1.5 px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] font-medium outline-none transition-colors hover:bg-[var(--pg-paper)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)] ${toneClass}`}
+          onClick={() => setDiagnosticsOpen(true)}
+          aria-label={`${status.label}. Open diagnostics.`}
+          data-testid="sync-status-button"
+        >
+          <span aria-hidden className="text-[var(--pg-accent)]">
+            {statusIcon}
+          </span>
+          <span className="truncate">{status.label}</span>
+        </button>
+
+        <div className="ml-auto flex items-center gap-1.5 sm:gap-2">
+          <div className="hidden items-center sm:flex">
+            {users.slice(0, 5).map((user, index) => (
+              <span
+                key={user.userId}
+                className="grid size-6 place-items-center border-2 border-[var(--pg-surface)] text-[9px] font-bold text-white"
+                style={{
+                  backgroundColor: user.color,
+                  marginLeft: index === 0 ? 0 : -5,
+                }}
+                title={user.name}
+              >
+                {user.name.slice(0, 2).toUpperCase()}
+              </span>
+            ))}
+            <span className="ml-2 whitespace-nowrap font-[family-name:var(--font-mono)] text-[11px] text-[var(--pg-ink-muted)]">
+              {peopleLabel}
+            </span>
+          </div>
+          <span className="font-[family-name:var(--font-mono)] text-[11px] text-[var(--pg-ink-muted)] sm:hidden">
+            {users.length} online
+          </span>
+
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 bg-[var(--pg-ink)] px-2.5 py-1.5 text-xs font-semibold text-[var(--pg-paper)] outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+            onClick={() => setShareOpen(true)}
+            data-testid="share-room-button"
+          >
+            <Share2 className="size-3.5" aria-hidden />
+            Share
+          </button>
+
+          <button
+            type="button"
+            className="inline-flex size-8 items-center justify-center border border-[var(--pg-line)] bg-[var(--pg-surface)] text-[var(--pg-ink-muted)] outline-none transition-colors hover:border-[var(--pg-ink)] hover:text-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+            onClick={() => {
+              if (onLabOpenChange) {
+                onLabOpenChange(!labOpen);
+              } else {
+                setDiagnosticsOpen(true);
+              }
+            }}
+            aria-label={labOpen ? "Hide Collaboration Lab" : "Diagnostics"}
+            aria-pressed={labOpen}
+            data-testid="diagnostics-menu-button"
+          >
+            <MoreHorizontal className="size-4" aria-hidden />
+          </button>
+        </div>
       </div>
-    </div>
+
+      <ShareRoomDialog
+        roomId={roomId}
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+      />
+      <DiagnosticsSheet
+        open={diagnosticsOpen}
+        onOpenChange={setDiagnosticsOpen}
+        roomId={roomId}
+        replicaId={replicaId}
+        connectionState={connectionState}
+        presenceState={presenceState}
+        documentSyncState={documentSyncState}
+        transportMode={transportMode}
+        persistenceState={persistenceState}
+        pendingCount={pendingCount}
+        storageBytes={storageBytes}
+      />
+    </>
   );
 }
-
-export { formatStorageSize, persistenceLabel };

--- a/apps/playground/src/modules/lexical-eg-walker/roomLink.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/roomLink.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildRoomUrl, clearRoomLocalData } from "./roomLink";
+
+describe("room link helpers", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("injects the room query param without dropping other params", () => {
+    expect(
+      buildRoomUrl(
+        "maple-abc",
+        "https://playground.softmaple.ink/demo/lexical-eg-walker?transport=websocket",
+      ),
+    ).toBe(
+      "https://playground.softmaple.ink/demo/lexical-eg-walker?transport=websocket&room=maple-abc",
+    );
+  });
+
+  it("clears matching localStorage keys for a room", () => {
+    localStorage.setItem("softmaple:lexical-eg-walker:v1:room:maple-abc", "{}");
+    localStorage.setItem("unrelated", "1");
+    expect(clearRoomLocalData("maple-abc")).toBe(1);
+    expect(localStorage.getItem("unrelated")).toBe("1");
+    expect(
+      localStorage.getItem("softmaple:lexical-eg-walker:v1:room:maple-abc"),
+    ).toBeNull();
+  });
+});

--- a/apps/playground/src/modules/lexical-eg-walker/roomLink.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/roomLink.ts
@@ -1,0 +1,58 @@
+import { toast } from "sonner";
+
+export const buildRoomUrl = (
+  roomId: string,
+  href = window.location.href,
+): string => {
+  const url = new URL(href);
+  url.searchParams.set("room", roomId);
+  return url.toString();
+};
+
+export const copyText = async (text: string): Promise<boolean> => {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to execCommand.
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const successful = document.execCommand("copy");
+  document.body.removeChild(textarea);
+  return successful;
+};
+
+export const copyRoomLink = async (roomId: string): Promise<boolean> => {
+  const link = buildRoomUrl(roomId);
+  const copied = await copyText(link);
+  if (copied) {
+    toast.success("Room link copied");
+  } else {
+    toast.error("Failed to copy room link", {
+      description: `Please copy manually: ${link}`,
+    });
+  }
+  return copied;
+};
+
+export const openAnotherWindow = (roomId: string): Window | null =>
+  window.open(buildRoomUrl(roomId), "_blank", "noopener,noreferrer");
+
+export const clearRoomLocalData = (roomId: string): number => {
+  const encoded = encodeURIComponent(roomId);
+  const keys = Object.keys(localStorage).filter(
+    (key) => key.includes(roomId) || key.includes(encoded),
+  );
+  for (const key of keys) {
+    localStorage.removeItem(key);
+  }
+  return keys.length;
+};

--- a/apps/playground/src/modules/lexical-eg-walker/syncStatus.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/syncStatus.ts
@@ -1,0 +1,124 @@
+import type { AdapterConnectionState } from "@softmaple/awareness";
+import type { TransportConnectionState } from "./persistence/channel";
+
+export type PersistenceDisplayState =
+  | "loading"
+  | "pending"
+  | "saved"
+  | "unsaved";
+
+export type SyncStatusTone = "default" | "warn" | "danger";
+
+export interface SyncStatusView {
+  readonly label: string;
+  readonly tone: SyncStatusTone;
+}
+
+const CONNECTION_RANK = {
+  error: 0,
+  disconnected: 1,
+  reconnecting: 2,
+  connecting: 3,
+  connected: 4,
+} as const satisfies Record<AdapterConnectionState, number>;
+
+/** Prefer the more degraded of presence + document sync states. */
+export const mergeConnectionStates = (
+  presence: AdapterConnectionState,
+  sync: TransportConnectionState | null | undefined,
+): AdapterConnectionState => {
+  if (sync == null) return presence;
+  return CONNECTION_RANK[presence] <= CONNECTION_RANK[sync] ? presence : sync;
+};
+
+export const formatStorageSize = (bytes: number): string => {
+  if (bytes < 1_024) return `${bytes} B`;
+  return `${(bytes / 1_024).toFixed(1)} KB`;
+};
+
+const offlineLabel = (pendingCount: number): string =>
+  pendingCount > 0
+    ? `Offline · ${pendingCount} change${pendingCount === 1 ? "" : "s"} waiting`
+    : "Offline · changes saved locally";
+
+/**
+ * Product-facing sync copy. Distinguishes remote sync from local durability.
+ */
+export const syncStatusView = ({
+  connectionState,
+  persistenceState,
+  pendingCount,
+  transportMode = "broadcast",
+}: {
+  readonly connectionState: AdapterConnectionState;
+  readonly persistenceState: PersistenceDisplayState;
+  readonly pendingCount: number;
+  readonly transportMode?: "websocket" | "broadcast";
+}): SyncStatusView => {
+  if (connectionState === "error") {
+    return { label: "Unable to sync this room", tone: "danger" };
+  }
+
+  if (persistenceState === "unsaved") {
+    return { label: "Changes are only stored in memory", tone: "danger" };
+  }
+
+  if (connectionState === "reconnecting") {
+    return { label: "Reconnecting…", tone: "warn" };
+  }
+
+  if (connectionState === "connecting") {
+    return { label: "Connecting…", tone: "warn" };
+  }
+
+  if (connectionState === "disconnected") {
+    if (transportMode === "websocket") {
+      return { label: offlineLabel(pendingCount), tone: "danger" };
+    }
+    return { label: "Working in this tab", tone: "warn" };
+  }
+
+  if (persistenceState === "loading") {
+    return { label: "Recovering missing changes…", tone: "warn" };
+  }
+
+  if (persistenceState === "pending" || pendingCount > 0) {
+    return { label: "Saving changes…", tone: "warn" };
+  }
+
+  return { label: "Synced", tone: "default" };
+};
+
+/** @deprecated Prefer syncStatusView — kept for diagnostics detail rows. */
+export const persistenceLabel = (
+  state: PersistenceDisplayState,
+  pendingCount: number,
+): string => {
+  switch (state) {
+    case "loading":
+      return "Recovering missing changes…";
+    case "pending":
+      return `${pendingCount} change${pendingCount === 1 ? "" : "s"} pending`;
+    case "saved":
+      return "Durable on this device";
+    case "unsaved":
+      return "Changes are only stored in memory";
+  }
+};
+
+export const connectionDetailLabel = (
+  state: AdapterConnectionState,
+): string => {
+  switch (state) {
+    case "connected":
+      return "Connected";
+    case "connecting":
+      return "Connecting";
+    case "reconnecting":
+      return "Reconnecting";
+    case "error":
+      return "Error";
+    case "disconnected":
+      return "Disconnected";
+  }
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Repositions the Softmaple playground as a **collaboration lab** visitors can understand in seconds—not a docs page with stacked technical chrome.

### Lexical × EG-walker demo
- Replaces the stacked title / StatusRail / panel header with an app-style top bar: **SoftMaple / Lexical · sync status · people · Share · Lab**
- Sync status uses product copy (`Synced`, `Saving changes…`, `Offline · N changes waiting`, etc.) and opens **Diagnostics**
- **Share room** dialog: copy link (with toast) + **Open another window**
- Solo-user hint when you’re alone in the room
- Collapsible **Collaboration Lab** side panel (network/replica snapshot + export debug trace); simulators noted as follow-up

### Homepage
- Hero height ~68vh with dual-pane **sync preview** animation
- Featured Lexical card vs compact **Experiments** list

### Tests
- Unit: sync status labels + room link helpers
- E2E expectations updated for new copy/CTAs
- `pnpm --filter playground typecheck` and unit tests pass

## Test plan
- [ ] Open `/demo/lexical-eg-walker` — editor fills first viewport; no duplicate EG-walker/WebSocket/schema banners
- [ ] Click Share → copy link toast + open another window syncs text
- [ ] Click sync status → Diagnostics sheet shows transport / pending / storage
- [ ] Toggle Collaboration Lab; export debug trace
- [ ] Solo hint appears with one user, disappears when a peer joins
- [ ] Homepage shows SoftMaple + sync preview above the fold; Featured vs Experiments
- [ ] `pnpm --filter playground test`
- [ ] `pnpm --filter playground test:e2e` (if WS endpoints available)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dd24a80-09b6-47bb-9c5b-ddbf10a3a522?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dd24a80-09b6-47bb-9c5b-ddbf10a3a522&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the home page with a featured demo, experiment list, animated sync preview, and updated navigation.
  - Added collaboration tools for sharing rooms, opening another window, viewing diagnostics, and inspecting room state.
  - Improved sync status display with clearer connection, persistence, offline, and pending-change indicators.
  - Added options to copy diagnostic reports and clear room-local data.

- **Bug Fixes**
  - Updated synchronization and persistence messaging to accurately reflect current connection and storage states.
  - Improved room-link handling and local-data cleanup while preserving unrelated browser data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->