### PR TITLE
style(apps/playground): dark Motion/Linear/Vercel palette

### DIFF
--- a/apps/playground/src/components/Header.tsx
+++ b/apps/playground/src/components/Header.tsx
@@ -27,10 +27,10 @@ export default function Header() {
 
   return (
     <header
-      className={`sticky top-0 z-40 border-b backdrop-blur-md ${
+      className={`sticky top-0 z-40 border-b backdrop-blur-xl ${
         isHome
-          ? "border-transparent bg-[var(--pg-paper)]/70"
-          : "border-[var(--pg-line)] bg-[var(--pg-paper)]/90"
+          ? "border-transparent bg-[var(--pg-paper)]/55"
+          : "border-[var(--pg-line)] bg-[var(--pg-paper)]/80"
       }`}
     >
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
@@ -88,7 +88,7 @@ export default function Header() {
           <SheetTrigger asChild>
             <button
               type="button"
-              className="rounded-sm p-2 text-[var(--pg-ink)] transition-colors hover:bg-[var(--pg-ink)]/5 md:hidden"
+              className="rounded-sm p-2 text-[var(--pg-ink)] transition-colors hover:bg-[var(--pg-elevated)] md:hidden"
               aria-label="Open menu"
             >
               <Menu size={22} />
@@ -96,7 +96,7 @@ export default function Header() {
           </SheetTrigger>
           <SheetContent
             side="right"
-            className="w-[min(100%,20rem)] gap-0 border-[var(--pg-line)] bg-[var(--pg-paper)] p-0 text-[var(--pg-ink)] sm:max-w-xs"
+            className="w-[min(100%,20rem)] gap-0 border-[var(--pg-line)] bg-[var(--pg-surface)] p-0 text-[var(--pg-ink)] sm:max-w-xs"
           >
             <SheetHeader className="border-b border-[var(--pg-line)] px-4 py-3">
               <SheetTitle className="font-[family-name:var(--font-display)] font-semibold tracking-[-0.02em] text-[var(--pg-ink)]">
@@ -124,7 +124,7 @@ export default function Header() {
                   <SheetClose asChild>
                     <Link
                       to="/"
-                      className="mb-1 block rounded-sm px-3 py-2.5 text-sm font-medium hover:bg-[var(--pg-ink)]/5"
+                      className="mb-1 block rounded-sm px-3 py-2.5 text-sm font-medium hover:bg-[var(--pg-elevated)]"
                     >
                       Home
                     </Link>
@@ -141,7 +141,7 @@ export default function Header() {
                     <SheetClose asChild>
                       <Link
                         to={demo.link}
-                        className="mb-1 block rounded-sm px-3 py-2.5 text-sm hover:bg-[var(--pg-ink)]/5"
+                        className="mb-1 block rounded-sm px-3 py-2.5 text-sm hover:bg-[var(--pg-elevated)]"
                       >
                         <span className="font-[family-name:var(--font-mono)] text-[10px] text-[var(--pg-ink-muted)]">
                           {demo.id}

--- a/apps/playground/src/components/collab-editor/RoomHeader.tsx
+++ b/apps/playground/src/components/collab-editor/RoomHeader.tsx
@@ -92,7 +92,7 @@ export function RoomHeader({
             size="sm"
             variant="ghost"
             onClick={onLeaveRoom}
-            className="border border-[var(--pg-accent)]/30 bg-[var(--pg-accent)]/10 text-[var(--pg-accent)] hover:bg-[var(--pg-accent)] hover:text-white"
+            className="border border-rose-400/30 bg-rose-500/10 text-rose-300 hover:bg-rose-500 hover:text-white"
           >
             <LogOut className="mr-1 h-4 w-4" aria-hidden="true" />
             Leave

--- a/apps/playground/src/components/collab-editor/RoomHeader.tsx
+++ b/apps/playground/src/components/collab-editor/RoomHeader.tsx
@@ -92,7 +92,7 @@ export function RoomHeader({
             size="sm"
             variant="ghost"
             onClick={onLeaveRoom}
-            className="border border-rose-400/30 bg-rose-500/10 text-rose-300 hover:bg-rose-500 hover:text-white"
+            className="border border-rose-400/30 bg-rose-500/10 text-rose-300 hover:bg-rose-700 hover:text-white"
           >
             <LogOut className="mr-1 h-4 w-4" aria-hidden="true" />
             Leave

--- a/apps/playground/src/components/demo.chat-area.tsx
+++ b/apps/playground/src/components/demo.chat-area.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
-import { useChat, useMessages } from "@/hooks/demo.useChat";
 import Messages from "@/components/demo.messages";
+import { useChat, useMessages } from "@/hooks/demo.useChat";
 
 export default function ChatArea() {
   const { sendMessage } = useChat();
@@ -26,36 +26,37 @@ export default function ChatArea() {
 
   return (
     <>
-      <div className="px-4 py-6 space-y-4">
+      <div className="space-y-4 px-4 py-6">
         <Messages messages={messages} user={user} />
       </div>
 
-      <div className="bg-white border-t border-gray-200 px-4 py-4">
+      <div className="border-t border-[var(--pg-line)] bg-[var(--pg-surface)] px-4 py-4">
         <div className="flex items-center space-x-3">
           <select
             value={user}
             onChange={(e) => setUser(e.target.value)}
-            className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="pg-input rounded-md px-3 py-2 text-sm focus:outline-none"
           >
             <option value="Alice">Alice</option>
             <option value="Bob">Bob</option>
           </select>
 
-          <div className="flex-1 relative">
+          <div className="relative flex-1">
             <input
               type="text"
               value={message}
               onChange={(e) => setMessage(e.target.value)}
               onKeyDown={handleKeyPress}
               placeholder="Type a message..."
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="pg-input w-full rounded-md px-4 py-2 focus:outline-none"
             />
           </div>
 
           <button
+            type="button"
             onClick={postMessage}
             disabled={message.trim() === ""}
-            className="px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="pg-btn-primary rounded-md px-6 py-2 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--pg-paper)] disabled:cursor-not-allowed disabled:opacity-50"
           >
             Send
           </button>

--- a/apps/playground/src/components/demo.messages.tsx
+++ b/apps/playground/src/components/demo.messages.tsx
@@ -2,14 +2,14 @@ import type { Message } from "@/db-collections";
 
 export const getAvatarColor = (username: string) => {
   const colors = [
-    "bg-blue-500",
-    "bg-green-500",
-    "bg-purple-500",
-    "bg-pink-500",
-    "bg-indigo-500",
-    "bg-red-500",
-    "bg-yellow-500",
+    "bg-[var(--pg-accent)]",
     "bg-teal-500",
+    "bg-orange-400",
+    "bg-indigo-400",
+    "bg-sky-500",
+    "bg-rose-400",
+    "bg-amber-400",
+    "bg-emerald-500",
   ];
   const index = username
     .split("")
@@ -39,7 +39,7 @@ export default function Messages({
             }`}
           >
             <div
-              className={`w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-medium ${getAvatarColor(
+              className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium text-white ${getAvatarColor(
                 msg.user,
               )}`}
             >
@@ -47,14 +47,14 @@ export default function Messages({
             </div>
 
             <div
-              className={`px-4 py-2 rounded-2xl ${
+              className={`rounded-2xl px-4 py-2 ${
                 msg.user === user
-                  ? "bg-blue-500 text-white rounded-br-md"
-                  : "bg-white text-gray-800 border border-gray-200 rounded-bl-md"
+                  ? "rounded-br-md bg-[var(--pg-accent)] text-white"
+                  : "rounded-bl-md border border-[var(--pg-line)] bg-[var(--pg-elevated)] text-[var(--pg-ink)]"
               }`}
             >
               {msg.user !== user && (
-                <p className="text-xs text-gray-500 mb-1 font-medium">
+                <p className="mb-1 text-xs font-medium text-[var(--pg-ink-muted)]">
                   {msg.user}
                 </p>
               )}

--- a/apps/playground/src/components/demo.messages.tsx
+++ b/apps/playground/src/components/demo.messages.tsx
@@ -3,13 +3,13 @@ import type { Message } from "@/db-collections";
 export const getAvatarColor = (username: string) => {
   const colors = [
     "bg-[var(--pg-accent)]",
-    "bg-teal-500",
-    "bg-orange-400",
-    "bg-indigo-400",
-    "bg-sky-500",
-    "bg-rose-400",
-    "bg-amber-400",
-    "bg-emerald-500",
+    "bg-teal-700",
+    "bg-orange-700",
+    "bg-indigo-700",
+    "bg-sky-700",
+    "bg-rose-700",
+    "bg-amber-700",
+    "bg-emerald-700",
   ];
   const index = username
     .split("")

--- a/apps/playground/src/components/demo/DemoPageShell.tsx
+++ b/apps/playground/src/components/demo/DemoPageShell.tsx
@@ -49,7 +49,7 @@ export function DemoPageShell({
             {showBackLink ? (
               <Link
                 to="/"
-                className="inline-flex items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-surface)] px-3 py-2 text-xs font-semibold text-[var(--pg-ink-muted)] transition-colors hover:border-[var(--pg-ink)] hover:text-[var(--pg-ink)]"
+                className="inline-flex items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-elevated)] px-3 py-2 text-xs font-semibold text-[var(--pg-ink-muted)] transition-colors hover:border-[var(--pg-ink-muted)] hover:text-[var(--pg-ink)]"
               >
                 <ArrowLeft className="size-3.5" aria-hidden />
                 Playground

--- a/apps/playground/src/components/home/DemoList.tsx
+++ b/apps/playground/src/components/home/DemoList.tsx
@@ -33,7 +33,7 @@ export function DemoList() {
               to={demo.link}
               className="group relative flex flex-col gap-4 py-7 transition-colors md:flex-row md:items-start md:gap-8 md:py-9"
             >
-              <span className="absolute inset-x-[-1rem] inset-y-0 -z-10 rounded-sm bg-[var(--pg-surface)] opacity-0 transition-opacity duration-200 group-hover:opacity-100 md:inset-x-[-1.5rem]" />
+              <span className="absolute inset-x-[-1rem] inset-y-0 -z-10 rounded-sm bg-[var(--pg-elevated)] opacity-0 transition-opacity duration-200 group-hover:opacity-100 md:inset-x-[-1.5rem]" />
 
               <span className="font-[family-name:var(--font-mono)] text-sm text-[var(--pg-ink-muted)] tabular-nums">
                 {demo.id}

--- a/apps/playground/src/components/home/HomeHero.tsx
+++ b/apps/playground/src/components/home/HomeHero.tsx
@@ -66,7 +66,7 @@ export function HomeHero() {
             href="https://docs.softmaple.ink"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center border border-[var(--pg-line)] bg-transparent px-7 py-3.5 text-sm font-semibold text-[var(--pg-ink)] transition-colors hover:border-[var(--pg-ink-muted)] hover:bg-[var(--pg-elevated)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
+            className="inline-flex items-center justify-center border border-[var(--pg-line)] bg-[var(--pg-surface)]/60 px-7 py-3.5 text-sm font-semibold text-[var(--pg-ink)] transition-colors hover:border-[var(--pg-ink-muted)] hover:bg-[var(--pg-elevated)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
           >
             Documentation
           </a>

--- a/apps/playground/src/components/home/HomeHero.tsx
+++ b/apps/playground/src/components/home/HomeHero.tsx
@@ -58,7 +58,7 @@ export function HomeHero() {
         >
           <Link
             to="/demo/lexical-eg-walker"
-            className="inline-flex items-center justify-center bg-[var(--pg-ink)] px-7 py-3.5 text-sm font-semibold text-[var(--pg-paper)] transition-transform hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
+            className="inline-flex items-center justify-center bg-[var(--pg-ink)] px-7 py-3.5 text-sm font-semibold text-[var(--pg-paper)] transition-[transform,opacity] hover:-translate-y-0.5 hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
           >
             Open Lexical demo
           </Link>
@@ -66,7 +66,7 @@ export function HomeHero() {
             href="https://docs.softmaple.ink"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center border border-[var(--pg-ink)]/20 bg-transparent px-7 py-3.5 text-sm font-semibold text-[var(--pg-ink)] transition-colors hover:border-[var(--pg-ink)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
+            className="inline-flex items-center justify-center border border-[var(--pg-line)] bg-transparent px-7 py-3.5 text-sm font-semibold text-[var(--pg-ink)] transition-colors hover:border-[var(--pg-ink-muted)] hover:bg-[var(--pg-elevated)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pg-accent)]"
           >
             Documentation
           </a>

--- a/apps/playground/src/components/home/SyncField.tsx
+++ b/apps/playground/src/components/home/SyncField.tsx
@@ -3,7 +3,7 @@ import { motion, useReducedMotion } from "motion/react";
 const cursors = [
   {
     id: "a",
-    color: "#0D9488",
+    color: "#2DD4BF",
     label: "You",
     path: { x: [58, 72, 80, 64, 58], y: [18, 28, 22, 34, 18] },
     duration: 14,
@@ -11,7 +11,7 @@ const cursors = [
   },
   {
     id: "b",
-    color: "#EA580C",
+    color: "#FB923C",
     label: "Alex",
     path: { x: [78, 86, 74, 82, 78], y: [42, 52, 60, 48, 42] },
     duration: 16,
@@ -19,7 +19,7 @@ const cursors = [
   },
   {
     id: "c",
-    color: "#DB2777",
+    color: "#818CF8",
     label: "Sam",
     path: { x: [66, 74, 88, 70, 66], y: [68, 58, 72, 80, 68] },
     duration: 18,
@@ -45,7 +45,19 @@ export function SyncField() {
       className="pointer-events-none absolute inset-0 overflow-hidden"
       aria-hidden
     >
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_78%_32%,rgba(13,148,136,0.16),transparent_50%),radial-gradient(ellipse_at_88%_68%,rgba(234,88,12,0.12),transparent_48%),radial-gradient(ellipse_at_70%_85%,rgba(225,29,72,0.1),transparent_42%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_78%_32%,var(--pg-glow-teal),transparent_52%),radial-gradient(ellipse_at_88%_68%,var(--pg-glow-orange),transparent_48%),radial-gradient(ellipse_at_70%_85%,var(--pg-glow-accent),transparent_42%)]" />
+
+      {/* Soft grid — Motion/Linear product-canvas cue */}
+      <div
+        className="absolute inset-0 opacity-[0.35]"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, color-mix(in srgb, var(--pg-line) 80%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in srgb, var(--pg-line) 80%, transparent) 1px, transparent 1px)",
+          backgroundSize: "64px 64px",
+          maskImage:
+            "radial-gradient(ellipse 70% 80% at 78% 45%, black 20%, transparent 75%)",
+        }}
+      />
 
       <div className="absolute inset-y-0 right-0 w-[58%] max-md:opacity-70">
         <svg
@@ -64,13 +76,13 @@ export function SyncField() {
               y2={line.y2}
               stroke="currentColor"
               strokeWidth="0.2"
-              className="text-[var(--pg-ink)]/20"
+              className="text-[var(--pg-ink)]/25"
               strokeDasharray="1.4 1.1"
               initial={false}
               animate={
                 reduceMotion
                   ? undefined
-                  : { strokeDashoffset: [0, -4], opacity: [0.3, 0.65, 0.3] }
+                  : { strokeDashoffset: [0, -4], opacity: [0.25, 0.7, 0.25] }
               }
               transition={{
                 duration: 6,
@@ -122,13 +134,13 @@ export function SyncField() {
                   <path
                     d="M1 1L16.5 10.2L9.2 12.1L6.8 20.5L1 1Z"
                     fill={cursor.color}
-                    stroke="white"
+                    stroke="#050505"
                     strokeWidth="1.2"
                     strokeLinejoin="round"
                   />
                 </svg>
                 <span
-                  className="absolute left-4 top-4 whitespace-nowrap rounded-sm px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[10px] font-medium text-white"
+                  className="absolute left-4 top-4 whitespace-nowrap rounded-sm px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[10px] font-medium text-[#050505]"
                   style={{ backgroundColor: cursor.color }}
                 >
                   {cursor.label}
@@ -140,7 +152,7 @@ export function SyncField() {
       </div>
 
       <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-[var(--pg-paper)] to-transparent" />
-      <div className="absolute inset-y-0 left-0 w-[42%] bg-gradient-to-r from-[var(--pg-paper)] via-[var(--pg-paper)]/80 to-transparent max-md:w-[55%]" />
+      <div className="absolute inset-y-0 left-0 w-[42%] bg-gradient-to-r from-[var(--pg-paper)] via-[var(--pg-paper)]/85 to-transparent max-md:w-[55%]" />
     </div>
   );
 }

--- a/apps/playground/src/components/home/SyncField.tsx
+++ b/apps/playground/src/components/home/SyncField.tsx
@@ -19,7 +19,7 @@ const cursors = [
   },
   {
     id: "c",
-    color: "#818CF8",
+    color: "#FB7185",
     label: "Sam",
     path: { x: [66, 74, 88, 70, 66], y: [68, 58, 72, 80, 68] },
     duration: 18,

--- a/apps/playground/src/lib/demos.ts
+++ b/apps/playground/src/lib/demos.ts
@@ -17,7 +17,7 @@ export const demos: ReadonlyArray<DemoItem> = [
       "Rich-text collaboration with Lexical, block-model CRDT, WebSocket document sync, and live presence. Open the same room in two browsers to verify.",
     link: "/demo/lexical-eg-walker",
     badge: "WebSocket",
-    accent: "#0D9488",
+    accent: "#2DD4BF",
   },
   {
     id: "02",
@@ -26,7 +26,7 @@ export const demos: ReadonlyArray<DemoItem> = [
       "Create or join rooms and sync plain-text editing over WebSocket. Share the room link to collaborate across browsers.",
     link: "/demo/online-collab-editor",
     badge: "WebSocket",
-    accent: "#EA580C",
+    accent: "#FB923C",
   },
   {
     id: "03",
@@ -34,7 +34,7 @@ export const demos: ReadonlyArray<DemoItem> = [
     description:
       "Pick a Pokémon trainer and collaborate with live cursors, selection highlights, and presence indicators from @softmaple/awareness.",
     link: "/demo/awareness-collab",
-    accent: "#DB2777",
+    accent: "#818CF8",
   },
   {
     id: "04",
@@ -42,7 +42,7 @@ export const demos: ReadonlyArray<DemoItem> = [
     description:
       "Side-by-side text editors powered by the Eg-Walker CRDT. Type in either panel to see instant local synchronization.",
     link: "/demo/collaborative-editor",
-    accent: "#2563EB",
+    accent: "#60A5FA",
   },
   {
     id: "05",
@@ -50,6 +50,6 @@ export const demos: ReadonlyArray<DemoItem> = [
     description:
       "Independent text editors side-by-side. Useful for comparing drafts, note-taking, or dual-language editing.",
     link: "/demo/two-panel-editor",
-    accent: "#7C3AED",
+    accent: "#A78BFA",
   },
 ];

--- a/apps/playground/src/lib/demos.ts
+++ b/apps/playground/src/lib/demos.ts
@@ -34,7 +34,7 @@ export const demos: ReadonlyArray<DemoItem> = [
     description:
       "Pick a Pokémon trainer and collaborate with live cursors, selection highlights, and presence indicators from @softmaple/awareness.",
     link: "/demo/awareness-collab",
-    accent: "#818CF8",
+    accent: "#FB7185",
   },
   {
     id: "04",

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
@@ -168,7 +168,7 @@ export function LexicalEgWalkerDemo({
         </div>
         <a
           href="/"
-          className="inline-flex shrink-0 items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-surface)] px-2.5 py-2 text-xs font-semibold text-[var(--pg-ink-muted)] outline-none transition-colors hover:border-[var(--pg-ink)] hover:text-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+          className="inline-flex shrink-0 items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-elevated)] px-2.5 py-2 text-xs font-semibold text-[var(--pg-ink-muted)] outline-none transition-colors hover:border-[var(--pg-ink-muted)] hover:text-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
         >
           <ArrowLeft className="size-3.5" />
           <span className="hidden sm:inline">Playground</span>
@@ -179,7 +179,7 @@ export function LexicalEgWalkerDemo({
         <div className="pg-panel relative flex min-h-[540px] w-full flex-col overflow-hidden">
           <div className="pg-panel-header flex items-center justify-between px-4 py-2 font-[family-name:var(--font-mono)] text-[10px] font-medium tracking-[0.14em] text-[var(--pg-ink-muted)] uppercase">
             <span>Collaborative manuscript</span>
-            <span className="inline-flex items-center gap-1.5 text-teal-700">
+            <span className="inline-flex items-center gap-1.5 text-teal-400">
               <ShieldCheck className="size-3.5" />
               v1 schema
             </span>
@@ -233,7 +233,7 @@ export function LexicalEgWalkerDemo({
           {visibleError !== null ? (
             <div
               role="alert"
-              className="border-t border-rose-200 bg-rose-50 px-4 py-2 text-xs text-rose-800"
+              className="border-t border-rose-400/25 bg-rose-500/10 px-4 py-2 text-xs text-rose-300"
             >
               {visibleError.message}
             </div>

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
@@ -107,15 +107,15 @@ const StatusItem = ({
 }) => {
   const toneClass =
     tone === "danger"
-      ? "text-rose-700"
+      ? "text-rose-400"
       : tone === "warn"
-        ? "text-amber-700"
+        ? "text-amber-400"
         : "text-[var(--pg-ink-muted)]";
   const iconClass =
     tone === "danger"
-      ? "text-rose-500"
+      ? "text-rose-400"
       : tone === "warn"
-        ? "text-amber-500"
+        ? "text-amber-400"
         : "text-[var(--pg-accent)]";
 
   return (
@@ -144,7 +144,7 @@ export function StatusRail({
     persistenceState === "saved" ? (
       <Check className="size-3.5" />
     ) : persistenceState === "unsaved" ? (
-      <CloudOff className="size-3.5 text-rose-500" />
+      <CloudOff className="size-3.5 text-rose-400" />
     ) : (
       <LoaderCircle className="size-3.5 motion-safe:animate-spin" />
     );
@@ -169,7 +169,7 @@ export function StatusRail({
   return (
     // biome-ignore lint/a11y/useSemanticElements: transport status live region; <output> is for form-calculated values.
     <div
-      className="relative z-20 flex min-h-10 flex-wrap items-center gap-x-4 gap-y-2 border-b border-[var(--pg-line)] bg-[var(--pg-surface)]/92 px-3 py-2 font-[family-name:var(--font-mono)] text-[11px] font-medium tracking-[0.02em] text-[var(--pg-ink-muted)] backdrop-blur md:px-5"
+      className="relative z-20 flex min-h-10 flex-wrap items-center gap-x-4 gap-y-2 border-b border-[var(--pg-line)] bg-[var(--pg-surface)]/90 px-3 py-2 font-[family-name:var(--font-mono)] text-[11px] font-medium tracking-[0.02em] text-[var(--pg-ink-muted)] backdrop-blur-xl md:px-5"
       data-testid="collaboration-status"
       data-transport={transportMode}
       data-connection-state={connectionState}
@@ -178,11 +178,11 @@ export function StatusRail({
     >
       <span
         aria-hidden
-        className="absolute inset-y-0 left-0 w-[3px] bg-gradient-to-b from-[var(--pg-accent)] via-teal-500 to-orange-500"
+        className="absolute inset-y-0 left-0 w-[3px] bg-gradient-to-b from-[var(--pg-accent)] via-teal-400 to-orange-400"
       />
       <button
         type="button"
-        className="group inline-flex max-w-48 items-center gap-1.5 px-1.5 py-1 text-[var(--pg-ink)] outline-none transition-colors hover:bg-[var(--pg-paper)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
+        className="group inline-flex max-w-48 items-center gap-1.5 px-1.5 py-1 text-[var(--pg-ink)] outline-none transition-colors hover:bg-[var(--pg-elevated)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
         onClick={onCopyRoomLink}
         aria-label={`Copy link for room ${roomId}`}
       >
@@ -195,7 +195,7 @@ export function StatusRail({
       </StatusItem>
       {isReconnectWarningState(connectionState) &&
       transportMode === "websocket" ? (
-        <span className="border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-800">
+        <span className="border border-amber-400/25 bg-amber-400/10 px-2 py-0.5 text-[10px] font-semibold text-amber-300">
           Sync paused until reconnect
         </span>
       ) : null}

--- a/apps/playground/src/routes/__root.tsx
+++ b/apps/playground/src/routes/__root.tsx
@@ -36,7 +36,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       },
       {
         name: "theme-color",
-        content: "#f4f4f5",
+        content: "#050505",
       },
     ],
     links: [
@@ -62,7 +62,7 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <head>
         <HeadContent />
       </head>

--- a/apps/playground/src/routes/__root.tsx
+++ b/apps/playground/src/routes/__root.tsx
@@ -69,7 +69,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       <body className="bg-[var(--pg-paper)] text-[var(--pg-ink)] antialiased">
         <Header />
         {children}
-        <Toaster position="bottom-right" />
+        <Toaster theme="dark" position="bottom-right" />
         <TanStackDevtools
           config={{
             position: "bottom-right",

--- a/apps/playground/src/routes/demo/collaborative-editor.tsx
+++ b/apps/playground/src/routes/demo/collaborative-editor.tsx
@@ -29,7 +29,7 @@ function CollaborativeEditor() {
       labelId: "replica-2-label",
       testId: "replica-2",
       placeholder: "Start typing in Replica 2...",
-      focusRingClassName: "focus-visible:ring-teal-600",
+      focusRingClassName: "focus-visible:ring-teal-400",
     },
   ];
 

--- a/apps/playground/src/routes/demo/db-chat.tsx
+++ b/apps/playground/src/routes/demo/db-chat.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute("/demo/db-chat")({
 
 function App() {
   return (
-    <div className="flex flex-col h-screen bg-gray-50">
+    <div className="flex h-screen flex-col bg-[var(--pg-paper)] text-[var(--pg-ink)]">
       <ChatArea />
     </div>
   );

--- a/apps/playground/src/styles.css
+++ b/apps/playground/src/styles.css
@@ -19,16 +19,16 @@
    * near-black canvas, cool elevated surfaces, quiet hairlines, indigo accent.
    */
   --pg-paper: #050505;
-  --pg-surface: #0e0e11;
-  --pg-elevated: #16161a;
+  --pg-surface: #121216;
+  --pg-elevated: #1a1a20;
   --pg-ink: #ededed;
   --pg-ink-muted: #8b8b96;
-  --pg-line: #222228;
+  --pg-line: #2a2a32;
   --pg-accent: #5e6ad2;
   --pg-accent-soft: color-mix(in srgb, var(--pg-accent) 18%, transparent);
-  --pg-glow-teal: rgba(45, 212, 191, 0.14);
-  --pg-glow-orange: rgba(251, 146, 60, 0.11);
-  --pg-glow-accent: rgba(94, 106, 210, 0.16);
+  --pg-glow-teal: rgba(45, 212, 191, 0.16);
+  --pg-glow-orange: rgba(251, 146, 60, 0.12);
+  --pg-glow-accent: rgba(94, 106, 210, 0.2);
 }
 
 body {
@@ -52,6 +52,9 @@ code {
 .pg-panel {
   background: var(--pg-surface);
   border: 1px solid var(--pg-line);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--pg-ink) 2%, transparent),
+    0 24px 48px -24px rgba(0, 0, 0, 0.55);
 }
 
 .pg-panel-header {

--- a/apps/playground/src/styles.css
+++ b/apps/playground/src/styles.css
@@ -16,7 +16,7 @@
 
   /*
    * SoftMaple Playground — dark-first palette mixed from Motion / Linear / Vercel:
-   * near-black canvas, cool elevated surfaces, quiet hairlines, indigo accent.
+   * near-black canvas, cool elevated surfaces, quiet hairlines, rose accent.
    */
   --pg-paper: #050505;
   --pg-surface: #121216;
@@ -25,7 +25,6 @@
   --pg-ink-muted: #8b8b96;
   --pg-line: #2a2a32;
   --pg-accent: #e11d48;
-  --pg-accent-soft: color-mix(in srgb, var(--pg-accent) 18%, transparent);
   --pg-glow-teal: rgba(45, 212, 191, 0.16);
   --pg-glow-orange: rgba(251, 146, 60, 0.12);
   --pg-glow-accent: rgba(225, 29, 72, 0.18);
@@ -148,6 +147,7 @@ code {
 /* Dark-first shadcn tokens (playground is always dark) */
 :root,
 .dark {
+  color-scheme: dark;
   --background: oklch(0.145 0.005 286);
   --foreground: oklch(0.96 0.002 286);
   --card: oklch(0.18 0.006 286);
@@ -232,7 +232,6 @@ code {
     background-image:
       radial-gradient(ellipse 80% 50% at 50% -20%, var(--pg-glow-accent), transparent 55%),
       radial-gradient(ellipse 40% 30% at 100% 0%, var(--pg-glow-teal), transparent 50%);
-    background-attachment: fixed;
   }
   ::selection {
     background: color-mix(in srgb, var(--pg-accent) 40%, transparent);

--- a/apps/playground/src/styles.css
+++ b/apps/playground/src/styles.css
@@ -14,13 +14,21 @@
   --font-body: "DM Sans", sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
 
-  /* Playground Motion-inspired tokens */
-  --pg-paper: #f4f4f5;
-  --pg-surface: #ffffff;
-  --pg-ink: #0b0b0b;
-  --pg-ink-muted: #5c5c5c;
-  --pg-line: #e4e4e7;
-  --pg-accent: #e11d48;
+  /*
+   * SoftMaple Playground — dark-first palette mixed from Motion / Linear / Vercel:
+   * near-black canvas, cool elevated surfaces, quiet hairlines, indigo accent.
+   */
+  --pg-paper: #050505;
+  --pg-surface: #0e0e11;
+  --pg-elevated: #16161a;
+  --pg-ink: #ededed;
+  --pg-ink-muted: #8b8b96;
+  --pg-line: #222228;
+  --pg-accent: #5e6ad2;
+  --pg-accent-soft: color-mix(in srgb, var(--pg-accent) 18%, transparent);
+  --pg-glow-teal: rgba(45, 212, 191, 0.14);
+  --pg-glow-orange: rgba(251, 146, 60, 0.11);
+  --pg-glow-accent: rgba(94, 106, 210, 0.16);
 }
 
 body {
@@ -48,24 +56,28 @@ code {
 
 .pg-panel-header {
   border-bottom: 1px solid var(--pg-line);
-  background: color-mix(in srgb, var(--pg-paper) 70%, white);
+  background: color-mix(in srgb, var(--pg-elevated) 70%, var(--pg-paper));
 }
 
 .pg-panel-footer {
   border-top: 1px solid var(--pg-line);
-  background: color-mix(in srgb, var(--pg-paper) 70%, white);
+  background: color-mix(in srgb, var(--pg-elevated) 70%, var(--pg-paper));
 }
 
 .pg-input {
   border: 1px solid var(--pg-line);
-  background: var(--pg-surface);
+  background: var(--pg-elevated);
   color: var(--pg-ink);
+}
+
+.pg-input::placeholder {
+  color: color-mix(in srgb, var(--pg-ink-muted) 80%, transparent);
 }
 
 .pg-input:focus-visible {
   outline: 2px solid var(--pg-accent);
   outline-offset: 1px;
-  border-color: var(--pg-ink);
+  border-color: color-mix(in srgb, var(--pg-accent) 55%, var(--pg-line));
 }
 
 .pg-btn-primary {
@@ -75,7 +87,7 @@ code {
 }
 
 .pg-btn-primary:hover:not(:disabled) {
-  opacity: 0.9;
+  opacity: 0.92;
 }
 
 .pg-btn-primary:disabled {
@@ -89,8 +101,9 @@ code {
 }
 
 .pg-btn-ghost:hover {
-  border-color: var(--pg-ink);
+  border-color: color-mix(in srgb, var(--pg-ink) 35%, var(--pg-line));
   color: var(--pg-ink);
+  background: color-mix(in srgb, var(--pg-elevated) 60%, transparent);
 }
 
 .pg-btn-accent {
@@ -107,7 +120,7 @@ code {
   background: linear-gradient(
     90deg,
     var(--pg-line) 0%,
-    color-mix(in srgb, var(--pg-line) 40%, white) 50%,
+    color-mix(in srgb, var(--pg-line) 35%, var(--pg-ink-muted)) 50%,
     var(--pg-line) 100%
   );
   background-size: 200% 100%;
@@ -129,75 +142,42 @@ code {
   }
 }
 
-:root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.871 0.006 286.286);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.871 0.006 286.286);
-}
-
+/* Dark-first shadcn tokens (playground is always dark) */
+:root,
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.141 0.005 285.823);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.141 0.005 285.823);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
-  --border: oklch(0.274 0.006 286.033);
-  --input: oklch(0.274 0.006 286.033);
-  --ring: oklch(0.442 0.017 285.786);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.274 0.006 286.033);
-  --sidebar-ring: oklch(0.442 0.017 285.786);
+  --background: oklch(0.145 0.005 286);
+  --foreground: oklch(0.96 0.002 286);
+  --card: oklch(0.18 0.006 286);
+  --card-foreground: oklch(0.96 0.002 286);
+  --popover: oklch(0.18 0.006 286);
+  --popover-foreground: oklch(0.96 0.002 286);
+  --primary: oklch(0.96 0.002 286);
+  --primary-foreground: oklch(0.145 0.005 286);
+  --secondary: oklch(0.24 0.008 286);
+  --secondary-foreground: oklch(0.96 0.002 286);
+  --muted: oklch(0.24 0.008 286);
+  --muted-foreground: oklch(0.68 0.015 286);
+  --accent: oklch(0.24 0.008 286);
+  --accent-foreground: oklch(0.96 0.002 286);
+  --destructive: oklch(0.55 0.2 25);
+  --destructive-foreground: oklch(0.78 0.12 25);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.55 0.12 275);
+  --chart-1: oklch(0.55 0.18 275);
+  --chart-2: oklch(0.7 0.14 165);
+  --chart-3: oklch(0.77 0.14 70);
+  --chart-4: oklch(0.62 0.2 310);
+  --chart-5: oklch(0.65 0.18 20);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.17 0.006 286);
+  --sidebar-foreground: oklch(0.96 0.002 286);
+  --sidebar-primary: oklch(0.55 0.18 275);
+  --sidebar-primary-foreground: oklch(0.98 0 0);
+  --sidebar-accent: oklch(0.24 0.008 286);
+  --sidebar-accent-foreground: oklch(0.96 0.002 286);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.55 0.12 275);
 }
 
 @theme inline {
@@ -245,6 +225,14 @@ code {
   }
   body {
     background-color: var(--pg-paper);
+    color: var(--pg-ink);
+    background-image:
+      radial-gradient(ellipse 80% 50% at 50% -20%, var(--pg-glow-accent), transparent 55%),
+      radial-gradient(ellipse 40% 30% at 100% 0%, var(--pg-glow-teal), transparent 50%);
+    background-attachment: fixed;
+  }
+  ::selection {
+    background: color-mix(in srgb, var(--pg-accent) 40%, transparent);
     color: var(--pg-ink);
   }
 }

--- a/apps/playground/src/styles.css
+++ b/apps/playground/src/styles.css
@@ -24,11 +24,11 @@
   --pg-ink: #ededed;
   --pg-ink-muted: #8b8b96;
   --pg-line: #2a2a32;
-  --pg-accent: #5e6ad2;
+  --pg-accent: #e11d48;
   --pg-accent-soft: color-mix(in srgb, var(--pg-accent) 18%, transparent);
   --pg-glow-teal: rgba(45, 212, 191, 0.16);
   --pg-glow-orange: rgba(251, 146, 60, 0.12);
-  --pg-glow-accent: rgba(94, 106, 210, 0.2);
+  --pg-glow-accent: rgba(225, 29, 72, 0.18);
 }
 
 body {
@@ -166,8 +166,8 @@ code {
   --destructive-foreground: oklch(0.78 0.12 25);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 12%);
-  --ring: oklch(0.55 0.12 275);
-  --chart-1: oklch(0.55 0.18 275);
+  --ring: oklch(0.55 0.2 15);
+  --chart-1: oklch(0.58 0.22 15);
   --chart-2: oklch(0.7 0.14 165);
   --chart-3: oklch(0.77 0.14 70);
   --chart-4: oklch(0.62 0.2 310);
@@ -175,12 +175,12 @@ code {
   --radius: 0.5rem;
   --sidebar: oklch(0.17 0.006 286);
   --sidebar-foreground: oklch(0.96 0.002 286);
-  --sidebar-primary: oklch(0.55 0.18 275);
+  --sidebar-primary: oklch(0.58 0.22 15);
   --sidebar-primary-foreground: oklch(0.98 0 0);
   --sidebar-accent: oklch(0.24 0.008 286);
   --sidebar-accent-foreground: oklch(0.96 0.002 286);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.55 0.12 275);
+  --sidebar-ring: oklch(0.55 0.2 15);
 }
 
 @theme inline {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switches SoftMaple Playground to a dark-first palette inspired by Motion / Linear / Vercel, then retunes chrome so panels, hero, status rail, and demos read correctly on near-black.

### Palette
- Canvas `#050505`, surface `#121216`, elevated `#1a1a20`
- Ink `#ededed` / muted `#8b8b96`, hairline `#2a2a32`
- Accent rose `#e11d48` with soft teal/orange/rose glows

### UI polish
- Hero SyncField: dark glows, soft grid, brighter cursor accents
- Header / sheet / demo shells use elevated surfaces
- Status rail + Lexical error/warn tones adapted for dark
- Chat demo + leave-room danger styling aligned to tokens
- `html.dark` + dark shadcn tokens + `color-scheme: dark`; `theme-color` → `#050505`
- Review follow-ups: dark Toaster theme, darker avatar fills, Leave `hover:bg-rose-700`

### Screenshots

[Home hero](https://cursor.com/agents/bc-8bf2c2a5-1b93-44a0-a54d-7586ddd0871b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayground-home-hero.png)
[Demos list](https://cursor.com/agents/bc-8bf2c2a5-1b93-44a0-a54d-7586ddd0871b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayground-demos-list.png)
[Lexical demo](https://cursor.com/agents/bc-8bf2c2a5-1b93-44a0-a54d-7586ddd0871b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayground-lexical-demo.png)
[Awareness trainer picker](https://cursor.com/agents/bc-8bf2c2a5-1b93-44a0-a54d-7586ddd0871b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayground-awareness-collab.png)

## Test plan
- [x] Home hero + demos list look dark on desktop
- [x] Lexical EG-walker room: status rail, editor panel
- [x] Awareness trainer picker readable
- [x] Unit tests + typecheck — passed after review fixes
- [ ] Spot-check rose accent on hero “Playground” word + focus rings
- [ ] Spot-check sheet nav on mobile viewport


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bf2c2a5-1b93-44a0-a54d-7586ddd0871b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bf2c2a5-1b93-44a0-a54d-7586ddd0871b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed the playground with a cohesive dark-first visual theme.
  * Improved header, navigation, buttons, forms, panels, and page backgrounds with updated contrast, blur, borders, and hover states.
  * Updated chat messages, avatars, collaboration cursors, status indicators, and alerts for clearer dark-theme presentation.
  * Refined demo accents, focus rings, links, and call-to-action styling.
  * Updated the leave action with rose-colored visual states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->