### PR TITLE
fix(packages/eg-walker): stop deferred typed-run batch over-coalescing

### DIFF
--- a/packages/eg-walker/src/engine/eg-walker-engine.ts
+++ b/packages/eg-walker/src/engine/eg-walker-engine.ts
@@ -909,6 +909,12 @@ export class EgWalkerEngine {
    * the shared record once. EventItemIndex resolves every skipped canonical
    * ID through the run interval and RecordSplitter materializes interior
    * anchors only if a later branch or delete needs them.
+   *
+   * The batch path must mirror {@link applyInsert}'s empty-conflict-region
+   * gate: a concurrent retreated sibling can sit after the tail without
+   * becoming `tail.originRight`, and scalar coalescing refuses to extend in
+   * that case. Requiring {@link IndexedSequence.isLast} keeps deferred
+   * typed-run spans identical to eager per-event records.
    */
   private extendObjectInsertRun(
     events: ReadonlyArray<GraphEvent>,
@@ -920,7 +926,8 @@ export class EgWalkerEngine {
       tail === null ||
       typeof tail.content !== "string" ||
       tail.run === null ||
-      tail.originRight !== null
+      tail.originRight !== null ||
+      !this.sequence.isLast(tail)
     ) {
       return startEventIndex;
     }
@@ -1583,7 +1590,8 @@ export class EgWalkerEngine {
       tail === null ||
       typeof tail.content !== "string" ||
       tail.run === null ||
-      tail.originRight !== null
+      tail.originRight !== null ||
+      !this.sequence.isLast(tail)
     ) {
       return startOrderIndex;
     }

--- a/packages/eg-walker/src/test/property/deferred-text-materialization.property.test.ts
+++ b/packages/eg-walker/src/test/property/deferred-text-materialization.property.test.ts
@@ -54,6 +54,64 @@ describe("property: deferred cold-replay text materialization", () => {
     );
   });
 
+  it("should not batch-extend a typed run past a concurrent retreated sibling", () => {
+    // Arrange — shrunk from seed 181972193. Concurrent dave:0 sits after
+    // alice:0 in sequence order while retreated from alice's prepare view;
+    // deferred batch extension must not absorb alice:1 into alice:0.
+    const params = {
+      initialText: "",
+      scripts: [
+        {
+          replicaId: "carol",
+          edits: [
+            { kind: "insert" as const, offsetSeed: 0, text: " " },
+            { kind: "delete" as const, offsetSeed: 0, lengthSeed: 0 },
+          ],
+        },
+        {
+          replicaId: "alice",
+          edits: [
+            { kind: "insert" as const, offsetSeed: 0, text: " " },
+            { kind: "insert" as const, offsetSeed: 0.5, text: " " },
+          ],
+        },
+        {
+          replicaId: "dave",
+          edits: [
+            { kind: "delete" as const, offsetSeed: 0, lengthSeed: 0 },
+            { kind: "insert" as const, offsetSeed: 0, text: " " },
+          ],
+        },
+      ],
+      syncEveryN: 7,
+    };
+    const trace = runTrace(params);
+    const graph = EventGraph.fromEvents(trace.events);
+    const eventOrder = graph.getBranchPreservingTopologicalOrder();
+
+    // Act
+    const eagerEngine = new EgWalkerEngine();
+    const eager = eagerEngine.generate(eventOrder, params.initialText, {
+      eventGraph: graph,
+      eventOrder,
+    });
+    const deferredEngine = new EgWalkerEngine();
+    const deferred = deferredEngine.generate(eventOrder, params.initialText, {
+      eventGraph: graph,
+      eventOrder,
+      collectTransformedOperations: false,
+    });
+
+    // Assert
+    expect(deferred.text).toBe(eager.text);
+    expect(deferredEngine.getSequenceRecords()).toEqual(
+      eagerEngine.getSequenceRecords(),
+    );
+    expect(deferredEngine.getDeleteTargetRecords()).toEqual(
+      eagerEngine.getDeleteTargetRecords(),
+    );
+  });
+
   it("should match eager replay for every generated concurrent trace", () => {
     fc.assert(
       fc.property(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deferred cold replay was batch-extending typed-run insert chains past concurrent retreated siblings that still sit after the tail in sequence order. Scalar `applyInsert` refuses that case (empty conflict-region / last-in-sequence), but `extendObjectInsertRun` / `extendPackedInsertRun` only checked `tail.originRight`, so deferred records could merge events that eager replay kept separate.

- Require `sequence.isLast(tail)` before object and packed batch typed-run extension
- Pin the CI counterexample (`seed: 181972193`) as a regression test

## Validation

- `pnpm --filter @softmaple/eg-walker test -- --run` — 731 passed
- `pnpm --filter @softmaple/eg-walker typecheck`
- `pnpm --filter @softmaple/eg-walker lint` — no new issues
- Replayed failing seed `181972193` / path from CI
- Ran the deferred property file 5× with `EG_WALKER_PROPERTY_RUNS=1000`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cc3fddd-8f8e-4a6b-a5cc-80e54785522c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cc3fddd-8f8e-4a6b-a5cc-80e54785522c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed replay batching so typed runs no longer incorrectly extend across concurrent successors.
  * Preserved correct handling of concurrent sibling changes during deferred text materialization.

* **Tests**
  * Added regression coverage verifying that deferred and eager replay produce matching text and sequence results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->