### PR TITLE
fix(apps/web): resolve workspace_members RLS on new workspace create

### DIFF
--- a/apps/web/app/actions/workspaces.ts
+++ b/apps/web/app/actions/workspaces.ts
@@ -4,11 +4,9 @@ import { createClient } from "@/utils/supabase/server";
 import { cache } from "react";
 import { redirect } from "next/navigation";
 import kebabCase from "lodash/kebabCase";
-import { createWorkspaceMember } from "@/app/actions/workspaceMembers";
 import { getUserBy } from "@/app/actions/users";
-import { WorkspaceMemberRole } from "@softmaple/db";
 import type { Workspace } from "@softmaple/db";
-import { WorkspaceMembersType, WorkspacesType } from "@/types/model";
+import { WorkspacesType } from "@/types/model";
 
 export const getWorkspaces = async () => {
   const supabase = await createClient();
@@ -87,20 +85,6 @@ export const handleCreateWorkspaceFormData = async (formData: FormData) => {
     throw new Error(`Failed to create workspace: ${workspaceError.message}`);
   }
 
-  const newWorkspaceMember: WorkspaceMembersType["Insert"] = {
-    workspace_id: newWorkspace.id,
-    user_id: userId,
-    role: WorkspaceMemberRole["OWNER"],
-  };
-
-  const { data: memberData, error: memberError } =
-    await createWorkspaceMember(newWorkspaceMember);
-
-  if (memberError) {
-    throw new Error(
-      `Failed to create workspace member: ${memberError.message}`,
-    );
-  }
-
+  // Owner membership is created by trg_workspaces_create_owner_member.
   redirect(`/workspace/${newWorkspace.slug}`);
 };

--- a/packages/db/prisma/migrations/20260808230400_fix_workspace_owner_membership_rls/migration.sql
+++ b/packages/db/prisma/migrations/20260808230400_fix_workspace_owner_membership_rls/migration.sql
@@ -1,0 +1,53 @@
+-- Creating a workspace must also create the owner's membership row.
+-- Without this, the first workspace_members INSERT ... RETURNING fails RLS:
+-- INSERT is allowed via workspaces.owner_id, but SELECT still requires an
+-- existing membership row (chicken-and-egg with .insert().select()).
+CREATE OR REPLACE FUNCTION private.create_owner_workspace_member()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    INSERT INTO public.workspace_members (
+        workspace_id,
+        user_id,
+        role,
+        created_by,
+        updated_by,
+        invited_by
+    )
+    VALUES (
+        NEW.id,
+        NEW.owner_id,
+        'OWNER',
+        NEW.owner_id,
+        NEW.owner_id,
+        NEW.owner_id
+    )
+    ON CONFLICT (user_id, workspace_id) DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.create_owner_workspace_member() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS trg_workspaces_create_owner_member ON public.workspaces;
+CREATE TRIGGER trg_workspaces_create_owner_member
+    AFTER INSERT ON public.workspaces
+    FOR EACH ROW
+    EXECUTE FUNCTION private.create_owner_workspace_member();
+
+-- Users must be able to read their own membership rows (including RETURNING
+-- after a self-insert when inviting is not going through the owner trigger).
+DROP POLICY IF EXISTS "workspace_members_select_member"
+    ON public.workspace_members;
+CREATE POLICY "workspace_members_select_member" ON public.workspace_members
+    FOR SELECT TO authenticated
+    USING (
+        user_id = (SELECT auth.uid())
+        OR private.is_workspace_member(workspace_id)
+    );
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/db/supabase/scripts/verify-collab-security.sql
+++ b/packages/db/supabase/scripts/verify-collab-security.sql
@@ -10,7 +10,8 @@ BEGIN
             ('20260808230000_create_collab_composite_unique_index'),
             ('20260808230100_add_collab_composite_fk_not_valid'),
             ('20260808230200_validate_collab_composite_fk'),
-            ('20260808230300_harden_auth_profile_trigger')
+            ('20260808230300_harden_auth_profile_trigger'),
+            ('20260808230400_fix_workspace_owner_membership_rls')
     )
     SELECT string_agg(expected.migration_name, ', ' ORDER BY migration_name)
     INTO missing_migrations
@@ -187,6 +188,7 @@ BEGIN
               'trg_documents_update',
               'trg_workspaces_insert',
               'trg_workspaces_update',
+              'trg_workspaces_create_owner_member',
               'trg_workspace_members_insert',
               'trg_workspace_members_update',
               'trg_document_versions_insert',
@@ -194,8 +196,24 @@ BEGIN
               'trg_users_insert',
               'trg_users_update'
           )
-    ) <> 11 THEN
+    ) <> 12 THEN
         RAISE EXCEPTION 'an application trigger is missing';
+    END IF;
+
+    IF to_regprocedure('private.create_owner_workspace_member()') IS NULL THEN
+        RAISE EXCEPTION 'workspace owner membership trigger function is missing';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'workspace_members'
+          AND policyname = 'workspace_members_select_member'
+          AND COALESCE(qual, '') LIKE '%user_id%'
+    ) THEN
+        RAISE EXCEPTION
+            'workspace_members SELECT policy does not allow self-read';
     END IF;
 END;
 $$;

--- a/packages/db/supabase/scripts/verify-collab-security.sql
+++ b/packages/db/supabase/scripts/verify-collab-security.sql
@@ -200,8 +200,18 @@ BEGIN
         RAISE EXCEPTION 'an application trigger is missing';
     END IF;
 
-    IF to_regprocedure('private.create_owner_workspace_member()') IS NULL THEN
-        RAISE EXCEPTION 'workspace owner membership trigger function is missing';
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE NOT tgisinternal
+          AND tgname = 'trg_workspaces_create_owner_member'
+          AND tgrelid = 'public.workspaces'::regclass
+          AND tgfoid = to_regprocedure(
+              'private.create_owner_workspace_member()'
+          )
+    ) THEN
+        RAISE EXCEPTION
+            'trg_workspaces_create_owner_member is missing or miswired on public.workspaces';
     END IF;
 
     IF NOT EXISTS (
@@ -210,7 +220,8 @@ BEGIN
         WHERE schemaname = 'public'
           AND tablename = 'workspace_members'
           AND policyname = 'workspace_members_select_member'
-          AND COALESCE(qual, '') LIKE '%user_id%'
+          AND COALESCE(qual, '') ~
+              'user_id[[:space:]]*=[[:space:]]*\([[:space:]]*SELECT[[:space:]]+auth\.uid\(\)'
     ) THEN
         RAISE EXCEPTION
             'workspace_members SELECT policy does not allow self-read';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes new-user workspace creation failing with:

`Failed to create workspace member: new row violates row-level security policy for table "workspace_members"`

### Cause

After creating a workspace, the app inserted an owner row into `workspace_members` with `.insert().select()`.

- INSERT was allowed via `private.is_workspace_owner()` (`workspaces.owner_id`)
- RETURNING still required `private.is_workspace_member()`, which needs an existing membership row

That chicken-and-egg fails for the first member.

### Fix

- Add `AFTER INSERT` trigger on `workspaces` to create the OWNER membership atomically (`SECURITY DEFINER`)
- Allow `workspace_members` SELECT when `user_id = auth.uid()` (self-read / RETURNING)
- Stop inserting the owner membership from the Next.js server action; the trigger owns that step
- Strengthen `verify-collab-security.sql`:
  - assert `trg_workspaces_create_owner_member` is on `public.workspaces` and calls `private.create_owner_workspace_member()`
  - require the SELECT policy to compare `user_id` with `auth.uid()`, not merely mention `user_id`

### Deploy

```bash
pnpm --filter @softmaple/db db:deploy
pnpm --filter @softmaple/db db:verify:collab-security
```

### Test plan

- [ ] Deploy migration to the target Supabase project
- [ ] Sign in as a new user with no workspaces
- [ ] Create a workspace → should redirect to `/workspace/<slug>` without RLS error
- [ ] Confirm a `workspace_members` OWNER row exists for that user/workspace
- [ ] Run `db:verify:collab-security` after deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e9c936b-36a4-45d5-94c6-e9508083f79b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e9c936b-36a4-45d5-94c6-e9508083f79b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace creators are now automatically assigned owner access when a workspace is created.
  * Improved workspace membership security so members can reliably view their own membership information.
  * Updated collaboration security checks to verify owner assignment and membership access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->