### PR TITLE
fix: resolve core v1 review blockers (gateway, migration, E2E)

### DIFF
--- a/apps/collab/server/routes/document.ts
+++ b/apps/collab/server/routes/document.ts
@@ -114,6 +114,28 @@ const invalidateDocumentAccess = (context: Record<string, unknown>): void => {
   delete context.authorizationExpiresAt;
 };
 
+const countedDocumentIdFromContext = (
+  context: Record<string, unknown>,
+): string | null => {
+  const value = context.countedDocumentId;
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+const releaseDocumentConnection = (
+  context: Record<string, unknown>,
+  documentId: string,
+): void => {
+  if (context.connectionCounted !== true) return;
+  const nextCount = Math.max(
+    0,
+    (documentConnectionCounts.get(documentId) ?? 1) - 1,
+  );
+  if (nextCount === 0) documentConnectionCounts.delete(documentId);
+  else documentConnectionCounts.set(documentId, nextCount);
+  delete context.connectionCounted;
+  delete context.countedDocumentId;
+};
+
 const consumeMessageQuota = (context: Record<string, unknown>): boolean => {
   const now = Date.now();
   const stored = context.messageRateLimit;
@@ -264,6 +286,7 @@ export default defineWebSocketHandler({
         }
         documentConnectionCounts.set(access.documentId, currentConnections + 1);
         peer.context.connectionCounted = true;
+        peer.context.countedDocumentId = access.documentId;
         cacheDocumentAccess(peer.context, access);
         peer.context.credential = credential;
         peer.context.protocolVersion = message.protocolVersion;
@@ -508,21 +531,13 @@ export default defineWebSocketHandler({
       );
     }
     const access = accessFromContext(peer.context);
-    if (access !== null) {
+    const documentId =
+      access?.documentId ?? countedDocumentIdFromContext(peer.context);
+    if (documentId !== null) {
       peer.unsubscribe(
-        topicForDocument(
-          access.documentId,
-          protocolVersionFromContext(peer.context),
-        ),
+        topicForDocument(documentId, protocolVersionFromContext(peer.context)),
       );
-      if (peer.context.connectionCounted === true) {
-        const nextCount = Math.max(
-          0,
-          (documentConnectionCounts.get(access.documentId) ?? 1) - 1,
-        );
-        if (nextCount === 0) documentConnectionCounts.delete(access.documentId);
-        else documentConnectionCounts.set(access.documentId, nextCount);
-      }
+      releaseDocumentConnection(peer.context, documentId);
     }
   },
 });

--- a/apps/collab/test/document-route.test.ts
+++ b/apps/collab/test/document-route.test.ts
@@ -49,6 +49,7 @@ interface TestDocumentRoute {
     readonly context: Record<string, unknown>;
   }>;
   readonly message: (peer: TestPeer, message: TestRawMessage) => Promise<void>;
+  readonly close: (peer: TestPeer) => void;
 }
 
 const route = documentRoute as unknown as TestDocumentRoute;
@@ -81,13 +82,16 @@ const createPeer = (): TestPeer => ({
   unsubscribe: vi.fn(),
 });
 
-const authMessage = (sessionId: string): TestRawMessage => ({
+const authMessage = (
+  sessionId: string,
+  documentId = "00000000-0000-4000-8000-000000000001",
+): TestRawMessage => ({
   text: () =>
     JSON.stringify({
       protocolVersion: COLLAB_PROTOCOL_VERSION,
       type: COLLAB_MESSAGE_TYPE.Auth,
       credential: { kind: "access-token", token: "access-token" },
-      documentId: "00000000-0000-4000-8000-000000000001",
+      documentId,
       sessionId,
     }),
 });
@@ -234,5 +238,49 @@ describe("collaboration document authentication", () => {
     await firstAuth;
 
     expect(peer.context.authenticationPending).toBeUndefined();
+  });
+
+  it("releases the document connection slot when access is cleared before close", async () => {
+    const documentId = "00000000-0000-4000-8000-000000000099";
+    const access = {
+      accessMode: "authenticated" as const,
+      documentId,
+      userId: "00000000-0000-4000-8000-000000000002",
+      role: "EDITOR" as const,
+      canWrite: true as const,
+    };
+    const peers: TestPeer[] = [];
+    for (let index = 0; index < 100; index += 1) {
+      mocks.authorizeDocument.mockResolvedValueOnce(access);
+      const peer = createPeer();
+      await route.message(peer, authMessage(`session-${index}`, documentId));
+      expect(peer.context.connectionCounted).toBe(true);
+      peers.push(peer);
+    }
+
+    mocks.authorizeDocument.mockResolvedValueOnce(access);
+    const blocked = createPeer();
+    await route.message(blocked, authMessage("session-blocked", documentId));
+    expect(blocked.close).toHaveBeenCalledWith(
+      1013,
+      "Document connection limit reached",
+    );
+
+    // Match the revocation path: clear cached access, then close.
+    delete peers[0]?.context.documentAccess;
+    delete peers[0]?.context.authorizationExpiresAt;
+    route.close(peers[0]!);
+
+    mocks.authorizeDocument.mockResolvedValueOnce(access);
+    const replacement = createPeer();
+    await route.message(
+      replacement,
+      authMessage("session-replacement", documentId),
+    );
+    expect(replacement.context.connectionCounted).toBe(true);
+    expect(replacement.close).not.toHaveBeenCalled();
+
+    for (const peer of peers.slice(1)) route.close(peer);
+    route.close(replacement);
   });
 });

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -76,6 +76,11 @@ external WebSocket rewrite path for `proxy.ts`: local HTTP Proxy tests pass,
 but an Upgrade request does not reach the rewrite destination. Do not work
 around this by exposing an unsigned backend URL to the browser.
 
+Playwright starts an Upgrade-capable reverse proxy
+(`scripts/e2e-collab-gateway.mjs`) in front of `next dev` so core E2E can exercise
+HMAC-signed `/collab/document` and `/collab/presence` handshakes locally.
+That proxy is still not a Vercel Preview substitute.
+
 Before promoting a deployment, verify a real Vercel Preview handshake through
 `/collab/document`, direct-backend rejection, reconnect, and repair/resync.
 Also configure a Vercel Firewall rate limit for the public gateway path. See

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,4 +1,15 @@
 import { nextJsConfig } from "@softmaple/eslint-config/next-js";
 
 /** @type {import("eslint").Linter.Config} */
-export default nextJsConfig;
+export default [
+  ...nextJsConfig,
+  {
+    files: ["scripts/**/*.{js,mjs,cjs}"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        process: "readonly",
+      },
+    },
+  },
+];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:e2e": "next dev",
+    "e2e:gateway": "node ./scripts/e2e-collab-gateway.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -10,7 +10,9 @@ const integerPort = (value: string | undefined, fallback: number): number => {
 
 const webPort = integerPort(process.env.E2E_WEB_PORT, 32_110);
 const collabPort = integerPort(process.env.E2E_COLLAB_PORT, 32_111);
+const nextPort = integerPort(process.env.E2E_NEXT_PORT, 32_112);
 const baseURL = `http://127.0.0.1:${webPort}`;
+const nextOrigin = `http://127.0.0.1:${nextPort}`;
 const collabOrigin = `http://127.0.0.1:${collabPort}`;
 const gatewayKeyId = "playwright-2026";
 const gatewaySecret = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8";
@@ -60,7 +62,9 @@ export default defineConfig({
       url: `${collabOrigin}/health`,
     },
     {
-      command: `pnpm exec next dev --port ${webPort}`,
+      // Next remains on an internal port; Upgrade rewrites are not release-
+      // equivalent here, so browsers only talk to the gateway below.
+      command: `pnpm exec next dev --port ${nextPort}`,
       cwd: ".",
       env: {
         ...process.env,
@@ -68,6 +72,21 @@ export default defineConfig({
         COLLAB_GATEWAY_HMAC_KEY_ID: gatewayKeyId,
         COLLAB_GATEWAY_HMAC_SECRET: gatewaySecret,
         NEXT_PUBLIC_APP_URL: baseURL,
+      },
+      reuseExistingServer: false,
+      timeout: 120_000,
+      url: nextOrigin,
+    },
+    {
+      command: "node ./scripts/e2e-collab-gateway.mjs",
+      cwd: ".",
+      env: {
+        ...process.env,
+        E2E_GATEWAY_PORT: String(webPort),
+        E2E_NEXT_ORIGIN: nextOrigin,
+        E2E_COLLAB_ORIGIN: collabOrigin,
+        COLLAB_GATEWAY_HMAC_KEY_ID: gatewayKeyId,
+        COLLAB_GATEWAY_HMAC_SECRET: gatewaySecret,
       },
       reuseExistingServer: false,
       timeout: 120_000,

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -97,6 +97,7 @@ describe("collaboration WebSocket gateway", () => {
   it("rewrites a validated presence room to the presence backend", async () => {
     configureGateway();
     const roomId = "9e2cb8d6-fb45-4daf-8f6e-0e598c82d8c5";
+    const backendTarget = `http://localhost:3002/presence?roomId=${roomId}`;
     const response = await proxy(
       upgradeRequest(
         "https://example.com",
@@ -105,9 +106,14 @@ describe("collaboration WebSocket gateway", () => {
     );
 
     expect(isRewrite(response)).toBe(true);
-    expect(getRewrittenUrl(response)).toBe(
-      `http://localhost:3002/presence?roomId=${roomId}`,
-    );
+    expect(getRewrittenUrl(response)).toBe(backendTarget);
+    const forwarded = overriddenRequestHeaders(response);
+    expect(
+      verifyCollabGatewayAuthRequest(
+        new Request(backendTarget, { method: "GET", headers: forwarded }),
+        parseCollabGatewayKeyring(JSON.stringify({ [KEY_ID]: SECRET })),
+      ),
+    ).toEqual({ ok: true, keyId: KEY_ID });
   });
 
   it.each([

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -129,6 +129,7 @@ const collabGatewayRewrite = (
     authHeaders = createCollabGatewayAuthHeaders({
       config: signerConfig,
       webSocketKey,
+      path: `${backendUrl.pathname}${backendUrl.search}`,
     });
   } catch {
     return badRequest();

--- a/apps/web/scripts/e2e-collab-gateway.mjs
+++ b/apps/web/scripts/e2e-collab-gateway.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Upgrade-capable local gateway for Playwright.
+ *
+ * Stock `next dev` does not forward external WebSocket Upgrade rewrites from
+ * `proxy.ts`. This reverse proxy terminates `/collab/document` and
+ * `/collab/presence` upgrades with the same HMAC signer, then pipes them to
+ * the collab backend. All other traffic is proxied to Next.js.
+ */
+import http from "node:http";
+import {
+  COLLAB_GATEWAY_AUTH_HEADER_NAMES,
+  createCollabGatewayAuthHeaders,
+  parseCollabGatewaySignerConfig,
+} from "@softmaple/collab-gateway-auth";
+
+const DOCUMENT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SENSITIVE_FORWARDED_HEADERS = [
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+];
+
+const requireEnv = (name) => {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+};
+
+const listenPort = Number(requireEnv("E2E_GATEWAY_PORT"));
+const nextOrigin = new URL(requireEnv("E2E_NEXT_ORIGIN"));
+const collabOrigin = new URL(requireEnv("E2E_COLLAB_ORIGIN"));
+const publicOrigin = `http://127.0.0.1:${listenPort}`;
+const signerConfig = parseCollabGatewaySignerConfig(
+  process.env.COLLAB_GATEWAY_HMAC_KEY_ID,
+  process.env.COLLAB_GATEWAY_HMAC_SECRET,
+);
+
+const collabRoutes = new Map([
+  ["/collab/document", { backendPath: "/document", query: "none" }],
+  ["/collab/presence", { backendPath: "/presence", query: "room" }],
+]);
+
+const isWebSocketUpgrade = (req) => {
+  const connectionTokens = (req.headers.connection ?? "")
+    .split(",")
+    .map((token) => token.trim().toLowerCase());
+  return (
+    req.method === "GET" &&
+    req.headers.upgrade?.toLowerCase() === "websocket" &&
+    connectionTokens.includes("upgrade") &&
+    req.headers["sec-websocket-version"] === "13" &&
+    typeof req.headers["sec-websocket-key"] === "string"
+  );
+};
+
+const isSameOriginBrowserRequest = (req) => {
+  const origin = req.headers.origin;
+  if (origin === undefined || origin === "null") return false;
+  try {
+    return new URL(origin).origin === publicOrigin;
+  } catch {
+    return false;
+  }
+};
+
+const hasValidGatewayQuery = (url, queryMode) => {
+  if (queryMode === "none") return url.search === "";
+  const entries = [...url.searchParams.entries()];
+  return (
+    entries.length === 1 &&
+    entries[0]?.[0] === "roomId" &&
+    DOCUMENT_ID_PATTERN.test(entries[0]?.[1] ?? "")
+  );
+};
+
+const writeSocketError = (socket, statusLine) => {
+  socket.write(`HTTP/1.1 ${statusLine}\r\nConnection: close\r\n\r\n`);
+  socket.destroy();
+};
+
+const serializeHeaders = (headers) =>
+  Object.entries(headers)
+    .flatMap(([name, value]) => {
+      if (value === undefined) return [];
+      return Array.isArray(value)
+        ? value.map((entry) => `${name}: ${entry}`)
+        : [`${name}: ${value}`];
+    })
+    .join("\r\n");
+
+const proxyHttp = (req, res, targetOrigin) => {
+  const headers = { ...req.headers, host: targetOrigin.host };
+  const proxyReq = http.request(
+    {
+      protocol: targetOrigin.protocol,
+      hostname: targetOrigin.hostname,
+      port: targetOrigin.port,
+      path: req.url,
+      method: req.method,
+      headers,
+    },
+    (proxyRes) => {
+      res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+      proxyRes.pipe(res);
+    },
+  );
+  proxyReq.on("error", () => {
+    if (!res.headersSent) res.writeHead(502);
+    res.end("Bad gateway");
+  });
+  req.pipe(proxyReq);
+};
+
+const pipeUpgrade = (req, socket, head, targetOrigin, path, headers) => {
+  const proxyReq = http.request({
+    protocol: targetOrigin.protocol,
+    hostname: targetOrigin.hostname,
+    port: targetOrigin.port,
+    path,
+    method: "GET",
+    headers: { ...headers, host: targetOrigin.host },
+  });
+
+  proxyReq.on("upgrade", (proxyRes, proxySocket, proxyHead) => {
+    socket.write(
+      `HTTP/1.1 101 Switching Protocols\r\n${serializeHeaders(proxyRes.headers)}\r\n\r\n`,
+    );
+    if (proxyHead.length > 0) socket.write(proxyHead);
+    if (head.length > 0) proxySocket.write(head);
+    proxySocket.pipe(socket);
+    socket.pipe(proxySocket);
+  });
+
+  proxyReq.on("response", (proxyRes) => {
+    socket.write(
+      `HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n${serializeHeaders(proxyRes.headers)}\r\n\r\n`,
+    );
+    proxyRes.pipe(socket);
+  });
+
+  proxyReq.on("error", () => {
+    socket.destroy();
+  });
+  proxyReq.end();
+};
+
+const server = http.createServer((req, res) => {
+  proxyHttp(req, res, nextOrigin);
+});
+
+server.on("upgrade", (req, socket, head) => {
+  let requestUrl;
+  try {
+    requestUrl = new URL(req.url ?? "/", publicOrigin);
+  } catch {
+    writeSocketError(socket, "400 Bad Request");
+    return;
+  }
+
+  const route = collabRoutes.get(requestUrl.pathname);
+  if (route === undefined) {
+    pipeUpgrade(
+      req,
+      socket,
+      head,
+      nextOrigin,
+      `${requestUrl.pathname}${requestUrl.search}`,
+      { ...req.headers },
+    );
+    return;
+  }
+
+  if (!isWebSocketUpgrade(req) || !hasValidGatewayQuery(requestUrl, route.query)) {
+    writeSocketError(socket, "400 Bad Request");
+    return;
+  }
+  if (!isSameOriginBrowserRequest(req)) {
+    writeSocketError(socket, "403 Forbidden");
+    return;
+  }
+
+  const backendUrl = new URL(route.backendPath, collabOrigin);
+  if (route.query === "room") backendUrl.search = requestUrl.search;
+
+  let authHeaders;
+  try {
+    authHeaders = createCollabGatewayAuthHeaders({
+      config: signerConfig,
+      webSocketKey: req.headers["sec-websocket-key"],
+      path: `${backendUrl.pathname}${backendUrl.search}`,
+    });
+  } catch {
+    writeSocketError(socket, "400 Bad Request");
+    return;
+  }
+
+  const headers = { ...req.headers };
+  for (const header of SENSITIVE_FORWARDED_HEADERS) {
+    delete headers[header];
+  }
+  for (const header of COLLAB_GATEWAY_AUTH_HEADER_NAMES) {
+    delete headers[header];
+  }
+  for (const header of COLLAB_GATEWAY_AUTH_HEADER_NAMES) {
+    const value = authHeaders.get(header);
+    if (value !== null) headers[header] = value;
+  }
+
+  pipeUpgrade(
+    req,
+    socket,
+    head,
+    collabOrigin,
+    `${backendUrl.pathname}${backendUrl.search}`,
+    headers,
+  );
+});
+
+server.listen(listenPort, "127.0.0.1", () => {
+  console.log(
+    `E2E collab gateway on ${publicOrigin} → next ${nextOrigin.origin}, collab ${collabOrigin.origin}`,
+  );
+});

--- a/apps/web/scripts/e2e-collab-gateway.mjs
+++ b/apps/web/scripts/e2e-collab-gateway.mjs
@@ -44,6 +44,13 @@ const collabRoutes = new Map([
   ["/collab/presence", { backendPath: "/presence", query: "room" }],
 ]);
 
+/** Prevent transient proxy socket resets from crashing the gateway process. */
+const swallowStreamError = (stream) => {
+  stream.on("error", () => {
+    stream.destroy();
+  });
+};
+
 const isWebSocketUpgrade = (req) => {
   const connectionTokens = (req.headers.connection ?? "")
     .split(",")
@@ -78,7 +85,12 @@ const hasValidGatewayQuery = (url, queryMode) => {
 };
 
 const writeSocketError = (socket, statusLine) => {
-  socket.write(`HTTP/1.1 ${statusLine}\r\nConnection: close\r\n\r\n`);
+  swallowStreamError(socket);
+  try {
+    socket.write(`HTTP/1.1 ${statusLine}\r\nConnection: close\r\n\r\n`);
+  } catch {
+    // Client may already be gone.
+  }
   socket.destroy();
 };
 
@@ -93,6 +105,9 @@ const serializeHeaders = (headers) =>
     .join("\r\n");
 
 const proxyHttp = (req, res, targetOrigin) => {
+  swallowStreamError(req);
+  swallowStreamError(res);
+
   const headers = { ...req.headers, host: targetOrigin.host };
   const proxyReq = http.request(
     {
@@ -104,18 +119,36 @@ const proxyHttp = (req, res, targetOrigin) => {
       headers,
     },
     (proxyRes) => {
+      swallowStreamError(proxyRes);
+      if (res.writableEnded || res.destroyed) {
+        proxyRes.destroy();
+        return;
+      }
       res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
       proxyRes.pipe(res);
+      res.on("close", () => {
+        if (!proxyRes.destroyed) proxyRes.destroy();
+      });
     },
   );
+  swallowStreamError(proxyReq);
   proxyReq.on("error", () => {
-    if (!res.headersSent) res.writeHead(502);
-    res.end("Bad gateway");
+    if (!res.headersSent && !res.writableEnded) {
+      res.writeHead(502);
+      res.end("Bad gateway");
+      return;
+    }
+    res.destroy();
+  });
+  req.on("aborted", () => {
+    proxyReq.destroy();
   });
   req.pipe(proxyReq);
 };
 
 const pipeUpgrade = (req, socket, head, targetOrigin, path, headers) => {
+  swallowStreamError(socket);
+
   const proxyReq = http.request({
     protocol: targetOrigin.protocol,
     hostname: targetOrigin.hostname,
@@ -124,21 +157,40 @@ const pipeUpgrade = (req, socket, head, targetOrigin, path, headers) => {
     method: "GET",
     headers: { ...headers, host: targetOrigin.host },
   });
+  swallowStreamError(proxyReq);
 
   proxyReq.on("upgrade", (proxyRes, proxySocket, proxyHead) => {
-    socket.write(
-      `HTTP/1.1 101 Switching Protocols\r\n${serializeHeaders(proxyRes.headers)}\r\n\r\n`,
-    );
+    swallowStreamError(proxySocket);
+    try {
+      socket.write(
+        `HTTP/1.1 101 Switching Protocols\r\n${serializeHeaders(proxyRes.headers)}\r\n\r\n`,
+      );
+    } catch {
+      proxySocket.destroy();
+      return;
+    }
     if (proxyHead.length > 0) socket.write(proxyHead);
     if (head.length > 0) proxySocket.write(head);
     proxySocket.pipe(socket);
     socket.pipe(proxySocket);
+    const tearDown = () => {
+      proxySocket.destroy();
+      socket.destroy();
+    };
+    socket.on("close", tearDown);
+    proxySocket.on("close", tearDown);
   });
 
   proxyReq.on("response", (proxyRes) => {
-    socket.write(
-      `HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n${serializeHeaders(proxyRes.headers)}\r\n\r\n`,
-    );
+    swallowStreamError(proxyRes);
+    try {
+      socket.write(
+        `HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n${serializeHeaders(proxyRes.headers)}\r\n\r\n`,
+      );
+    } catch {
+      proxyRes.destroy();
+      return;
+    }
     proxyRes.pipe(socket);
   });
 
@@ -152,7 +204,17 @@ const server = http.createServer((req, res) => {
   proxyHttp(req, res, nextOrigin);
 });
 
+server.on("clientError", (error, socket) => {
+  swallowStreamError(socket);
+  if (error.code === "ECONNRESET" || !socket.writable) {
+    socket.destroy();
+    return;
+  }
+  writeSocketError(socket, "400 Bad Request");
+});
+
 server.on("upgrade", (req, socket, head) => {
+  swallowStreamError(socket);
   let requestUrl;
   try {
     requestUrl = new URL(req.url ?? "/", publicOrigin);
@@ -174,7 +236,10 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
-  if (!isWebSocketUpgrade(req) || !hasValidGatewayQuery(requestUrl, route.query)) {
+  if (
+    !isWebSocketUpgrade(req) ||
+    !hasValidGatewayQuery(requestUrl, route.query)
+  ) {
     writeSocketError(socket, "400 Bad Request");
     return;
   }

--- a/apps/web/scripts/e2e-collab-gateway.mjs
+++ b/apps/web/scripts/e2e-collab-gateway.mjs
@@ -104,11 +104,30 @@ const serializeHeaders = (headers) =>
     })
     .join("\r\n");
 
+const publicHostFromRequest = (req) =>
+  typeof req.headers.host === "string" && req.headers.host.length > 0
+    ? req.headers.host
+    : `127.0.0.1:${listenPort}`;
+
+/**
+ * Headers for upstream Next. Keep the browser-facing Host / forwarded host so
+ * Server Actions CSRF accepts Origin from the public gateway port.
+ */
+const nextProxyHeaders = (req) => {
+  const publicHost = publicHostFromRequest(req);
+  return {
+    ...req.headers,
+    host: publicHost,
+    "x-forwarded-host": publicHost,
+    "x-forwarded-proto": "http",
+    "x-forwarded-port": String(listenPort),
+  };
+};
+
 const proxyHttp = (req, res, targetOrigin) => {
   swallowStreamError(req);
   swallowStreamError(res);
 
-  const headers = { ...req.headers, host: targetOrigin.host };
   const proxyReq = http.request(
     {
       protocol: targetOrigin.protocol,
@@ -116,7 +135,7 @@ const proxyHttp = (req, res, targetOrigin) => {
       port: targetOrigin.port,
       path: req.url,
       method: req.method,
-      headers,
+      headers: nextProxyHeaders(req),
     },
     (proxyRes) => {
       swallowStreamError(proxyRes);
@@ -155,7 +174,7 @@ const pipeUpgrade = (req, socket, head, targetOrigin, path, headers) => {
     port: targetOrigin.port,
     path,
     method: "GET",
-    headers: { ...headers, host: targetOrigin.host },
+    headers,
   });
   swallowStreamError(proxyReq);
 
@@ -171,14 +190,16 @@ const pipeUpgrade = (req, socket, head, targetOrigin, path, headers) => {
     }
     if (proxyHead.length > 0) socket.write(proxyHead);
     if (head.length > 0) proxySocket.write(head);
-    proxySocket.pipe(socket);
-    socket.pipe(proxySocket);
     const tearDown = () => {
       proxySocket.destroy();
       socket.destroy();
     };
-    socket.on("close", tearDown);
+    proxySocket.on("error", tearDown);
+    socket.on("error", tearDown);
     proxySocket.on("close", tearDown);
+    socket.on("close", tearDown);
+    proxySocket.pipe(socket);
+    socket.pipe(proxySocket);
   });
 
   proxyReq.on("response", (proxyRes) => {
@@ -191,6 +212,9 @@ const pipeUpgrade = (req, socket, head, targetOrigin, path, headers) => {
       proxyRes.destroy();
       return;
     }
+    proxyRes.on("error", () => {
+      socket.destroy();
+    });
     proxyRes.pipe(socket);
   });
 
@@ -231,7 +255,7 @@ server.on("upgrade", (req, socket, head) => {
       head,
       nextOrigin,
       `${requestUrl.pathname}${requestUrl.search}`,
-      { ...req.headers },
+      nextProxyHeaders(req),
     );
     return;
   }
@@ -263,7 +287,7 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
-  const headers = { ...req.headers };
+  const headers = { ...req.headers, host: collabOrigin.host };
   for (const header of SENSITIVE_FORWARDED_HEADERS) {
     delete headers[header];
   }

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -138,5 +138,7 @@ Before promotion, verify in a real Preview environment:
 - avatar upload, public delivery, replacement, and removal;
 - a single Collab replica is configured.
 
-The local Next.js dev server is not a release-equivalent test of an external
-WebSocket rewrite, so Preview validation remains a required release gate.
+Playwright's local Upgrade-capable gateway covers signed document and Presence
+handshakes against `next dev`, but it is not a release-equivalent test of the
+Vercel external WebSocket rewrite, so Preview validation remains a required
+release gate.

--- a/docs/development.mdx
+++ b/docs/development.mdx
@@ -139,6 +139,6 @@ Before promotion, verify in a real Preview environment:
 - a single Collab replica is configured.
 
 Playwright's local Upgrade-capable gateway covers signed document and Presence
-handshakes against `next dev`, but it is not a release-equivalent test of the
-Vercel external WebSocket rewrite, so Preview validation remains a required
-release gate.
+handshakes through that gateway (not against `next dev` directly), but it is
+not a release-equivalent test of the Vercel external WebSocket rewrite, so
+Preview validation remains a required release gate.

--- a/packages/collab-gateway-auth/README.md
+++ b/packages/collab-gateway-auth/README.md
@@ -5,7 +5,8 @@ and the Nitro collaboration service. It authenticates a WebSocket upgrade as
 having passed through the trusted web gateway; it does not authenticate the
 user or authorize access to a document.
 
-The canonical payload is UTF-8 with LF separators and no trailing newline:
+The canonical payload is UTF-8 with LF separators and no trailing newline.
+The sixth field is the backend upgrade target (pathname plus query):
 
 ```text
 softmaple-collab-upgrade-v1
@@ -13,9 +14,13 @@ ${keyId}
 ${timestamp}
 ${nonce}
 GET
-/document
+${pathname}${search}
 ${secWebSocketKey}
 ```
+
+Document upgrades use `/document`. Presence upgrades use
+`/presence?roomId=<document-uuid>`. The verifier rejects a signature whose
+bound target does not exactly match the request URL.
 
 Secrets are exactly 32 bytes encoded as unpadded base64url. Signatures use
 HMAC-SHA-256, nonces contain 16 random bytes, and verification accepts a

--- a/packages/collab-gateway-auth/src/index.ts
+++ b/packages/collab-gateway-auth/src/index.ts
@@ -3,7 +3,7 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 const AUTH_VERSION = "1";
 const CANONICAL_PREFIX = "softmaple-collab-upgrade-v1";
 const UPGRADE_METHOD = "GET";
-const UPGRADE_PATH = "/document";
+const DEFAULT_UPGRADE_TARGET = "/document";
 const MAX_CLOCK_SKEW_SECONDS = 30;
 const KEY_BYTE_LENGTH = 32;
 const NONCE_BYTE_LENGTH = 16;
@@ -13,6 +13,8 @@ const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
 const TIMESTAMP_PATTERN = /^(0|[1-9][0-9]{0,12})$/;
 const UNPADDED_BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
 const STANDARD_BASE64_PATTERN = /^[A-Za-z0-9+/]{22}==$/;
+const UPGRADE_TARGET_PATTERN =
+  /^\/[A-Za-z0-9._~!$&'()*+,;=:@%/-]*(?:\?[A-Za-z0-9._~!$&'()*+,;=:@%/?-]*)?$/;
 
 export const COLLAB_GATEWAY_AUTH_HEADERS = Object.freeze({
   version: "x-softmaple-collab-auth-version",
@@ -45,6 +47,8 @@ interface CanonicalPayloadInput {
 interface CreateAuthHeadersInput {
   readonly config: CollabGatewaySignerConfig;
   readonly webSocketKey: string;
+  /** Backend upgrade target: pathname plus query, for example `/presence?roomId=…`. */
+  readonly path?: string;
   readonly nowSeconds?: number;
   readonly nonce?: Uint8Array;
 }
@@ -95,6 +99,31 @@ const isValidWebSocketKey = (value: string): boolean => {
     decoded.byteLength === WEB_SOCKET_KEY_BYTE_LENGTH &&
     decoded.toString("base64") === value
   );
+};
+
+/** Canonical request target bound into the HMAC (pathname + search, no hash). */
+export const collabGatewayUpgradeTarget = (url: URL): string =>
+  `${url.pathname}${url.search}`;
+
+const isValidUpgradeTarget = (path: string): boolean => {
+  if (
+    !UPGRADE_TARGET_PATTERN.test(path) ||
+    path.includes("\\") ||
+    path.includes("..")
+  ) {
+    return false;
+  }
+  try {
+    const parsed = new URL(path, "https://collab.invalid");
+    return (
+      parsed.username === "" &&
+      parsed.password === "" &&
+      parsed.hash === "" &&
+      collabGatewayUpgradeTarget(parsed) === path
+    );
+  } catch {
+    return false;
+  }
 };
 
 const parseTimestamp = (value: string): number | null => {
@@ -199,6 +228,7 @@ const createSignature = (
 export const createCollabGatewayAuthHeaders = ({
   config,
   webSocketKey,
+  path = DEFAULT_UPGRADE_TARGET,
   nowSeconds = Math.floor(Date.now() / 1000),
   nonce = randomBytes(NONCE_BYTE_LENGTH),
 }: CreateAuthHeadersInput): Headers => {
@@ -223,6 +253,11 @@ export const createCollabGatewayAuthHeaders = ({
       "The WebSocket key is invalid",
     );
   }
+  if (!isValidUpgradeTarget(path)) {
+    throw new CollabGatewayAuthConfigurationError(
+      "The collaboration gateway upgrade target is invalid",
+    );
+  }
 
   const timestamp = String(nowSeconds);
   const encodedNonce = Buffer.from(nonce).toString("base64url");
@@ -231,7 +266,7 @@ export const createCollabGatewayAuthHeaders = ({
     timestamp,
     nonce: encodedNonce,
     method: UPGRADE_METHOD,
-    path: UPGRADE_PATH,
+    path,
     webSocketKey,
   });
   const signature = createSignature(config.secret, canonicalPayload);
@@ -257,11 +292,16 @@ export const verifyCollabGatewayAuthRequest = (
   keyring: CollabGatewayKeyring,
   nowSeconds = Math.floor(Date.now() / 1000),
 ): CollabGatewayVerificationResult => {
-  const url = new URL(request.url);
+  let upgradeTarget: string;
+  try {
+    const url = new URL(request.url);
+    upgradeTarget = collabGatewayUpgradeTarget(url);
+  } catch {
+    return invalid("invalid-request");
+  }
   if (
     request.method !== UPGRADE_METHOD ||
-    url.pathname !== UPGRADE_PATH ||
-    url.search !== ""
+    !isValidUpgradeTarget(upgradeTarget)
   ) {
     return invalid("invalid-request");
   }
@@ -309,7 +349,7 @@ export const verifyCollabGatewayAuthRequest = (
     timestamp: timestampValue,
     nonce,
     method: request.method,
-    path: url.pathname,
+    path: upgradeTarget,
     webSocketKey,
   });
   const expectedSignature = Buffer.from(

--- a/packages/collab-gateway-auth/test/index.test.ts
+++ b/packages/collab-gateway-auth/test/index.test.ts
@@ -123,6 +123,33 @@ describe("collaboration gateway HMAC", () => {
     );
   });
 
+  it("accepts a presence upgrade signed for the room query target", () => {
+    const roomId = "9e2cb8d6-fb45-4daf-8f6e-0e598c82d8c5";
+    const path = `/presence?roomId=${roomId}`;
+    const headers = createCollabGatewayAuthHeaders({
+      config: signer,
+      webSocketKey: WEB_SOCKET_KEY,
+      path,
+      nowSeconds: TIMESTAMP,
+      nonce: NONCE,
+    });
+
+    expect(
+      verifyCollabGatewayAuthRequest(
+        signedRequest({ headers, path }),
+        keyring,
+        TIMESTAMP,
+      ),
+    ).toEqual({ ok: true, keyId: KEY_ID });
+    expect(
+      verifyCollabGatewayAuthRequest(
+        signedRequest({ headers, path: `/presence?roomId=${roomId}&extra=1` }),
+        keyring,
+        TIMESTAMP,
+      ).ok,
+    ).toBe(false);
+  });
+
   it.each([
     [COLLAB_GATEWAY_AUTH_HEADERS.version, "2"],
     [COLLAB_GATEWAY_AUTH_HEADERS.keyId, "unknown"],

--- a/packages/db/prisma/migrations/20260809000000_core_v1/migration.sql
+++ b/packages/db/prisma/migrations/20260809000000_core_v1/migration.sql
@@ -10,8 +10,24 @@ ALTER TABLE public.documents
     ALTER COLUMN is_public SET NOT NULL;
 
 -- Preserve legacy bodies/history before dropping them. Refuse to drop live
--- markdown that has not already been represented as CRDT event batches.
+-- markdown unless an offline CRDT replay has recorded a matching content hash.
+-- Prisma runs this migration in a single transaction, so the locks below are
+-- held through validation and DROP COLUMN / DROP TABLE.
 CREATE SCHEMA IF NOT EXISTS archive;
+
+-- Optional pre-migration artifact: after replaying document_event_batches and
+-- comparing reconstructed markdown to documents.markdown_content, insert
+-- (document_id, sha256(utf8 markdown)) here so this migration can proceed.
+CREATE TABLE IF NOT EXISTS archive.markdown_crdt_verified_20260809 (
+    document_id UUID PRIMARY KEY,
+    markdown_sha256 TEXT NOT NULL,
+    verified_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    CONSTRAINT markdown_crdt_verified_20260809_sha_hex
+        CHECK (markdown_sha256 ~ '^[0-9a-f]{64}$')
+);
+
+LOCK TABLE public.documents IN EXCLUSIVE MODE;
+LOCK TABLE public.document_versions IN EXCLUSIVE MODE;
 
 CREATE TABLE IF NOT EXISTS archive.documents_markdown_content_20260809 AS
 SELECT
@@ -45,12 +61,16 @@ BEGIN
           AND btrim(document.markdown_content) <> ''
           AND NOT EXISTS (
               SELECT 1
-              FROM public.document_event_batches AS batch
-              WHERE batch.document_id = document.id
+              FROM archive.markdown_crdt_verified_20260809 AS verified
+              WHERE verified.document_id = document.id
+                AND verified.markdown_sha256 = encode(
+                    sha256(convert_to(document.markdown_content, 'UTF8')),
+                    'hex'
+                )
           )
     ) THEN
         RAISE EXCEPTION
-            'core_v1 refuses to drop markdown_content: non-empty bodies exist without document_event_batches. Backfill CRDT history first; archived rows are in archive.documents_markdown_content_20260809';
+            'core_v1 refuses to drop markdown_content: non-empty bodies lack a matching archive.markdown_crdt_verified_20260809 hash after CRDT replay. Archived snapshot rows are in archive.documents_markdown_content_20260809';
     END IF;
 END
 $$;

--- a/packages/db/prisma/migrations/20260809000000_core_v1/migration.sql
+++ b/packages/db/prisma/migrations/20260809000000_core_v1/migration.sql
@@ -7,7 +7,55 @@ WHERE is_public IS NULL;
 
 ALTER TABLE public.documents
     ALTER COLUMN is_public SET DEFAULT FALSE,
-    ALTER COLUMN is_public SET NOT NULL,
+    ALTER COLUMN is_public SET NOT NULL;
+
+-- Preserve legacy bodies/history before dropping them. Refuse to drop live
+-- markdown that has not already been represented as CRDT event batches.
+CREATE SCHEMA IF NOT EXISTS archive;
+
+CREATE TABLE IF NOT EXISTS archive.documents_markdown_content_20260809 AS
+SELECT
+    document.id AS document_id,
+    document.workspace_id,
+    document.author_id,
+    document.title,
+    document.slug,
+    document.markdown_content,
+    document.created_at,
+    document.updated_at,
+    document.created_by,
+    document.updated_by,
+    clock_timestamp() AS archived_at
+FROM public.documents AS document
+WHERE document.markdown_content IS NOT NULL
+  AND btrim(document.markdown_content) <> '';
+
+CREATE TABLE IF NOT EXISTS archive.document_versions_20260809 AS
+SELECT
+    version.*,
+    clock_timestamp() AS archived_at
+FROM public.document_versions AS version;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM public.documents AS document
+        WHERE document.markdown_content IS NOT NULL
+          AND btrim(document.markdown_content) <> ''
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.document_event_batches AS batch
+              WHERE batch.document_id = document.id
+          )
+    ) THEN
+        RAISE EXCEPTION
+            'core_v1 refuses to drop markdown_content: non-empty bodies exist without document_event_batches. Backfill CRDT history first; archived rows are in archive.documents_markdown_content_20260809';
+    END IF;
+END
+$$;
+
+ALTER TABLE public.documents
     DROP COLUMN markdown_content;
 
 DROP TABLE public.document_versions;

--- a/turbo.json
+++ b/turbo.json
@@ -46,7 +46,11 @@
       "dependsOn": ["^build"],
       "env": [
         "E2E_BASE_URL",
+        "E2E_COLLAB_ORIGIN",
         "E2E_COLLAB_PORT",
+        "E2E_GATEWAY_PORT",
+        "E2E_NEXT_ORIGIN",
+        "E2E_NEXT_PORT",
         "E2E_SEED_SECRET",
         "E2E_WEB_PORT",
         "EG_WALKER_PROPERTY_RUNS",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the four actionable review findings on the core v1 branch:

1. **Presence HMAC signing** — `@softmaple/collab-gateway-auth` now signs and verifies the actual backend upgrade target (`pathname` + `search`), so `/presence?roomId=…` upgrades are accepted instead of failing as `invalid-request`.
2. **Legacy document data** — `20260809000000_core_v1` archives non-empty `markdown_content` and all `document_versions` into `archive.*_20260809`, takes `EXCLUSIVE` locks for the archive→validate→drop window, and refuses to drop markdown unless `archive.markdown_crdt_verified_20260809` contains a matching SHA-256 after offline CRDT replay.
3. **Connection slot leak** — document peers retain `countedDocumentId` so `close` can decrement `documentConnectionCounts` even after access invalidation/revocation.
4. **Upgrade-capable E2E gateway** — Playwright fronts `next dev` with `scripts/e2e-collab-gateway.mjs`, which HMAC-signs `/collab/document` and `/collab/presence` WebSocket upgrades locally (docs clarify handshakes go through that gateway, not directly against `next dev`).

CI follow-ups for that gateway:

- Swallow transient proxy `ECONNRESET`/client aborts so Chromium smoke does not lose `:32110` mid-run.
- Preserve the browser-facing `Host` / `x-forwarded-host` when proxying to Next so Server Actions accept signup POSTs.

## Test plan

- [x] Gateway-auth / collab / proxy unit tests
- [x] Typecheck/lint for touched packages
- [x] Local abort-traffic and Host-forwarding repros for the E2E gateway
- [x] Static assertions for migration fence + docs wording
- [ ] Chromium Smoke CI (`public.spec.ts`)
- [ ] Isolated Supabase E2E when credentials are available

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5547e00-5058-443d-b7bb-0641fb741f10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5547e00-5058-443d-b7bb-0641fb741f10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Collaboration connections are now released correctly when access information is cleared before disconnecting, allowing replacement connections to join at capacity.
  - WebSocket authorization now validates the complete destination, including paths and query parameters, improving protection for document and presence connections.

- **Testing**
  - Added local end-to-end gateway coverage for signed collaboration WebSocket handshakes and request routing.

- **Documentation**
  - Clarified local gateway testing procedures and preview validation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->