### PR TITLE
fix: build Vercel Services via Turborepo dependency graph

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,12 @@
   "services": {
     "web": {
       "root": "apps/web",
-      "framework": "nextjs"
+      "framework": "nextjs",
+      "buildCommand": "cd ../.. && pnpm exec turbo run build --filter=@softmaple/web"
     },
     "collab": {
-      "root": "apps/collab"
+      "root": "apps/collab",
+      "buildCommand": "cd ../.. && pnpm exec turbo run build --filter=@softmaple/collab"
     }
   },
   "rewrites": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes # .

## Summary

Vercel Services builds `apps/web` and `apps/collab` independently. Without a service-level `buildCommand`, each service ran its framework build (`next build` / `nitro build`) without first compiling workspace packages that export `dist/*` (e.g. `@softmaple/md2latex`), which caused:

`Module not found: Can't resolve '@softmaple/md2latex'`

This updates root `vercel.json` so each JavaScript service builds through Turborepo’s dependency graph (`dependsOn: ["^build"]`), while keeping the existing Services routing.

### Config change

Per [Vercel Services docs](https://vercel.com/docs/services) and the [service config reference](https://vercel.com/docs/services/config-reference), `buildCommand` belongs on each service (not top-level) when `services` is present:

- **web:** `cd ../.. && pnpm exec turbo run build --filter=@softmaple/web`
- **collab:** `cd ../.. && pnpm exec turbo run build --filter=@softmaple/collab`

Top-level rewrites for `/collab/(.*)` → collab and `/(.*)` → web are unchanged.

## Test plan

- [x] Confirmed service-level `buildCommand` is documented for Services
- [x] `pnpm exec turbo run build --filter=@softmaple/web --filter=@softmaple/collab` (succeeded; deps including `@softmaple/md2latex` built first)
- [x] Re-ran the same turbo filters from `apps/web` / `apps/collab` via `cd ../..` (cache hit / success)
- [ ] Preview deploy on Vercel Services confirms web no longer fails on workspace package resolution

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c483d153-297c-45bb-825b-231f417d9e99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c483d153-297c-45bb-825b-231f417d9e99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured explicit build commands for the web and collaboration services.
  * Improved deployment builds by targeting only the required service and its dependencies.
  * Preserved the existing Next.js framework configuration for the web service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->