### PR TITLE
fix(apps/web): use browser-safe WebSocket close codes for collab

### DIFF
--- a/apps/web/modules/docs/collab-client-close.test.ts
+++ b/apps/web/modules/docs/collab-client-close.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  closeCollabClientSocket,
+  COLLAB_CLIENT_CLOSE_CODE,
+  isBrowserAllowedWebSocketCloseCode,
+} from "./collab-client-close";
+
+/** Mirrors Chromium's WebSocket.close() close-code validation. */
+const assertBrowserWebSocketCloseCode = (code: number | undefined): void => {
+  if (code === undefined) return;
+  if (code === 1000 || (code >= 3000 && code <= 4999)) return;
+  throw new DOMException(
+    `Failed to execute 'close' on 'WebSocket': The code must be either 1000, or between 3000 and 4999. ${code} is neither.`,
+    "InvalidAccessError",
+  );
+};
+
+describe("COLLAB_CLIENT_CLOSE_CODE", () => {
+  it("should use distinct application codes in the 4000–4999 range", () => {
+    // Arrange
+    const codes = Object.values(COLLAB_CLIENT_CLOSE_CODE);
+
+    // Assert
+    expect(new Set(codes).size).toBe(codes.length);
+    for (const code of codes) {
+      expect(code).toBeGreaterThanOrEqual(4000);
+      expect(code).toBeLessThanOrEqual(4999);
+      expect(isBrowserAllowedWebSocketCloseCode(code)).toBe(true);
+    }
+  });
+
+  it("should be accepted by a browser-faithful WebSocket.close mock", () => {
+    // Arrange
+    const closed: Array<{ code: number; reason: string }> = [];
+    const socket = {
+      close: (code?: number, reason?: string) => {
+        assertBrowserWebSocketCloseCode(code);
+        if (code !== undefined) {
+          closed.push({ code, reason: reason ?? "" });
+        }
+      },
+    };
+
+    // Act
+    closeCollabClientSocket(
+      socket,
+      COLLAB_CLIENT_CLOSE_CODE.InvalidServerResponse,
+      "Invalid collaboration response",
+    );
+    closeCollabClientSocket(
+      socket,
+      COLLAB_CLIENT_CLOSE_CODE.RetryableServerError,
+      "Retry collaboration sync",
+    );
+    closeCollabClientSocket(
+      socket,
+      COLLAB_CLIENT_CLOSE_CODE.FatalServerError,
+      "Fatal error",
+    );
+    closeCollabClientSocket(
+      socket,
+      COLLAB_CLIENT_CLOSE_CODE.ResponseApplyFailure,
+      "Collaboration response could not be applied",
+    );
+
+    // Assert
+    expect(closed).toEqual([
+      {
+        code: COLLAB_CLIENT_CLOSE_CODE.InvalidServerResponse,
+        reason: "Invalid collaboration response",
+      },
+      {
+        code: COLLAB_CLIENT_CLOSE_CODE.RetryableServerError,
+        reason: "Retry collaboration sync",
+      },
+      {
+        code: COLLAB_CLIENT_CLOSE_CODE.FatalServerError,
+        reason: "Fatal error",
+      },
+      {
+        code: COLLAB_CLIENT_CLOSE_CODE.ResponseApplyFailure,
+        reason: "Collaboration response could not be applied",
+      },
+    ]);
+  });
+});
+
+describe("isBrowserAllowedWebSocketCloseCode", () => {
+  it("should allow 1000 and the application/private ranges", () => {
+    expect(isBrowserAllowedWebSocketCloseCode(1000)).toBe(true);
+    expect(isBrowserAllowedWebSocketCloseCode(3000)).toBe(true);
+    expect(isBrowserAllowedWebSocketCloseCode(4999)).toBe(true);
+  });
+
+  it("should reject protocol codes that browsers forbid for client close()", () => {
+    for (const code of [1001, 1008, 1011, 1013, 2999]) {
+      expect(isBrowserAllowedWebSocketCloseCode(code)).toBe(false);
+      expect(() => assertBrowserWebSocketCloseCode(code)).toThrow(DOMException);
+    }
+  });
+});
+
+describe("closeCollabClientSocket", () => {
+  it("should not let a close() InvalidAccessError escape to callers", () => {
+    // Arrange — simulate a browser rejecting the close invocation
+    const socket = {
+      close: () => {
+        throw new DOMException(
+          "Failed to execute 'close' on 'WebSocket': The code must be either 1000, or between 3000 and 4999. 1008 is neither.",
+          "InvalidAccessError",
+        );
+      },
+    };
+
+    // Act / Assert — helper swallows the browser exception
+    expect(() =>
+      closeCollabClientSocket(
+        socket,
+        COLLAB_CLIENT_CLOSE_CODE.FatalServerError,
+        "Fatal error",
+      ),
+    ).not.toThrow();
+  });
+});

--- a/apps/web/modules/docs/collab-client-close.ts
+++ b/apps/web/modules/docs/collab-client-close.ts
@@ -1,0 +1,37 @@
+/**
+ * Application close codes for client-initiated collaboration WebSocket
+ * shutdowns. Browsers only permit WebSocket.close(code) with 1000 or
+ * 3000–4999; protocol codes such as 1008/1011 are valid on server-generated
+ * close frames but throw InvalidAccessError when passed to the browser API.
+ */
+export const COLLAB_CLIENT_CLOSE_CODE = {
+  InvalidServerResponse: 4008,
+  RetryableServerError: 4011,
+  FatalServerError: 4009,
+  ResponseApplyFailure: 4012,
+} as const;
+
+export type CollabClientCloseCode =
+  (typeof COLLAB_CLIENT_CLOSE_CODE)[keyof typeof COLLAB_CLIENT_CLOSE_CODE];
+
+/** True when `code` is allowed by the browser WebSocket.close() API. */
+export const isBrowserAllowedWebSocketCloseCode = (code: number): boolean =>
+  code === 1000 || (code >= 3000 && code <= 4999);
+
+/**
+ * Close a collaboration socket with an application close code. Swallows
+ * close()-time exceptions so they cannot hide collaboration errors the caller
+ * already surfaced (e.g. via setError).
+ */
+export const closeCollabClientSocket = (
+  socket: Pick<WebSocket, "close">,
+  code: CollabClientCloseCode,
+  reason: string,
+): void => {
+  try {
+    socket.close(code, reason);
+  } catch {
+    // Intentionally ignored: InvalidAccessError / close races must not mask
+    // the original collaboration failure reported by the message handler.
+  }
+};

--- a/apps/web/modules/docs/use-collab-document.test.ts
+++ b/apps/web/modules/docs/use-collab-document.test.ts
@@ -1,0 +1,394 @@
+// @vitest-environment jsdom
+
+import {
+  COLLAB_ACCESS_MODE,
+  COLLAB_ERROR_CODE,
+  COLLAB_MESSAGE_TYPE,
+  COLLAB_PROTOCOL_VERSION,
+} from "@softmaple/collab-protocol";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { COLLAB_CLIENT_CLOSE_CODE } from "./collab-client-close";
+import { useCollabDocument } from "./use-collab-document";
+
+vi.mock("@/utils/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: async () => ({
+        data: { session: null },
+        error: null,
+      }),
+    },
+  }),
+}));
+
+const reactActGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+type FakeWebSocketEventType = "open" | "message" | "close" | "error";
+type FakeWebSocketListener = (event: Event | MessageEvent<string>) => void;
+
+/** Mirrors Chromium's WebSocket.close() close-code validation. */
+const assertBrowserWebSocketCloseCode = (code: number | undefined): void => {
+  if (code === undefined) return;
+  if (code === 1000 || (code >= 3000 && code <= 4999)) return;
+  throw new DOMException(
+    `Failed to execute 'close' on 'WebSocket': The code must be either 1000, or between 3000 and 4999. ${code} is neither.`,
+    "InvalidAccessError",
+  );
+};
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  readonly closeCalls: Array<{ code?: number; reason?: string }> = [];
+
+  private readonly listeners = new Map<
+    FakeWebSocketEventType,
+    Set<FakeWebSocketListener>
+  >();
+
+  constructor(url: string) {
+    this.url = url;
+    fakeSockets.push(this);
+  }
+
+  addEventListener = (
+    type: FakeWebSocketEventType,
+    listener: FakeWebSocketListener,
+  ): void => {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  };
+
+  removeEventListener = (
+    type: FakeWebSocketEventType,
+    listener: FakeWebSocketListener,
+  ): void => {
+    this.listeners.get(type)?.delete(listener);
+  };
+
+  send = (): void => {};
+
+  close = (code?: number, reason?: string): void => {
+    assertBrowserWebSocketCloseCode(code);
+    this.closeCalls.push({ code, reason });
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit("close", new CloseEvent("close", { code: code ?? 1000, reason }));
+  };
+
+  emitOpen = (): void => {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit("open", new Event("open"));
+  };
+
+  emitMessage = (data: unknown): void => {
+    this.emit(
+      "message",
+      new MessageEvent("message", { data: JSON.stringify(data) }),
+    );
+  };
+
+  emitRawMessage = (data: string): void => {
+    this.emit("message", new MessageEvent("message", { data }));
+  };
+
+  private emit = (
+    type: FakeWebSocketEventType,
+    event: Event | MessageEvent<string>,
+  ): void => {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  };
+}
+
+const fakeSockets: FakeWebSocket[] = [];
+const originalWebSocket = globalThis.WebSocket;
+
+type HookState = ReturnType<typeof useCollabDocument>;
+
+const renderCollabHook = (
+  documentId: string,
+  sessionMode: "authenticated" | "public" = "public",
+): { result: { current: HookState }; unmount: () => void } => {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const result: { current: HookState } = {
+    current: {
+      replica: null,
+      status: "connecting",
+      canWrite: false,
+      error: null,
+      onBindingChange: () => {},
+    },
+  };
+
+  const Capture = (): null => {
+    result.current = useCollabDocument(documentId, sessionMode);
+    return null;
+  };
+
+  act(() => {
+    root.render(createElement(Capture));
+  });
+
+  return {
+    result,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+const waitForSocket = async (): Promise<FakeWebSocket> => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+  const socket = fakeSockets.at(-1);
+  if (socket === undefined) {
+    throw new Error("Expected a collaboration WebSocket to be created");
+  }
+  return socket;
+};
+
+describe("useCollabDocument", () => {
+  beforeEach(() => {
+    fakeSockets.length = 0;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.WebSocket = originalWebSocket;
+    vi.clearAllTimers();
+  });
+
+  it("should close invalid server payloads with an application close code", async () => {
+    // Arrange
+    const { result, unmount } = renderCollabHook("doc-invalid");
+    const socket = await waitForSocket();
+
+    // Act
+    act(() => {
+      socket.emitOpen();
+      socket.emitRawMessage("not-json");
+    });
+
+    // Assert
+    expect(socket.closeCalls).toEqual([
+      {
+        code: COLLAB_CLIENT_CLOSE_CODE.InvalidServerResponse,
+        reason: "Invalid collaboration response",
+      },
+    ]);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error?.message).toBe(
+      "The collaboration server returned invalid data",
+    );
+    expect(result.current.canWrite).toBe(false);
+
+    // Fatal: must not schedule reconnect
+    act(() => {
+      vi.advanceTimersByTime(20_000);
+    });
+    expect(fakeSockets).toHaveLength(1);
+
+    unmount();
+  });
+
+  it("should close retryable server errors without marking the session fatal", async () => {
+    // Arrange
+    const { result, unmount } = renderCollabHook("doc-retry");
+    const socket = await waitForSocket();
+
+    // Act
+    act(() => {
+      socket.emitOpen();
+      socket.emitMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Error,
+        code: COLLAB_ERROR_CODE.PersistenceFailed,
+        message: "Temporary persistence failure",
+        retryable: true,
+      });
+    });
+
+    // Assert
+    expect(socket.closeCalls).toEqual([
+      {
+        code: COLLAB_CLIENT_CLOSE_CODE.RetryableServerError,
+        reason: "Retry collaboration sync",
+      },
+    ]);
+    expect(result.current.error?.message).toBe("Temporary persistence failure");
+    expect(result.current.status).toBe("offline");
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(fakeSockets.length).toBeGreaterThan(1);
+
+    unmount();
+  });
+
+  it("should close fatal server errors and skip reconnect", async () => {
+    // Arrange
+    const { result, unmount } = renderCollabHook("doc-fatal");
+    const socket = await waitForSocket();
+
+    // Act
+    act(() => {
+      socket.emitOpen();
+      socket.emitMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Error,
+        code: COLLAB_ERROR_CODE.Forbidden,
+        message: "Access denied",
+        retryable: false,
+      });
+    });
+
+    // Assert
+    expect(socket.closeCalls).toEqual([
+      {
+        code: COLLAB_CLIENT_CLOSE_CODE.FatalServerError,
+        reason: "Fatal error",
+      },
+    ]);
+    expect(result.current.status).toBe("error");
+    expect(result.current.error?.message).toBe("Access denied");
+    expect(result.current.canWrite).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(20_000);
+    });
+    expect(fakeSockets).toHaveLength(1);
+
+    unmount();
+  });
+
+  it("should keep the apply-failure error observable when closing the socket", async () => {
+    // Arrange
+    const { result, unmount } = renderCollabHook("doc-apply", "public");
+    const socket = await waitForSocket();
+
+    // Act — Ready with the wrong access mode throws inside the handler
+    act(() => {
+      socket.emitOpen();
+      socket.emitMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Ready,
+        accessMode: COLLAB_ACCESS_MODE.Authenticated,
+        documentId: "doc-apply",
+        userId: "user-1",
+        role: "EDITOR",
+        canWrite: true,
+      });
+    });
+
+    // Assert
+    expect(socket.closeCalls).toEqual([
+      {
+        code: COLLAB_CLIENT_CLOSE_CODE.ResponseApplyFailure,
+        reason: "Collaboration response could not be applied",
+      },
+    ]);
+    expect(result.current.error?.message).toBe(
+      "The collaboration access mode is invalid",
+    );
+
+    unmount();
+  });
+
+  it("should never call browser WebSocket.close with forbidden protocol codes", async () => {
+    // Arrange
+    const { unmount } = renderCollabHook("doc-codes");
+    const socket = await waitForSocket();
+
+    // Act — exercise every client-initiated coded close path
+    act(() => {
+      socket.emitOpen();
+      socket.emitRawMessage("{");
+    });
+
+    const { unmount: unmountRetry } = renderCollabHook("doc-codes-retry");
+    const retrySocket = await waitForSocket();
+    act(() => {
+      retrySocket.emitOpen();
+      retrySocket.emitMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Error,
+        code: COLLAB_ERROR_CODE.Conflict,
+        message: "retry me",
+        retryable: true,
+      });
+    });
+
+    const { unmount: unmountFatal } = renderCollabHook("doc-codes-fatal");
+    const fatalSocket = await waitForSocket();
+    act(() => {
+      fatalSocket.emitOpen();
+      fatalSocket.emitMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Error,
+        code: COLLAB_ERROR_CODE.AuthenticationFailed,
+        message: "auth failed",
+        retryable: false,
+      });
+    });
+
+    const { unmount: unmountApply } = renderCollabHook("doc-codes-apply");
+    const applySocket = await waitForSocket();
+    act(() => {
+      applySocket.emitOpen();
+      applySocket.emitMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Ready,
+        accessMode: COLLAB_ACCESS_MODE.Authenticated,
+        documentId: "doc-codes-apply",
+        userId: null,
+        role: null,
+        canWrite: false,
+      });
+    });
+
+    // Assert — FakeWebSocket.close would have thrown for 1001–2999
+    const codedCloses = [
+      ...socket.closeCalls,
+      ...retrySocket.closeCalls,
+      ...fatalSocket.closeCalls,
+      ...applySocket.closeCalls,
+    ].filter((call) => call.code !== undefined);
+
+    expect(codedCloses.length).toBeGreaterThanOrEqual(4);
+    for (const call of codedCloses) {
+      expect(
+        call.code === 1000 ||
+          (call.code !== undefined && call.code >= 3000 && call.code <= 4999),
+      ).toBe(true);
+      expect(call.code).not.toBe(1008);
+      expect(call.code).not.toBe(1011);
+    }
+
+    unmount();
+    unmountRetry();
+    unmountFatal();
+    unmountApply();
+  });
+});

--- a/apps/web/modules/docs/use-collab-document.ts
+++ b/apps/web/modules/docs/use-collab-document.ts
@@ -14,6 +14,10 @@ import {
 } from "@softmaple/collab-protocol";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  closeCollabClientSocket,
+  COLLAB_CLIENT_CLOSE_CODE,
+} from "@/modules/docs/collab-client-close";
+import {
   acknowledgePendingBatches,
   addPendingBatches,
   loadPendingBatches,
@@ -273,7 +277,11 @@ export const useCollabDocument = (
           setError(new Error("The collaboration server returned invalid data"));
           setStatus("error");
           setCanWrite(false);
-          nextSocket.close(1008, "Invalid collaboration response");
+          closeCollabClientSocket(
+            nextSocket,
+            COLLAB_CLIENT_CLOSE_CODE.InvalidServerResponse,
+            "Invalid collaboration response",
+          );
           return;
         }
 
@@ -357,19 +365,28 @@ export const useCollabDocument = (
                 setStatus("error");
                 setCanWrite(false);
               }
-              nextSocket.close(
-                message.retryable ? 1011 : 1008,
+              closeCollabClientSocket(
+                nextSocket,
+                message.retryable
+                  ? COLLAB_CLIENT_CLOSE_CODE.RetryableServerError
+                  : COLLAB_CLIENT_CLOSE_CODE.FatalServerError,
                 message.retryable ? "Retry collaboration sync" : "Fatal error",
               );
               return;
           }
         } catch (handlerError) {
-          setError(
+          const applyError =
             handlerError instanceof Error
               ? handlerError
-              : new Error("The collaboration response could not be applied"),
+              : new Error("The collaboration response could not be applied");
+          // Surface the apply failure before close() so a browser InvalidAccessError
+          // from WebSocket.close cannot hide the collaboration error.
+          setError(applyError);
+          closeCollabClientSocket(
+            nextSocket,
+            COLLAB_CLIENT_CLOSE_CODE.ResponseApplyFailure,
+            "Collaboration response could not be applied",
           );
-          nextSocket.close(1011, "Collaboration response could not be applied");
         }
       });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes browser `InvalidAccessError` when the collaboration client closes its WebSocket.

### Summary
- Browser `WebSocket.close(code)` only permits `1000` or `3000–4999`. The collab document client was calling `close(1008)` / `close(1011)`, which throws in Chromium and hid the real collaboration failure.
- Introduced private application close codes in the `4000–4999` range for client-initiated shutdowns (`InvalidServerResponse`, `RetryableServerError`, `FatalServerError`, `ResponseApplyFailure`).
- Close through a helper that surfaces the message-handler error first and swallows close-time exceptions so they cannot mask the collaboration error.
- Left server-side `peer.close(1008/1011)` unchanged (valid for server-generated close frames).
- Preserved reconnect behavior gated by `fatalConnectionError`.

### Tests
- `pnpm --filter @softmaple/web exec vitest run modules/docs/collab-client-close.test.ts modules/docs/use-collab-document.test.ts`
- WebSocket mock enforces browser close-code rules so forbidden `1001–2999` codes cannot regress.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-429bb53f-06b6-4a42-bf71-75ced679efc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-429bb53f-06b6-4a42-bf71-75ced679efc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer connection close handling for collaborative documents.
  - Collaboration errors now use distinct close codes and messages.
  - Improved reporting of response-application failures before disconnecting.

- **Bug Fixes**
  - Prevented invalid browser WebSocket close codes.
  - Suppressed browser close-time exceptions that could obscure the original collaboration error.
  - Improved reconnection and error-state behavior for failed collaboration requests.

- **Tests**
  - Added comprehensive coverage for close codes, error handling, retries, reconnection, permissions, and invalid responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->