### PR TITLE
fix: defer unresolved remote presence anchors without crashing editor

### DIFF
--- a/apps/playground/src/modules/lexical-eg-walker/RemoteSelectionLayer.test.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/RemoteSelectionLayer.test.ts
@@ -49,15 +49,18 @@ describe("remote selection resolution", () => {
       focus: { blockId: "block-a", offset: 4 },
     };
     let historyAvailable = false;
-    const resolveSelection = vi.fn(() => {
-      if (!historyAvailable) throw new Error("Unknown selection anchor");
-      return logical;
-    });
+    const tryResolveSelection = vi.fn(() =>
+      historyAvailable
+        ? { status: "resolved" as const, selection: logical }
+        : { status: "temporarily-unresolved" as const },
+    );
 
-    expect(resolvePeerSelection({ resolveSelection }, peer)).toBeNull();
+    expect(resolvePeerSelection({ tryResolveSelection }, peer)).toBeNull();
     historyAvailable = true;
-    expect(resolvePeerSelection({ resolveSelection }, peer)).toEqual(logical);
-    expect(resolveSelection).toHaveBeenCalledTimes(2);
+    expect(resolvePeerSelection({ tryResolveSelection }, peer)).toEqual(
+      logical,
+    );
+    expect(tryResolveSelection).toHaveBeenCalledTimes(2);
   });
 
   it("retries unresolved anchors when replica history changes", () => {
@@ -69,9 +72,9 @@ describe("remote selection resolution", () => {
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     let retry: (() => void) | null = null;
     const unsubscribe = vi.fn();
-    const resolveSelection = vi.fn(() => {
-      throw new Error("Unknown selection anchor");
-    });
+    const tryResolveSelection = vi.fn(() => ({
+      status: "temporarily-unresolved" as const,
+    }));
     const binding = {
       replica: {
         subscribe: (listener: () => void) => {
@@ -79,7 +82,7 @@ describe("remote selection resolution", () => {
           return unsubscribe;
         },
       },
-      resolveSelection,
+      tryResolveSelection,
       getBlockIndex: () => ({
         blockIdToNodeKey: new Map(),
         nodeKeyToBlockId: new Map(),
@@ -96,11 +99,11 @@ describe("remote selection resolution", () => {
         users: [peer],
       }),
     );
-    expect(resolveSelection).toHaveBeenCalledTimes(1);
+    expect(tryResolveSelection).toHaveBeenCalledTimes(1);
 
     act(() => retry?.());
 
-    expect(resolveSelection).toHaveBeenCalledTimes(2);
+    expect(tryResolveSelection).toHaveBeenCalledTimes(2);
     rendered.unmount();
     expect(unsubscribe).toHaveBeenCalledOnce();
     host.remove();

--- a/apps/playground/src/modules/lexical-eg-walker/remote-selection-geometry.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/remote-selection-geometry.ts
@@ -129,15 +129,14 @@ const toStableSelection = (
 ): StableBlockSelection => selection;
 
 export const resolvePeerSelection = (
-  binding: Pick<LexicalBinding, "resolveSelection">,
+  binding: Pick<LexicalBinding, "tryResolveSelection">,
   peer: PresenceUser,
 ): LogicalSelection | null => {
   if (!isDirectionalSelectionRange(peer.selection)) return null;
-  try {
-    return binding.resolveSelection(toStableSelection(peer.selection));
-  } catch {
-    return null;
-  }
+  const resolved = binding.tryResolveSelection(
+    toStableSelection(peer.selection),
+  );
+  return resolved.status === "resolved" ? resolved.selection : null;
 };
 
 export const measurePeer = (

--- a/apps/web/modules/docs/document-presence-geometry.test.ts
+++ b/apps/web/modules/docs/document-presence-geometry.test.ts
@@ -1,0 +1,117 @@
+import type { PresenceUser } from "@softmaple/awareness";
+import type {
+  LexicalBinding,
+  LogicalSelection,
+  ResolveSelectionResult,
+} from "@softmaple/binding-lexical";
+import {
+  BOOTSTRAP_BLOCK_ID,
+  InvalidSequenceAtomError,
+  UnknownSequenceAtomError,
+} from "@softmaple/block-model";
+import { describe, expect, it, vi } from "vitest";
+import {
+  isIsolatablePresenceAnchorError,
+  mapPresenceUsers,
+  resolveRemotePresenceSelection,
+} from "./document-presence-geometry";
+
+const baseUser = (
+  connectionId: string,
+  overrides: Partial<PresenceUser> = {},
+): PresenceUser => ({
+  connectionId,
+  userId: connectionId,
+  name: connectionId,
+  color: "#c9184a",
+  status: "active",
+  lastActivityAt: 1,
+  lastSeenAt: 1,
+  clock: 0,
+  ...overrides,
+});
+
+const cursorAt = (eventId: string): PresenceUser["cursor"] => ({
+  blockId: BOOTSTRAP_BLOCK_ID,
+  anchor: {
+    type: "atom",
+    eventId,
+    offset: 0,
+    affinity: "after",
+  },
+});
+
+describe("resolveRemotePresenceSelection", () => {
+  it("returns null while the remote atom is temporarily unresolved", () => {
+    let historyAvailable = false;
+    const logical: LogicalSelection = {
+      anchor: { blockId: BOOTSTRAP_BLOCK_ID, offset: 3 },
+      focus: { blockId: BOOTSTRAP_BLOCK_ID, offset: 3 },
+    };
+    const tryResolveSelection = vi.fn(
+      (): ResolveSelectionResult =>
+        historyAvailable
+          ? { status: "resolved", selection: logical }
+          : { status: "temporarily-unresolved" },
+    );
+    const binding = { tryResolveSelection } as Pick<
+      LexicalBinding,
+      "tryResolveSelection"
+    >;
+    const peer = baseUser("peer-a", { cursor: cursorAt("alice:1") });
+
+    expect(resolveRemotePresenceSelection(binding, peer)).toBeNull();
+    historyAvailable = true;
+    expect(resolveRemotePresenceSelection(binding, peer)).toEqual(logical);
+    expect(tryResolveSelection).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves already-integrated anchors", () => {
+    const logical: LogicalSelection = {
+      anchor: { blockId: BOOTSTRAP_BLOCK_ID, offset: 2 },
+      focus: { blockId: BOOTSTRAP_BLOCK_ID, offset: 2 },
+    };
+    const binding = {
+      tryResolveSelection: () =>
+        ({
+          status: "resolved",
+          selection: logical,
+        }) satisfies ResolveSelectionResult,
+    };
+
+    expect(
+      resolveRemotePresenceSelection(
+        binding,
+        baseUser("peer-b", { cursor: cursorAt("alice:0") }),
+      ),
+    ).toEqual(logical);
+  });
+});
+
+describe("mapPresenceUsers", () => {
+  it("does not let one invalid peer block other remote carets", () => {
+    const users = [baseUser("bad"), baseUser("good")];
+    const mapped = mapPresenceUsers(users, (user) => {
+      if (user.connectionId === "bad") {
+        throw new InvalidSequenceAtomError("alice:0", 99);
+      }
+      return user.connectionId;
+    });
+
+    expect(mapped).toEqual(["good"]);
+    expect(
+      isIsolatablePresenceAnchorError(new InvalidSequenceAtomError("a", 0)),
+    ).toBe(true);
+    expect(
+      isIsolatablePresenceAnchorError(new UnknownSequenceAtomError("a", 0)),
+    ).toBe(true);
+  });
+
+  it("still propagates unexpected errors", () => {
+    expect(() =>
+      mapPresenceUsers([baseUser("boom")], () => {
+        throw new TypeError("unexpected");
+      }),
+    ).toThrow(TypeError);
+  });
+});

--- a/apps/web/modules/docs/document-presence-geometry.ts
+++ b/apps/web/modules/docs/document-presence-geometry.ts
@@ -1,0 +1,61 @@
+import {
+  isDirectionalSelectionRange,
+  isStableCursorPosition,
+  type PresenceUser,
+} from "@softmaple/awareness";
+import type {
+  LexicalBinding,
+  LogicalSelection,
+  StableBlockSelection,
+} from "@softmaple/binding-lexical";
+import {
+  InvalidSequenceAtomError,
+  UnknownSequenceAtomError,
+} from "@softmaple/block-model";
+
+/** Hard anchor errors that must not take down every remote caret. */
+export const isIsolatablePresenceAnchorError = (error: unknown): boolean =>
+  error instanceof InvalidSequenceAtomError ||
+  error instanceof UnknownSequenceAtomError;
+
+/**
+ * Resolve a remote presence selection against the local replica.
+ * Returns `null` when the selection is absent or temporarily unresolved.
+ */
+export const resolveRemotePresenceSelection = (
+  binding: Pick<LexicalBinding, "tryResolveSelection">,
+  user: PresenceUser,
+): LogicalSelection | null => {
+  const selection = isDirectionalSelectionRange(user.selection)
+    ? user.selection
+    : null;
+  const cursor = isStableCursorPosition(user.cursor) ? user.cursor : null;
+  if (selection === null && cursor === null) return null;
+
+  const stableSelection: StableBlockSelection =
+    selection === null
+      ? { anchor: cursor!, focus: cursor! }
+      : { anchor: selection.anchor, focus: selection.focus };
+  const resolved = binding.tryResolveSelection(stableSelection);
+  return resolved.status === "resolved" ? resolved.selection : null;
+};
+
+/**
+ * Map remote presence users one-by-one, skipping temporarily unresolved or
+ * isolatable hard-anchor failures without aborting the whole overlay.
+ */
+export const mapPresenceUsers = <T>(
+  users: ReadonlyArray<PresenceUser>,
+  mapUser: (user: PresenceUser) => T | null,
+): T[] =>
+  users.flatMap((user) => {
+    try {
+      const value = mapUser(user);
+      return value === null ? [] : [value];
+    } catch (error) {
+      if (isIsolatablePresenceAnchorError(error)) {
+        return [];
+      }
+      throw error;
+    }
+  });

--- a/apps/web/modules/docs/document-presence.tsx
+++ b/apps/web/modules/docs/document-presence.tsx
@@ -12,8 +12,6 @@ import {
 import {
   createNoopAdapter,
   createWebSocketAdapter,
-  isDirectionalSelectionRange,
-  isStableCursorPosition,
   PresenceProvider,
   useOthers,
   usePresence,
@@ -38,6 +36,10 @@ import {
   domPointAtOffset,
   type DomPoint,
 } from "@/modules/docs/document-presence-dom";
+import {
+  mapPresenceUsers,
+  resolveRemotePresenceSelection,
+} from "@/modules/docs/document-presence-geometry";
 
 type ProfileIdentity = {
   readonly avatarUrl: string | null;
@@ -110,17 +112,8 @@ const geometryForUser = (
   container: HTMLElement,
   user: PresenceUser,
 ): RemoteGeometry | null => {
-  const selection = isDirectionalSelectionRange(user.selection)
-    ? user.selection
-    : null;
-  const cursor = isStableCursorPosition(user.cursor) ? user.cursor : null;
-  if (selection === null && cursor === null) return null;
-
-  const stableSelection: StableBlockSelection =
-    selection === null
-      ? { anchor: cursor!, focus: cursor! }
-      : { anchor: selection.anchor, focus: selection.focus };
-  const logical = binding.resolveSelection(stableSelection);
+  const logical = resolveRemotePresenceSelection(binding, user);
+  if (logical === null) return null;
   const anchorPoint = logicalDomPoint(binding, logical.anchor);
   const focusPoint = logicalDomPoint(binding, logical.focus);
   if (anchorPoint === null || focusPoint === null) return null;
@@ -171,19 +164,22 @@ const RemotePresenceOverlay: FC<{
       if (frame !== null) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
         setGeometries(
-          others.flatMap((user) => {
-            const geometry = geometryForUser(binding, container, user);
-            return geometry === null ? [] : [geometry];
-          }),
+          mapPresenceUsers(others, (user) =>
+            geometryForUser(binding, container, user),
+          ),
         );
       });
     };
     refresh();
+    // Lexical updates cover materialize(); replica.subscribe covers remote
+    // integration even when a Lexical update is deferred (e.g. composition).
     const unregisterEditor = binding.editor.registerUpdateListener(refresh);
+    const unsubscribeReplica = binding.replica.subscribe(refresh);
     window.addEventListener("resize", refresh);
     window.addEventListener("scroll", refresh, true);
     return () => {
       unregisterEditor();
+      unsubscribeReplica();
       window.removeEventListener("resize", refresh);
       window.removeEventListener("scroll", refresh, true);
       if (frame !== null) cancelAnimationFrame(frame);

--- a/packages/binding-lexical/src/binding.test.ts
+++ b/packages/binding-lexical/src/binding.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   BOOTSTRAP_BLOCK_ID,
   createBlockReplica,
+  InvalidSequenceAtomError,
   type BlockReplicaOrigin,
   type RichTextEventBatch,
 } from "@softmaple/block-model";
@@ -307,6 +308,90 @@ describe("createLexicalBinding", () => {
       focus: { blockId: blockIds[0], offset: 1 },
     });
     expect(JSON.parse(JSON.stringify(stable))).toEqual(stable);
+    binding.destroy();
+  });
+
+  it("defers remote presence selections until the creating event arrives", () => {
+    const author = createBlockReplica("presence-author");
+    const seed = author.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "AB");
+    });
+    if (seed === null) throw new Error("Expected a seed batch");
+    const receiverReplica = createBlockReplica("presence-receiver");
+    receiverReplica.applyRemoteEvents(seed);
+    const insert = author.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 2, "!");
+    });
+    if (insert === null) throw new Error("Expected an insert batch");
+    const stable = {
+      anchor: author.captureBlockAnchor(BOOTSTRAP_BLOCK_ID, 3, "after"),
+      focus: author.captureBlockAnchor(BOOTSTRAP_BLOCK_ID, 3, "after"),
+    };
+    const editor = createTestEditor();
+    const binding = createLexicalBinding({
+      editor,
+      replica: receiverReplica,
+    });
+
+    expect(binding.tryResolveSelection(stable)).toEqual({
+      status: "temporarily-unresolved",
+    });
+    expect(() => binding.resolveSelection(stable)).toThrow(/unknown atom/);
+
+    binding.applyRemoteEvents(insert);
+
+    expect(binding.tryResolveSelection(stable)).toEqual({
+      status: "resolved",
+      selection: {
+        anchor: { blockId: BOOTSTRAP_BLOCK_ID, offset: 3 },
+        focus: { blockId: BOOTSTRAP_BLOCK_ID, offset: 3 },
+      },
+    });
+    expect(binding.resolveSelection(stable)).toEqual({
+      anchor: { blockId: BOOTSTRAP_BLOCK_ID, offset: 3 },
+      focus: { blockId: BOOTSTRAP_BLOCK_ID, offset: 3 },
+    });
+    binding.destroy();
+  });
+
+  it("does not treat invalid known-atom offsets as temporarily unresolved", () => {
+    const replica = createBlockReplica("invalid-atom");
+    const batch = replica.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "A");
+    });
+    if (batch === null) throw new Error("Expected an insert batch");
+    const insertEventId = batch.events.find(
+      (event) => event.operation.type === "insert",
+    )?.id;
+    if (insertEventId === undefined) {
+      throw new Error("Expected an insert event id");
+    }
+    const editor = createTestEditor();
+    const binding = createLexicalBinding({ editor, replica });
+    const malformed = {
+      anchor: {
+        blockId: BOOTSTRAP_BLOCK_ID,
+        anchor: {
+          type: "atom" as const,
+          eventId: insertEventId,
+          offset: 99,
+          affinity: "before" as const,
+        },
+      },
+      focus: {
+        blockId: BOOTSTRAP_BLOCK_ID,
+        anchor: {
+          type: "atom" as const,
+          eventId: insertEventId,
+          offset: 99,
+          affinity: "before" as const,
+        },
+      },
+    };
+
+    expect(() => binding.tryResolveSelection(malformed)).toThrow(
+      InvalidSequenceAtomError,
+    );
     binding.destroy();
   });
 

--- a/packages/binding-lexical/src/binding.test.ts
+++ b/packages/binding-lexical/src/binding.test.ts
@@ -395,6 +395,47 @@ describe("createLexicalBinding", () => {
     binding.destroy();
   });
 
+  it("throws for an invalid focus even when the anchor is temporarily unresolved", () => {
+    const replica = createBlockReplica("mixed-endpoints");
+    const batch = replica.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "A");
+    });
+    if (batch === null) throw new Error("Expected an insert batch");
+    const insertEventId = batch.events.find(
+      (event) => event.operation.type === "insert",
+    )?.id;
+    if (insertEventId === undefined) {
+      throw new Error("Expected an insert event id");
+    }
+    const editor = createTestEditor();
+    const binding = createLexicalBinding({ editor, replica });
+    const mixed = {
+      anchor: {
+        blockId: BOOTSTRAP_BLOCK_ID,
+        anchor: {
+          type: "atom" as const,
+          eventId: "missing-remote-insert",
+          offset: 0,
+          affinity: "after" as const,
+        },
+      },
+      focus: {
+        blockId: BOOTSTRAP_BLOCK_ID,
+        anchor: {
+          type: "atom" as const,
+          eventId: insertEventId,
+          offset: 99,
+          affinity: "before" as const,
+        },
+      },
+    };
+
+    expect(() => binding.tryResolveSelection(mixed)).toThrow(
+      InvalidSequenceAtomError,
+    );
+    binding.destroy();
+  });
+
   it("restores a forward same-block selection through a remote insert", () => {
     const localReplica = createBlockReplica("selection-local");
     const remoteReplica = createBlockReplica("selection-remote");

--- a/packages/binding-lexical/src/binding.ts
+++ b/packages/binding-lexical/src/binding.ts
@@ -50,6 +50,21 @@ export interface LexicalBindingOptions {
   readonly onSelectionChange?: (selection: StableBlockSelection | null) => void;
 }
 
+/**
+ * Result of attempting to resolve a wire/stable selection against the current
+ * replica. `temporarily-unresolved` means at least one endpoint names an atom
+ * whose creating event has not been integrated yet (common for presence that
+ * races ahead of document collaboration). Invalid anchors still throw.
+ */
+export type ResolveSelectionResult =
+  | {
+      readonly status: "resolved";
+      readonly selection: LogicalSelection;
+    }
+  | {
+      readonly status: "temporarily-unresolved";
+    };
+
 export interface LexicalBinding {
   readonly editor: LexicalEditor;
   readonly replica: BlockReplica;
@@ -58,6 +73,12 @@ export interface LexicalBinding {
   ): ApplyRichTextEventsResult | null;
   captureSelection(): StableBlockSelection | null;
   resolveSelection(selection: StableBlockSelection): LogicalSelection;
+  /**
+   * Resolve a stable selection for ephemeral consumers (remote presence).
+   * Returns `temporarily-unresolved` instead of throwing when an endpoint
+   * references an atom that has not been integrated yet.
+   */
+  tryResolveSelection(selection: StableBlockSelection): ResolveSelectionResult;
   getBlockIndex(): LexicalBlockIndex;
   destroy(): void;
 }
@@ -299,6 +320,24 @@ const resolveStableSelection = (
   anchor: replica.resolveBlockAnchor(selection.anchor),
   focus: replica.resolveBlockAnchor(selection.focus),
 });
+
+const tryResolveStableSelection = (
+  selection: StableBlockSelection,
+  replica: BlockReplica,
+): ResolveSelectionResult => {
+  const anchor = replica.tryResolveBlockAnchor(selection.anchor);
+  if (anchor === null) {
+    return { status: "temporarily-unresolved" };
+  }
+  const focus = replica.tryResolveBlockAnchor(selection.focus);
+  if (focus === null) {
+    return { status: "temporarily-unresolved" };
+  }
+  return {
+    status: "resolved",
+    selection: { anchor, focus },
+  };
+};
 
 const sameLinkValue = (
   left: ProjectedMark["value"],
@@ -689,6 +728,8 @@ export const createLexicalBinding = ({
     },
     captureSelection,
     resolveSelection: (selection) => resolveStableSelection(selection, replica),
+    tryResolveSelection: (selection) =>
+      tryResolveStableSelection(selection, replica),
     getBlockIndex: () => blockIndex,
     destroy: () => {
       if (destroyed) return;

--- a/packages/binding-lexical/src/binding.ts
+++ b/packages/binding-lexical/src/binding.ts
@@ -325,12 +325,11 @@ const tryResolveStableSelection = (
   selection: StableBlockSelection,
   replica: BlockReplica,
 ): ResolveSelectionResult => {
+  // Resolve both endpoints before short-circuiting so an invalid known atom on
+  // either side still throws instead of being masked as temporarily unresolved.
   const anchor = replica.tryResolveBlockAnchor(selection.anchor);
-  if (anchor === null) {
-    return { status: "temporarily-unresolved" };
-  }
   const focus = replica.tryResolveBlockAnchor(selection.focus);
-  if (focus === null) {
+  if (anchor === null || focus === null) {
     return { status: "temporarily-unresolved" };
   }
   return {

--- a/packages/binding-lexical/src/index.ts
+++ b/packages/binding-lexical/src/index.ts
@@ -2,6 +2,7 @@ export {
   createLexicalBinding,
   type LexicalBinding,
   type LexicalBindingOptions,
+  type ResolveSelectionResult,
   type StableBlockSelection,
 } from "./binding";
 export { UnsupportedLexicalNodeError } from "./errors";

--- a/packages/block-model/src/index.ts
+++ b/packages/block-model/src/index.ts
@@ -14,4 +14,8 @@ export {
   METADATA_MARKER,
   TEXT_ESCAPE,
 } from "./constants";
+export {
+  InvalidSequenceAtomError,
+  UnknownSequenceAtomError,
+} from "@softmaple/eg-walker/anchors";
 export type * from "./types";

--- a/packages/block-model/src/replica.ts
+++ b/packages/block-model/src/replica.ts
@@ -3,6 +3,7 @@ import {
   captureAnchor,
   createSequenceAnchorProjection,
   resolveAnchor,
+  tryResolveAnchor,
   type AnchorAffinity,
 } from "@softmaple/eg-walker/anchors";
 
@@ -225,6 +226,26 @@ export class BlockReplica {
 
   resolveBlockAnchor(anchor: BlockAnchor): ResolvedBlockAnchor {
     const rawIndex = resolveRawAnchor(this.egWalker, anchor);
+    const resolved = nearestBlockBoundary(
+      this.state.projectedBlocks,
+      rawIndex,
+      anchor,
+    );
+    if (resolved === null) {
+      throw new Error("Cannot resolve block anchor in an empty document");
+    }
+    return resolved;
+  }
+
+  /**
+   * Resolve a block anchor, or return `null` when the underlying sequence atom
+   * has not been integrated yet. Invalid anchors still throw.
+   */
+  tryResolveBlockAnchor(anchor: BlockAnchor): ResolvedBlockAnchor | null {
+    const rawIndex = tryResolveRawAnchor(this.egWalker, anchor);
+    if (rawIndex === null) {
+      return null;
+    }
     const resolved = nearestBlockBoundary(
       this.state.projectedBlocks,
       rawIndex,
@@ -914,6 +935,11 @@ const resolveRawAnchor = (
   // current on-demand EG replay without changing the public block API.
   return resolveAnchor(egWalker, anchor.anchor);
 };
+
+const tryResolveRawAnchor = (
+  egWalker: EgWalkerReplica,
+  anchor: BlockAnchor,
+): number | null => tryResolveAnchor(egWalker, anchor.anchor);
 
 const nearestBlockBoundary = (
   projectedBlocks: ReadonlyArray<ProjectedBlock>,

--- a/packages/block-model/src/test/replica.test.ts
+++ b/packages/block-model/src/test/replica.test.ts
@@ -735,6 +735,43 @@ describe("BlockReplica", () => {
     expect(left.getDocument().blocks[0]?.text).toMatch(/^A(?:xy|yx)$/);
   });
 
+  it("should defer block anchors until the creating event is integrated", () => {
+    // Arrange — Case A: presence arrives before the document event.
+    const author = new BlockReplica("alice");
+    const seed = author.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "AB");
+    });
+    if (seed === null) throw new Error("Expected a seed batch");
+    const receiver = new BlockReplica("bob");
+    receiver.applyRemoteEvents(seed);
+    const insert = author.transact((transaction) => {
+      transaction.insertText(BOOTSTRAP_BLOCK_ID, 2, "!");
+    });
+    if (insert === null) throw new Error("Expected an insert batch");
+    const remoteAnchor = author.captureBlockAnchor(
+      BOOTSTRAP_BLOCK_ID,
+      3,
+      "after",
+    );
+
+    // Act / Assert — receiver has presence-shaped anchor but not the event.
+    expect(receiver.tryResolveBlockAnchor(remoteAnchor)).toBeNull();
+    expect(() => receiver.resolveBlockAnchor(remoteAnchor)).toThrow(
+      /unknown atom/,
+    );
+
+    receiver.applyRemoteEvents(insert);
+
+    expect(receiver.tryResolveBlockAnchor(remoteAnchor)).toEqual({
+      blockId: BOOTSTRAP_BLOCK_ID,
+      offset: 3,
+    });
+    expect(receiver.resolveBlockAnchor(remoteAnchor)).toEqual({
+      blockId: BOOTSTRAP_BLOCK_ID,
+      offset: 3,
+    });
+  });
+
   it("should preserve directional block anchors across a split", () => {
     // Arrange
     const replica = new BlockReplica("alice");

--- a/packages/eg-walker/src/anchors.ts
+++ b/packages/eg-walker/src/anchors.ts
@@ -110,6 +110,11 @@ export interface SequenceAnchorProjection {
   readonly text: string;
   captureAnchor(index: number, affinity: AnchorAffinity): SequenceAnchor;
   resolveAnchor(anchor: SequenceAnchor): number;
+  /**
+   * Resolve an anchor against this projection, or return `null` when the
+   * atom's creating event is not present. Invalid anchors (bad shape, known
+   * event with a missing offset, etc.) still throw.
+   */
   tryResolveAnchor(anchor: SequenceAnchor): number | null;
 }
 

--- a/packages/eg-walker/src/anchors.ts
+++ b/packages/eg-walker/src/anchors.ts
@@ -16,6 +16,38 @@ import type { EventId, GraphEvent } from "./types";
 
 export type AnchorAffinity = "before" | "after";
 
+/**
+ * The referenced insert event is not present in the replica's integrated
+ * event graph. Ephemeral consumers (e.g. remote presence) may treat this as
+ * temporarily unresolved until document state catches up.
+ */
+export class UnknownSequenceAtomError extends Error {
+  override readonly name = "UnknownSequenceAtomError";
+
+  constructor(
+    readonly eventId: EventId,
+    readonly offset: number,
+  ) {
+    super(`Sequence anchor references unknown atom ${eventId}:${offset}`);
+  }
+}
+
+/**
+ * The referenced event is known to the replica, but the atom offset does not
+ * exist in the sequence projection (wrong offset, non-insert event, etc.).
+ * This is not a transient catch-up failure.
+ */
+export class InvalidSequenceAtomError extends Error {
+  override readonly name = "InvalidSequenceAtomError";
+
+  constructor(
+    readonly eventId: EventId,
+    readonly offset: number,
+  ) {
+    super(`Sequence anchor references invalid atom ${eventId}:${offset}`);
+  }
+}
+
 export interface AtomSequenceAnchor {
   readonly type: "atom";
   readonly eventId: EventId;
@@ -57,6 +89,11 @@ export interface LocalInsertWithAnchorsResult {
 export interface SequenceAnchorApi {
   captureAnchor(index: number, affinity: AnchorAffinity): SequenceAnchor;
   resolveAnchor(anchor: SequenceAnchor): number;
+  /**
+   * Like {@link resolveAnchor}, but returns `null` when the atom's creating
+   * event has not been integrated yet. Invalid anchors still throw.
+   */
+  tryResolveAnchor(anchor: SequenceAnchor): number | null;
   insert(index: number, text: string): LocalInsertWithAnchorsResult | null;
   delete(index: number, length: number): GraphEvent | null;
   getFrontier(): ReadonlySet<EventId>;
@@ -73,6 +110,7 @@ export interface SequenceAnchorProjection {
   readonly text: string;
   captureAnchor(index: number, affinity: AnchorAffinity): SequenceAnchor;
   resolveAnchor(anchor: SequenceAnchor): number;
+  tryResolveAnchor(anchor: SequenceAnchor): number | null;
 }
 
 interface SequenceAtom {
@@ -93,6 +131,7 @@ interface SequenceProjection {
     EventId,
     ReadonlyMap<number, SequenceAtomPosition>
   >;
+  readonly knownEventIds: ReadonlySet<EventId>;
   readonly text: string;
 }
 
@@ -105,6 +144,7 @@ export const createSequenceAnchorApi = (
 ): SequenceAnchorApi => ({
   captureAnchor: (index, affinity) => captureAnchor(replica, index, affinity),
   resolveAnchor: (anchor) => resolveAnchor(replica, anchor),
+  tryResolveAnchor: (anchor) => tryResolveAnchor(replica, anchor),
   insert: (index, text) => insertWithAnchors(replica, index, text),
   delete: (index, length) => replica.delete(index, length),
   getFrontier: () => replica.getFrontier(),
@@ -131,6 +171,8 @@ export const createSequenceAnchorProjection = (
       captureProjectedAnchor(projection, index, affinity),
     resolveAnchor: (anchor: SequenceAnchor): number =>
       resolveProjectedAnchor(projection, anchor),
+    tryResolveAnchor: (anchor: SequenceAnchor): number | null =>
+      tryResolveProjectedAnchor(projection, anchor),
   });
 };
 
@@ -161,18 +203,42 @@ export const resolveAnchor = (
   anchor: SequenceAnchor,
 ): number => createSequenceAnchorProjection(replica).resolveAnchor(anchor);
 
+/**
+ * Resolve an anchor, or return `null` when its creating event is not yet in
+ * the replica. Shape errors and known-but-invalid atoms still throw so callers
+ * can distinguish transient catch-up from corruption / malformed presence.
+ */
+export const tryResolveAnchor = (
+  replica: EgWalkerReplica,
+  anchor: SequenceAnchor,
+): number | null =>
+  createSequenceAnchorProjection(replica).tryResolveAnchor(anchor);
+
 const resolveProjectedAnchor = (
   projection: SequenceProjection,
   anchor: SequenceAnchor,
 ): number => {
+  const resolved = tryResolveProjectedAnchor(projection, anchor);
+  if (resolved !== null) {
+    return resolved;
+  }
+  if (anchor.type !== "atom") {
+    throw new Error("Expected an atom sequence anchor");
+  }
+  throw new UnknownSequenceAtomError(anchor.eventId, anchor.offset);
+};
+
+const tryResolveProjectedAnchor = (
+  projection: SequenceProjection,
+  anchor: SequenceAnchor,
+): number | null => {
   assertSequenceAnchor(anchor);
   if (anchor.type === "boundary") {
     return anchor.edge === "start" ? 0 : projection.text.length;
   }
 
-  const position = projection.atomPositions
-    .get(anchor.eventId)
-    ?.get(anchor.offset);
+  const eventAtoms = projection.atomPositions.get(anchor.eventId);
+  const position = eventAtoms?.get(anchor.offset);
   if (position !== undefined) {
     const resolved =
       anchor.affinity === "after" ? position.after : position.before;
@@ -180,9 +246,18 @@ const resolveProjectedAnchor = (
     return resolved;
   }
 
-  throw new Error(
-    `Sequence anchor references unknown atom ${anchor.eventId}:${anchor.offset}`,
-  );
+  // Event is integrated (or otherwise known to the projection) but this atom
+  // offset does not exist — malformed / corrupted anchor, not catch-up.
+  if (
+    eventAtoms !== undefined ||
+    projection.knownEventIds.has(anchor.eventId)
+  ) {
+    throw new InvalidSequenceAtomError(anchor.eventId, anchor.offset);
+  }
+
+  // Creating event is absent from the integrated graph: presence may arrive
+  // before the corresponding document collaboration event.
+  return null;
 };
 
 /**
@@ -315,7 +390,12 @@ const createProjection = (replica: EgWalkerReplica): SequenceProjection => {
       "Stable anchor projection failed to reproduce document text",
     );
   }
-  return { visibleAtoms, atomPositions, text: visibleText };
+  return {
+    visibleAtoms,
+    atomPositions,
+    knownEventIds: new Set(events.keys()),
+    text: visibleText,
+  };
 };
 
 const indexAtomPositions = (

--- a/packages/eg-walker/src/test/anchors.test.ts
+++ b/packages/eg-walker/src/test/anchors.test.ts
@@ -5,8 +5,11 @@ import {
   createSequenceAnchorApi,
   createSequenceAnchorProjection,
   insertWithAnchors,
+  InvalidSequenceAtomError,
   isSequenceAnchor,
   resolveAnchor,
+  tryResolveAnchor,
+  UnknownSequenceAtomError,
   type SequenceAnchor,
 } from "../anchors";
 import { NativeSnapshotCodec } from "../core/native-snapshot";
@@ -241,6 +244,63 @@ describe("resolveAnchor", () => {
     expect(() => resolveAnchor(replica, insidePair)).toThrow(
       "splits a UTF-16 surrogate pair",
     );
+  });
+
+  it("should treat missing insert events as temporarily unresolved", () => {
+    // Arrange — presence can arrive before the document collaboration event.
+    const author = bootstrapReplica("alice", "AB");
+    const bootstrap = author.exportEventGraph()[0]!;
+    author.insert(2, "!");
+    const lateInsert = author.exportEventGraph()[1]!;
+    const remoteAtom: SequenceAnchor = {
+      type: "atom",
+      eventId: lateInsert.id,
+      offset: 0,
+      affinity: "after",
+    };
+    const receiver = replicaFromEvents("bob", [bootstrap]);
+
+    // Act / Assert
+    expect(tryResolveAnchor(receiver, remoteAtom)).toBeNull();
+    expect(() => resolveAnchor(receiver, remoteAtom)).toThrow(
+      UnknownSequenceAtomError,
+    );
+
+    receiver.applyRemoteEvent(cloneEvent(lateInsert));
+
+    expect(tryResolveAnchor(receiver, remoteAtom)).toBe(3);
+    expect(resolveAnchor(receiver, remoteAtom)).toBe(3);
+  });
+
+  it("should not classify a known event with a bad offset as transient", () => {
+    // Arrange
+    const replica = bootstrapReplica("alice", "A");
+    const malformed: SequenceAnchor = {
+      type: "atom",
+      eventId: "alice:0",
+      offset: 99,
+      affinity: "before",
+    };
+
+    // Act / Assert
+    expect(() => tryResolveAnchor(replica, malformed)).toThrow(
+      InvalidSequenceAtomError,
+    );
+    expect(() => resolveAnchor(replica, malformed)).toThrow(
+      InvalidSequenceAtomError,
+    );
+  });
+
+  it("should keep deleted-atom affinity when resolving through tryResolve", () => {
+    // Arrange
+    const replica = bootstrapReplica("alice", "ABCDE");
+    const before = captureAnchor(replica, 2, "before");
+    const after = captureAnchor(replica, 3, "after");
+    replica.delete(1, 3);
+
+    // Act / Assert
+    expect(tryResolveAnchor(replica, before)).toBe(1);
+    expect(tryResolveAnchor(replica, after)).toBe(1);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remote presence can arrive before the corresponding document collaboration event. Resolving those anchors with the strict `resolveSelection()` path threw `Sequence anchor references unknown atom …` and crashed remote presence rendering.

This change keeps durable EG-walker resolve strict, and adds typed `tryResolve*` APIs for ephemeral presence so temporarily missing atoms are deferred instead of crashing the session.

## Root cause

Confirmed race **#1**: presence channel ahead of document channel.

```text
User A inserts → selection anchors new atom E
presence(selection(E)) ──→ User B  (first)
document event E       ──→ User B  (later)
B: resolveSelection → resolveAnchor → UnknownSequenceAtomError → crash
```

`runtime.lastError: Could not establish connection…` is unrelated browser-extension noise.

## Changes

- **`@softmaple/eg-walker/anchors`**: `UnknownSequenceAtomError` / `InvalidSequenceAtomError`, `tryResolveAnchor()` (null only when creating event is absent); JSDoc on `SequenceAnchorProjection.tryResolveAnchor`
- **`@softmaple/block-model`**: `tryResolveBlockAnchor()`, re-exports anchor errors
- **`@softmaple/binding-lexical`**: `tryResolveSelection()` → `{ status: "resolved" | "temporarily-unresolved" }`; resolves **both** endpoints before short-circuiting so invalid known atoms still throw
- **`apps/web` RemotePresenceOverlay**: uses try-resolve; skips temporarily unresolved carets; also refreshes on `replica.subscribe`; isolates per-peer hard anchor errors
- **Playground**: stop catch-all swallowing; use `tryResolveSelection`

## Tests

- Case A: presence before document event → temporarily unresolved → resolves after integrate
- Case B: already-integrated anchors still resolve
- Case C: known event + bad offset → `InvalidSequenceAtomError` (not transient)
- Case C′: unresolved anchor + invalid focus → still throws `InvalidSequenceAtomError`
- Case D: deleted-atom affinity still works via `tryResolveAnchor`
- Case F: one invalid peer does not block other remote carets

## Follow-up (not in this PR)

Versioned presence / causal frontier in the awareness payload would let receivers defer with stronger guarantees than “unknown atom”. Not required for this bugfix.

## Test plan

- [x] `pnpm --filter @softmaple/eg-walker exec vitest run src/test/anchors.test.ts`
- [x] `pnpm --filter @softmaple/block-model exec vitest run src/test/replica.test.ts`
- [x] `pnpm --filter @softmaple/binding-lexical exec vitest run src/binding.test.ts`
- [x] `pnpm --filter @softmaple/web exec vitest run modules/docs/document-presence-geometry.test.ts`
- [x] `pnpm --filter playground exec vitest run src/modules/lexical-eg-walker/RemoteSelectionLayer.test.ts`
- [x] typecheck/lint on affected packages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d38bf091-e70a-4556-ba1c-7cb7a2408b78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d38bf091-e70a-4556-ba1c-7cb7a2408b78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote selections and presence indicators remain pending until referenced document history is available, then resolve automatically.
  * Safer anchor and selection resolution distinguishes temporary unavailability from invalid references.
  * Presence overlays refresh when replica updates make previously unresolved selections available.

* **Bug Fixes**
  * Invalid anchors no longer prevent other presence indicators from displaying.
  * Malformed known anchors continue to report errors instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->