### PR TITLE
fix(apps/web): stop collapsing workspace ActionResult failures into 404

### DIFF
--- a/apps/web/app/api/e2e/seed/route.ts
+++ b/apps/web/app/api/e2e/seed/route.ts
@@ -135,6 +135,29 @@ export async function POST(request: Request) {
       { status: 500 },
     );
   }
+  // Owner-only workspace: trigger adds the owner member; viewer/editor stay out.
+  const ownerOnlyWorkspace = await admin
+    .from("workspaces")
+    .insert({
+      description: `Owner-only Playwright run ${parsed.data.runId}`,
+      owner_id: owner.data.user.id,
+      slug: `e2e-owner-only-${parsed.data.runId}-${suffix}`,
+      title: `E2E Owner Only ${parsed.data.runId}`,
+    })
+    .select("id, slug, title")
+    .single();
+  if (ownerOnlyWorkspace.error !== null) {
+    await Promise.all([
+      admin.auth.admin.deleteUser(owner.data.user.id),
+      admin.auth.admin.deleteUser(editor.data.user.id),
+      admin.auth.admin.deleteUser(viewer.data.user.id),
+    ]);
+    return NextResponse.json(
+      { error: "Owner-only workspace seed failed" },
+      { status: 500 },
+    );
+  }
+
   const membership = await admin.from("workspace_members").insert([
     {
       invited_by: owner.data.user.id,
@@ -175,6 +198,7 @@ export async function POST(request: Request) {
     document: document.data,
     editor: { email: emails.editor, password },
     owner: { email: emails.owner, password },
+    ownerOnlyWorkspace: ownerOnlyWorkspace.data,
     viewer: { email: emails.viewer, password },
     workspace: workspace.data,
   });

--- a/apps/web/app/workspace/[workspaceSlug]/doc/[docSlug]/page.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/doc/[docSlug]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
 import { DocumentEditor } from "@/modules/docs/document-editor";
 import { NewDocumentForm } from "@/modules/docs/new-document-form";
 import { cachedGetDocumentBySlug } from "@/app/actions/documents/documents";
@@ -7,10 +6,13 @@ import { getWorkspaceMemberByUserId } from "@/app/actions/workspaceMembers";
 import { cachedGetWorkspaceBySlug } from "@/app/actions/workspaces";
 import { getCurrentUser } from "@/app/actions/auth";
 import { getCurrentProfile } from "@/app/actions/users";
+import { requireWorkspaceRouteData } from "@/lib/actions/workspace-route";
 
 type Props = {
   params: Promise<{ docSlug: string; workspaceSlug: string }>;
 };
+
+const ROUTE = "/workspace/[workspaceSlug]/doc/[docSlug]";
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { docSlug, workspaceSlug } = await params;
@@ -26,34 +28,61 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function DocumentPage({ params }: Props) {
   const { docSlug, workspaceSlug } = await params;
-  const [workspace, user, profile] = await Promise.all([
+  const loginNext = `/workspace/${workspaceSlug}/doc/${docSlug}`;
+  const failureContext = {
+    loginNext,
+    route: ROUTE,
+    workspaceSlug,
+  } as const;
+
+  const [workspaceResult, userResult, profileResult] = await Promise.all([
     cachedGetWorkspaceBySlug(workspaceSlug),
     getCurrentUser(),
     getCurrentProfile(),
   ]);
-  if (!workspace.ok || !user.ok || !profile.ok) notFound();
+
+  const workspace = requireWorkspaceRouteData(workspaceResult, {
+    ...failureContext,
+    operation: "get_workspace_by_slug",
+  });
+  const user = requireWorkspaceRouteData(userResult, {
+    ...failureContext,
+    operation: "get_current_user",
+  });
+  const profile = requireWorkspaceRouteData(profileResult, {
+    ...failureContext,
+    operation: "get_current_profile",
+  });
 
   if (docSlug === "new") {
     return <NewDocumentForm workspaceSlug={workspaceSlug} />;
   }
 
-  const [document, membership] = await Promise.all([
+  const [documentResult, membershipResult] = await Promise.all([
     cachedGetDocumentBySlug(workspaceSlug, docSlug),
-    getWorkspaceMemberByUserId(workspace.data.id),
+    getWorkspaceMemberByUserId(workspace.id),
   ]);
-  if (!document.ok || !membership.ok) notFound();
+
+  const document = requireWorkspaceRouteData(documentResult, {
+    ...failureContext,
+    operation: "get_document_by_slug",
+  });
+  const membership = requireWorkspaceRouteData(membershipResult, {
+    ...failureContext,
+    operation: "get_workspace_member_by_user_id",
+  });
 
   return (
     <DocumentEditor
-      authorId={document.data.author_id}
-      avatarUrl={profile.data.avatar_src}
-      currentUserId={user.data.id}
-      docSlug={document.data.slug}
-      documentId={document.data.id}
-      isPublic={document.data.is_public}
-      role={membership.data.role}
-      title={document.data.title}
-      userName={profile.data.full_name?.trim() || "Workspace member"}
+      authorId={document.author_id}
+      avatarUrl={profile.avatar_src}
+      currentUserId={user.id}
+      docSlug={document.slug}
+      documentId={document.id}
+      isPublic={document.is_public}
+      role={membership.role}
+      title={document.title}
+      userName={profile.full_name?.trim() || "Workspace member"}
       workspaceSlug={workspaceSlug}
     />
   );

--- a/apps/web/app/workspace/[workspaceSlug]/doc/[docSlug]/page.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/doc/[docSlug]/page.tsx
@@ -28,9 +28,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function DocumentPage({ params }: Props) {
   const { docSlug, workspaceSlug } = await params;
-  const loginNext = `/workspace/${workspaceSlug}/doc/${docSlug}`;
+
+  if (docSlug === "new") {
+    return <NewDocumentForm workspaceSlug={workspaceSlug} />;
+  }
+
   const failureContext = {
-    loginNext,
+    loginNext: `/workspace/${workspaceSlug}/doc/${docSlug}`,
     route: ROUTE,
     workspaceSlug,
   } as const;
@@ -53,10 +57,6 @@ export default async function DocumentPage({ params }: Props) {
     ...failureContext,
     operation: "get_current_profile",
   });
-
-  if (docSlug === "new") {
-    return <NewDocumentForm workspaceSlug={workspaceSlug} />;
-  }
 
   const [documentResult, membershipResult] = await Promise.all([
     cachedGetDocumentBySlug(workspaceSlug, docSlug),

--- a/apps/web/app/workspace/[workspaceSlug]/layout.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/layout.tsx
@@ -18,14 +18,15 @@ type Props = {
 export default async function WorkspaceLayoutPage(props: Props) {
   const { params, children } = props;
   const { workspaceSlug } = await params;
-  const loginNext = `/workspace/${workspaceSlug}`;
-  const route = "/workspace/[workspaceSlug]";
+  const failureContext = {
+    loginNext: `/workspace/${workspaceSlug}`,
+    route: "/workspace/[workspaceSlug]",
+    workspaceSlug,
+  } as const;
 
   const workspaces = requireWorkspaceRouteData(await cachedGetWorkspaces(), {
-    loginNext,
+    ...failureContext,
     operation: "get_workspaces",
-    route,
-    workspaceSlug,
   });
   const currentWorkspace = workspaces.find(
     (workspace) => workspace.slug === workspaceSlug,
@@ -41,19 +42,15 @@ export default async function WorkspaceLayoutPage(props: Props) {
     documentsResource === null
       ? []
       : requireWorkspaceRouteData(documentsResource, {
-          loginNext,
+          ...failureContext,
           operation: "list_workspace_documents",
-          route,
-          workspaceSlug,
         });
   const membership =
     membershipResource === null
       ? null
       : requireWorkspaceRouteData(membershipResource, {
-          loginNext,
+          ...failureContext,
           operation: "get_workspace_member_by_user_id",
-          route,
-          workspaceSlug,
         });
   const canEdit =
     membership?.role === WORKSPACE_ROLE.Owner ||
@@ -69,7 +66,7 @@ export default async function WorkspaceLayoutPage(props: Props) {
       >
         <WorkspaceDropdown
           workspaceSlug={workspaceSlug}
-          workspacesResource={{ ok: true, data: workspaces }}
+          workspaces={workspaces}
         />
       </WorkspaceMobileSidebar>
 
@@ -81,7 +78,7 @@ export default async function WorkspaceLayoutPage(props: Props) {
       >
         <WorkspaceDropdown
           workspaceSlug={workspaceSlug}
-          workspacesResource={{ ok: true, data: workspaces }}
+          workspaces={workspaces}
         />
       </WorkspaceDesktopSidebar>
 

--- a/apps/web/app/workspace/[workspaceSlug]/layout.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/layout.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import { cachedGetWorkspaces } from "@/app/actions/workspaces";
 import { listWorkspaceDocuments } from "@/app/actions/documents/documents";
 import { getWorkspaceMemberByUserId } from "@/app/actions/workspaceMembers";
+import { requireWorkspaceRouteData } from "@/lib/actions/workspace-route";
 import { WORKSPACE_ROLE } from "@/lib/workspace-roles";
 import { WorkspaceDesktopSidebar } from "@/modules/workspaces/workspace-desktop-sidebar";
 import { WorkspaceDropdown } from "@/modules/workspaces/workspace-dropdown";
@@ -17,13 +18,18 @@ type Props = {
 export default async function WorkspaceLayoutPage(props: Props) {
   const { params, children } = props;
   const { workspaceSlug } = await params;
+  const loginNext = `/workspace/${workspaceSlug}`;
+  const route = "/workspace/[workspaceSlug]";
 
-  const workspaceResource = await cachedGetWorkspaces();
-  const currentWorkspace = workspaceResource.ok
-    ? workspaceResource.data.find(
-        (workspace) => workspace.slug === workspaceSlug,
-      )
-    : undefined;
+  const workspaces = requireWorkspaceRouteData(await cachedGetWorkspaces(), {
+    loginNext,
+    operation: "get_workspaces",
+    route,
+    workspaceSlug,
+  });
+  const currentWorkspace = workspaces.find(
+    (workspace) => workspace.slug === workspaceSlug,
+  );
   const [documentsResource, membershipResource] =
     currentWorkspace === undefined
       ? [null, null]
@@ -31,16 +37,27 @@ export default async function WorkspaceLayoutPage(props: Props) {
           listWorkspaceDocuments(currentWorkspace.id, 100),
           getWorkspaceMemberByUserId(currentWorkspace.id),
         ]);
-  if (documentsResource !== null && !documentsResource.ok) {
-    throw new Error(documentsResource.message);
-  }
-  if (membershipResource !== null && !membershipResource.ok) {
-    throw new Error(membershipResource.message);
-  }
-  const documents = documentsResource?.data ?? [];
+  const documents =
+    documentsResource === null
+      ? []
+      : requireWorkspaceRouteData(documentsResource, {
+          loginNext,
+          operation: "list_workspace_documents",
+          route,
+          workspaceSlug,
+        });
+  const membership =
+    membershipResource === null
+      ? null
+      : requireWorkspaceRouteData(membershipResource, {
+          loginNext,
+          operation: "get_workspace_member_by_user_id",
+          route,
+          workspaceSlug,
+        });
   const canEdit =
-    membershipResource?.data.role === WORKSPACE_ROLE.Owner ||
-    membershipResource?.data.role === WORKSPACE_ROLE.Editor;
+    membership?.role === WORKSPACE_ROLE.Owner ||
+    membership?.role === WORKSPACE_ROLE.Editor;
 
   return (
     <div className="flex h-dvh min-w-0 bg-background">
@@ -52,7 +69,7 @@ export default async function WorkspaceLayoutPage(props: Props) {
       >
         <WorkspaceDropdown
           workspaceSlug={workspaceSlug}
-          workspacesResource={workspaceResource}
+          workspacesResource={{ ok: true, data: workspaces }}
         />
       </WorkspaceMobileSidebar>
 
@@ -64,7 +81,7 @@ export default async function WorkspaceLayoutPage(props: Props) {
       >
         <WorkspaceDropdown
           workspaceSlug={workspaceSlug}
-          workspacesResource={workspaceResource}
+          workspacesResource={{ ok: true, data: workspaces }}
         />
       </WorkspaceDesktopSidebar>
 

--- a/apps/web/app/workspace/[workspaceSlug]/page.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
 import { FileText, Plus, Settings2, Users } from "lucide-react";
 import { Button } from "@softmaple/ui/components/button";
 import { Badge } from "@softmaple/ui/components/badge";
@@ -18,6 +17,7 @@ import {
   getWorkspaceMemberByUserId,
   listWorkspaceMembers,
 } from "@/app/actions/workspaceMembers";
+import { requireWorkspaceRouteData } from "@/lib/actions/workspace-route";
 import { WORKSPACE_ROLE } from "@/lib/workspace-roles";
 
 type Props = { params: Promise<{ workspaceSlug: string }> };
@@ -43,12 +43,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function WorkspacePage({ params }: Props) {
   const { workspaceSlug } = await params;
-  const workspaceResult = await cachedGetWorkspaceBySlug(workspaceSlug);
-  if (!workspaceResult.ok) {
-    if (workspaceResult.code === "NOT_FOUND") notFound();
-    throw new Error(workspaceResult.message);
-  }
-  const workspace = workspaceResult.data;
+  const loginNext = `/workspace/${workspaceSlug}`;
+  const route = "/workspace/[workspaceSlug]";
+  const workspace = requireWorkspaceRouteData(
+    await cachedGetWorkspaceBySlug(workspaceSlug),
+    {
+      loginNext,
+      operation: "get_workspace_by_slug",
+      route,
+      workspaceSlug,
+    },
+  );
   const [documentsResult, documentCountResult, membersResult, roleResult] =
     await Promise.all([
       listWorkspaceDocuments(workspace.id, 5),
@@ -56,15 +61,35 @@ export default async function WorkspacePage({ params }: Props) {
       listWorkspaceMembers(workspace.id),
       getWorkspaceMemberByUserId(workspace.id),
     ]);
-  if (!documentsResult.ok) throw new Error(documentsResult.message);
-  if (!documentCountResult.ok) throw new Error(documentCountResult.message);
-  if (!membersResult.ok) throw new Error(membersResult.message);
-  if (!roleResult.ok) throw new Error(roleResult.message);
+  const documents = requireWorkspaceRouteData(documentsResult, {
+    loginNext,
+    operation: "list_workspace_documents",
+    route,
+    workspaceSlug,
+  });
+  const documentCount = requireWorkspaceRouteData(documentCountResult, {
+    loginNext,
+    operation: "count_workspace_documents",
+    route,
+    workspaceSlug,
+  });
+  const members = requireWorkspaceRouteData(membersResult, {
+    loginNext,
+    operation: "list_workspace_members",
+    route,
+    workspaceSlug,
+  });
+  const membership = requireWorkspaceRouteData(roleResult, {
+    loginNext,
+    operation: "get_workspace_member_by_user_id",
+    route,
+    workspaceSlug,
+  });
 
   const canEdit =
-    roleResult.data.role === WORKSPACE_ROLE.Owner ||
-    roleResult.data.role === WORKSPACE_ROLE.Editor;
-  const isOwner = roleResult.data.role === WORKSPACE_ROLE.Owner;
+    membership.role === WORKSPACE_ROLE.Owner ||
+    membership.role === WORKSPACE_ROLE.Editor;
+  const isOwner = membership.role === WORKSPACE_ROLE.Owner;
 
   return (
     <div className="min-w-0 flex-1 overflow-y-auto">
@@ -72,7 +97,7 @@ export default async function WorkspacePage({ params }: Props) {
         <div className="mx-auto flex max-w-6xl flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
           <div className="min-w-0">
             <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-primary">
-              Workspace / {roleResult.data.role.toLowerCase()}
+              Workspace / {membership.role.toLowerCase()}
             </p>
             <h1 className="font-display mt-2 truncate text-3xl font-semibold">
               {workspace.title}
@@ -83,7 +108,10 @@ export default async function WorkspacePage({ params }: Props) {
           </div>
           <div className="flex flex-wrap gap-2">
             <Button asChild variant="outline">
-              <Link href={`/workspace/${workspaceSlug}/settings`}>
+              <Link
+                href={`/workspace/${workspaceSlug}/settings`}
+                prefetch={false}
+              >
                 <Settings2 className="mr-2 h-4 w-4" />
                 Settings
               </Link>
@@ -106,11 +134,11 @@ export default async function WorkspacePage({ params }: Props) {
             <div>
               <h2 className="text-lg font-semibold">Recent documents</h2>
               <p className="text-sm text-muted-foreground">
-                {documentCountResult.data} total
+                {documentCount} total
               </p>
             </div>
           </div>
-          {documentsResult.data.length === 0 ? (
+          {documents.length === 0 ? (
             <div className="rounded-sm border border-dashed p-10 text-center">
               <FileText className="mx-auto h-8 w-8 text-muted-foreground" />
               <h3 className="mt-4 font-medium">No documents yet</h3>
@@ -128,7 +156,7 @@ export default async function WorkspacePage({ params }: Props) {
             </div>
           ) : (
             <div className="divide-y rounded-sm border bg-card">
-              {documentsResult.data.map((document) => (
+              {documents.map((document) => (
                 <Link
                   className="flex min-w-0 items-center gap-4 p-4 transition-colors hover:bg-accent"
                   href={`/workspace/${workspaceSlug}/doc/${document.slug}`}
@@ -159,13 +187,13 @@ export default async function WorkspacePage({ params }: Props) {
             <div>
               <h2 className="text-lg font-semibold">Members</h2>
               <p className="text-sm text-muted-foreground">
-                {membersResult.data.length} people
+                {members.length} people
               </p>
             </div>
             <Users className="h-4 w-4 text-muted-foreground" />
           </div>
           <div className="space-y-1">
-            {membersResult.data.slice(0, 8).map((member) => (
+            {members.slice(0, 8).map((member) => (
               <div
                 className="flex items-center gap-3 rounded-sm px-2 py-2"
                 key={member.member_id}
@@ -192,7 +220,10 @@ export default async function WorkspacePage({ params }: Props) {
           </div>
           {isOwner ? (
             <Button asChild className="mt-4 w-full" size="sm" variant="outline">
-              <Link href={`/workspace/${workspaceSlug}/settings?tab=members`}>
+              <Link
+                href={`/workspace/${workspaceSlug}/settings?tab=members`}
+                prefetch={false}
+              >
                 Manage members
               </Link>
             </Button>

--- a/apps/web/app/workspace/[workspaceSlug]/page.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/page.tsx
@@ -43,15 +43,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function WorkspacePage({ params }: Props) {
   const { workspaceSlug } = await params;
-  const loginNext = `/workspace/${workspaceSlug}`;
-  const route = "/workspace/[workspaceSlug]";
+  const failureContext = {
+    loginNext: `/workspace/${workspaceSlug}`,
+    route: "/workspace/[workspaceSlug]",
+    workspaceSlug,
+  } as const;
   const workspace = requireWorkspaceRouteData(
     await cachedGetWorkspaceBySlug(workspaceSlug),
     {
-      loginNext,
+      ...failureContext,
       operation: "get_workspace_by_slug",
-      route,
-      workspaceSlug,
     },
   );
   const [documentsResult, documentCountResult, membersResult, roleResult] =
@@ -62,28 +63,20 @@ export default async function WorkspacePage({ params }: Props) {
       getWorkspaceMemberByUserId(workspace.id),
     ]);
   const documents = requireWorkspaceRouteData(documentsResult, {
-    loginNext,
+    ...failureContext,
     operation: "list_workspace_documents",
-    route,
-    workspaceSlug,
   });
   const documentCount = requireWorkspaceRouteData(documentCountResult, {
-    loginNext,
+    ...failureContext,
     operation: "count_workspace_documents",
-    route,
-    workspaceSlug,
   });
   const members = requireWorkspaceRouteData(membersResult, {
-    loginNext,
+    ...failureContext,
     operation: "list_workspace_members",
-    route,
-    workspaceSlug,
   });
   const membership = requireWorkspaceRouteData(roleResult, {
-    loginNext,
+    ...failureContext,
     operation: "get_workspace_member_by_user_id",
-    route,
-    workspaceSlug,
   });
 
   const canEdit =

--- a/apps/web/app/workspace/[workspaceSlug]/settings/page.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/settings/page.tsx
@@ -17,18 +17,20 @@ export default async function WorkspaceSettingsPage({
 }) {
   const { workspaceSlug } = await params;
   const { tab } = await searchParams;
-  const loginNext =
-    tab === "members"
-      ? `/workspace/${workspaceSlug}/settings?tab=members`
-      : `/workspace/${workspaceSlug}/settings`;
+  const failureContext = {
+    loginNext:
+      tab === "members"
+        ? `/workspace/${workspaceSlug}/settings?tab=members`
+        : `/workspace/${workspaceSlug}/settings`,
+    route: ROUTE,
+    workspaceSlug,
+  } as const;
 
   const workspace = requireWorkspaceRouteData(
     await cachedGetWorkspaceBySlug(workspaceSlug),
     {
-      loginNext,
+      ...failureContext,
       operation: "get_workspace_by_slug",
-      route: ROUTE,
-      workspaceSlug,
     },
   );
 
@@ -38,16 +40,12 @@ export default async function WorkspaceSettingsPage({
   ]);
 
   const membership = requireWorkspaceRouteData(membershipResult, {
-    loginNext,
+    ...failureContext,
     operation: "get_workspace_member_by_user_id",
-    route: ROUTE,
-    workspaceSlug,
   });
   const members = requireWorkspaceRouteData(membersResult, {
-    loginNext,
+    ...failureContext,
     operation: "list_workspace_members",
-    route: ROUTE,
-    workspaceSlug,
   });
 
   return (

--- a/apps/web/app/workspace/[workspaceSlug]/settings/page.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/settings/page.tsx
@@ -1,10 +1,12 @@
-import { notFound } from "next/navigation";
 import { cachedGetWorkspaceBySlug } from "@/app/actions/workspaces";
 import {
   getWorkspaceMemberByUserId,
   listWorkspaceMembers,
 } from "@/app/actions/workspaceMembers";
+import { requireWorkspaceRouteData } from "@/lib/actions/workspace-route";
 import { WorkspaceSettings } from "@/modules/workspaces/workspace-settings";
+
+const ROUTE = "/workspace/[workspaceSlug]/settings";
 
 export default async function WorkspaceSettingsPage({
   params,
@@ -15,20 +17,45 @@ export default async function WorkspaceSettingsPage({
 }) {
   const { workspaceSlug } = await params;
   const { tab } = await searchParams;
-  const workspace = await cachedGetWorkspaceBySlug(workspaceSlug);
-  if (!workspace.ok) notFound();
-  const [membership, members] = await Promise.all([
-    getWorkspaceMemberByUserId(workspace.data.id),
-    listWorkspaceMembers(workspace.data.id),
+  const loginNext =
+    tab === "members"
+      ? `/workspace/${workspaceSlug}/settings?tab=members`
+      : `/workspace/${workspaceSlug}/settings`;
+
+  const workspace = requireWorkspaceRouteData(
+    await cachedGetWorkspaceBySlug(workspaceSlug),
+    {
+      loginNext,
+      operation: "get_workspace_by_slug",
+      route: ROUTE,
+      workspaceSlug,
+    },
+  );
+
+  const [membershipResult, membersResult] = await Promise.all([
+    getWorkspaceMemberByUserId(workspace.id),
+    listWorkspaceMembers(workspace.id),
   ]);
-  if (!membership.ok || !members.ok) notFound();
+
+  const membership = requireWorkspaceRouteData(membershipResult, {
+    loginNext,
+    operation: "get_workspace_member_by_user_id",
+    route: ROUTE,
+    workspaceSlug,
+  });
+  const members = requireWorkspaceRouteData(membersResult, {
+    loginNext,
+    operation: "list_workspace_members",
+    route: ROUTE,
+    workspaceSlug,
+  });
 
   return (
     <WorkspaceSettings
-      members={members.data}
-      role={membership.data.role}
+      members={members}
+      role={membership.role}
       initialTab={tab === "members" ? "members" : "general"}
-      workspace={workspace.data}
+      workspace={workspace}
     />
   );
 }

--- a/apps/web/e2e/helpers/seed.ts
+++ b/apps/web/e2e/helpers/seed.ts
@@ -1,5 +1,11 @@
 import type { Page } from "@playwright/test";
 
+type SeedWorkspace = {
+  readonly id: number;
+  readonly slug: string;
+  readonly title: string;
+};
+
 export type E2ESeed = {
   readonly document: {
     readonly id: string;
@@ -8,12 +14,11 @@ export type E2ESeed = {
   };
   readonly editor: { readonly email: string; readonly password: string };
   readonly owner: { readonly email: string; readonly password: string };
+  /** Workspace owned by seed.owner with no viewer/editor membership. */
+  readonly ownerOnlyWorkspace: SeedWorkspace;
   readonly viewer: { readonly email: string; readonly password: string };
-  readonly workspace: {
-    readonly id: number;
-    readonly slug: string;
-    readonly title: string;
-  };
+  /** Shared workspace where viewer is a member. */
+  readonly workspace: SeedWorkspace;
 };
 
 const seedRequest = async (action: "cleanup" | "seed", runId: string) => {

--- a/apps/web/e2e/workspace-settings.spec.ts
+++ b/apps/web/e2e/workspace-settings.spec.ts
@@ -71,11 +71,22 @@ test("missing workspace Settings slug returns 404", async ({ page }) => {
 test("authenticated viewer gets 404 for a missing workspace Settings slug", async ({
   page,
 }) => {
-  // Seed helpers only create one shared workspace where viewer is a member, so
-  // this covers a truly missing slug (not a separate foreign-workspace seed).
   await login(page, seed.viewer);
   const response = await page.goto(
     "/workspace/does-not-exist-zzzzzzzzzzzz/settings",
+  );
+  expect(response?.status()).toBe(404);
+  await expect(page.getByText(/This page could not be found/i)).toBeVisible();
+  await expect(page).not.toHaveURL(/\/login/);
+});
+
+test("non-member viewer gets 404 for an owner-only workspace Settings route", async ({
+  page,
+}) => {
+  // RLS hides inaccessible workspaces as missing → ActionResult NOT_FOUND → notFound().
+  await login(page, seed.viewer);
+  const response = await page.goto(
+    `/workspace/${seed.ownerOnlyWorkspace.slug}/settings`,
   );
   expect(response?.status()).toBe(404);
   await expect(page.getByText(/This page could not be found/i)).toBeVisible();

--- a/apps/web/e2e/workspace-settings.spec.ts
+++ b/apps/web/e2e/workspace-settings.spec.ts
@@ -32,7 +32,9 @@ test("authenticated member can open Settings and Members from the workspace", as
 
   await settingsLink.click();
   await expect(page).toHaveURL(
-    new RegExp(`/workspace/${seed.workspace.slug}/settings`),
+    (url) =>
+      url.pathname === `/workspace/${seed.workspace.slug}/settings` &&
+      url.search === "",
   );
   await expect(page.getByLabel("Name")).toHaveValue(seed.workspace.title);
 
@@ -66,14 +68,14 @@ test("missing workspace Settings slug returns 404", async ({ page }) => {
   await expect(page.getByText(/This page could not be found/i)).toBeVisible();
 });
 
-test("inaccessible workspace Settings returns intentional 404", async ({
+test("authenticated viewer gets 404 for a missing workspace Settings slug", async ({
   page,
 }) => {
-  // Viewer is a member of the seeded workspace; use a slug they cannot see.
-  // RLS hides foreign private workspaces as missing → same 404 as not found.
+  // Seed helpers only create one shared workspace where viewer is a member, so
+  // this covers a truly missing slug (not a separate foreign-workspace seed).
   await login(page, seed.viewer);
   const response = await page.goto(
-    "/workspace/someone-elses-workspace-zzzz/settings",
+    "/workspace/does-not-exist-zzzzzzzzzzzz/settings",
   );
   expect(response?.status()).toBe(404);
   await expect(page.getByText(/This page could not be found/i)).toBeVisible();

--- a/apps/web/e2e/workspace-settings.spec.ts
+++ b/apps/web/e2e/workspace-settings.spec.ts
@@ -19,7 +19,9 @@ test("authenticated member can open Settings and Members from the workspace", as
   page,
 }) => {
   await login(page, seed.owner);
-  await page.goto(`/workspace/${seed.workspace.slug}/doc/${seed.document.slug}`);
+  await page.goto(
+    `/workspace/${seed.workspace.slug}/doc/${seed.document.slug}`,
+  );
   await expect(page.getByLabel("Document title")).toBeVisible();
 
   const settingsLink = page.getByRole("link", { name: "Settings" }).first();
@@ -52,9 +54,7 @@ test("unauthenticated Settings access redirects to login instead of 404", async 
   await expect(
     page.getByRole("heading", { name: /Welcome back/i }),
   ).toBeVisible();
-  await expect(
-    page.getByText(/This page could not be found/i),
-  ).toHaveCount(0);
+  await expect(page.getByText(/This page could not be found/i)).toHaveCount(0);
 });
 
 test("missing workspace Settings slug returns 404", async ({ page }) => {
@@ -63,9 +63,7 @@ test("missing workspace Settings slug returns 404", async ({ page }) => {
     "/workspace/does-not-exist-zzzzzzzzzzzz/settings",
   );
   expect(response?.status()).toBe(404);
-  await expect(
-    page.getByText(/This page could not be found/i),
-  ).toBeVisible();
+  await expect(page.getByText(/This page could not be found/i)).toBeVisible();
 });
 
 test("inaccessible workspace Settings returns intentional 404", async ({
@@ -78,8 +76,6 @@ test("inaccessible workspace Settings returns intentional 404", async ({
     "/workspace/someone-elses-workspace-zzzz/settings",
   );
   expect(response?.status()).toBe(404);
-  await expect(
-    page.getByText(/This page could not be found/i),
-  ).toBeVisible();
+  await expect(page.getByText(/This page could not be found/i)).toBeVisible();
   await expect(page).not.toHaveURL(/\/login/);
 });

--- a/apps/web/e2e/workspace-settings.spec.ts
+++ b/apps/web/e2e/workspace-settings.spec.ts
@@ -1,0 +1,85 @@
+import { randomBytes } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { cleanupSeed, createSeed, login, type E2ESeed } from "./helpers/seed";
+
+const runId = `pw-settings-${randomBytes(8).toString("hex")}`;
+let seed: E2ESeed;
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeAll(async () => {
+  seed = await createSeed(runId);
+});
+
+test.afterAll(async () => {
+  await cleanupSeed(runId);
+});
+
+test("authenticated member can open Settings and Members from the workspace", async ({
+  page,
+}) => {
+  await login(page, seed.owner);
+  await page.goto(`/workspace/${seed.workspace.slug}/doc/${seed.document.slug}`);
+  await expect(page.getByLabel("Document title")).toBeVisible();
+
+  const settingsLink = page.getByRole("link", { name: "Settings" }).first();
+  await expect(settingsLink).toHaveAttribute(
+    "href",
+    `/workspace/${seed.workspace.slug}/settings`,
+  );
+
+  await settingsLink.click();
+  await expect(page).toHaveURL(
+    new RegExp(`/workspace/${seed.workspace.slug}/settings`),
+  );
+  await expect(page.getByLabel("Name")).toHaveValue(seed.workspace.title);
+
+  await page.getByRole("link", { name: "Members" }).first().click();
+  await expect(page).toHaveURL(/tab=members/);
+  await expect(page.getByText("E2E Editor")).toBeVisible();
+});
+
+test("unauthenticated Settings access redirects to login instead of 404", async ({
+  page,
+}) => {
+  await page.goto(`/workspace/${seed.workspace.slug}/settings`);
+  await expect(page).toHaveURL(/\/login/);
+  const loginUrl = new URL(page.url());
+  expect(loginUrl.pathname).toBe("/login");
+  expect(loginUrl.searchParams.get("next")).toBe(
+    `/workspace/${seed.workspace.slug}/settings`,
+  );
+  await expect(
+    page.getByRole("heading", { name: /Welcome back/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/This page could not be found/i),
+  ).toHaveCount(0);
+});
+
+test("missing workspace Settings slug returns 404", async ({ page }) => {
+  await login(page, seed.owner);
+  const response = await page.goto(
+    "/workspace/does-not-exist-zzzzzzzzzzzz/settings",
+  );
+  expect(response?.status()).toBe(404);
+  await expect(
+    page.getByText(/This page could not be found/i),
+  ).toBeVisible();
+});
+
+test("inaccessible workspace Settings returns intentional 404", async ({
+  page,
+}) => {
+  // Viewer is a member of the seeded workspace; use a slug they cannot see.
+  // RLS hides foreign private workspaces as missing → same 404 as not found.
+  await login(page, seed.viewer);
+  const response = await page.goto(
+    "/workspace/someone-elses-workspace-zzzz/settings",
+  );
+  expect(response?.status()).toBe(404);
+  await expect(
+    page.getByText(/This page could not be found/i),
+  ).toBeVisible();
+  await expect(page).not.toHaveURL(/\/login/);
+});

--- a/apps/web/lib/actions/workspace-route.test.ts
+++ b/apps/web/lib/actions/workspace-route.test.ts
@@ -97,22 +97,19 @@ describe("requireWorkspaceRouteData", () => {
     [ACTION_ERROR_CODE.Conflict, "That change conflicts with existing data."],
     [ACTION_ERROR_CODE.Validation, "Check the highlighted fields."],
     [ACTION_ERROR_CODE.Storage, "Storage failed."],
-  ] as const)(
-    "maps %s to a thrown server error instead of notFound",
-    async (code, message) => {
-      const { requireWorkspaceRouteData } = await import("./workspace-route");
-      expect(() =>
-        requireWorkspaceRouteData(actionFailure(code, message), context),
-      ).toThrow(`${context.operation} failed (${code}): ${message}`);
-      expect(notFound).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalledWith(
-        "[workspace-route]",
-        expect.objectContaining({
-          code,
-          operation: context.operation,
-          workspaceSlug: context.workspaceSlug,
-        }),
-      );
-    },
-  );
+  ] as const)("maps %s to a thrown server error instead of notFound", async (code, message) => {
+    const { requireWorkspaceRouteData } = await import("./workspace-route");
+    expect(() =>
+      requireWorkspaceRouteData(actionFailure(code, message), context),
+    ).toThrow(`${context.operation} failed (${code}): ${message}`);
+    expect(notFound).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "[workspace-route]",
+      expect.objectContaining({
+        code,
+        operation: context.operation,
+        workspaceSlug: context.workspaceSlug,
+      }),
+    );
+  });
 });

--- a/apps/web/lib/actions/workspace-route.test.ts
+++ b/apps/web/lib/actions/workspace-route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ACTION_ERROR_CODE, actionFailure, actionSuccess } from "./result";
 
 const notFound = vi.hoisted(() =>
@@ -29,6 +29,10 @@ describe("requireWorkspaceRouteData", () => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("returns data for successful results", async () => {

--- a/apps/web/lib/actions/workspace-route.test.ts
+++ b/apps/web/lib/actions/workspace-route.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ACTION_ERROR_CODE, actionFailure, actionSuccess } from "./result";
+
+const notFound = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+);
+const redirect = vi.hoisted(() =>
+  vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+);
+
+vi.mock("next/navigation", () => ({
+  notFound,
+  redirect,
+}));
+
+describe("requireWorkspaceRouteData", () => {
+  const context = {
+    loginNext: "/workspace/acme/settings",
+    operation: "list_workspace_members",
+    route: "/workspace/[workspaceSlug]/settings",
+    workspaceSlug: "acme",
+  } as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  it("returns data for successful results", async () => {
+    const { requireWorkspaceRouteData } = await import("./workspace-route");
+    expect(
+      requireWorkspaceRouteData(actionSuccess({ role: "OWNER" }), context),
+    ).toEqual({ role: "OWNER" });
+    expect(notFound).not.toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it("maps NOT_FOUND to notFound without logging", async () => {
+    const { requireWorkspaceRouteData } = await import("./workspace-route");
+    expect(() =>
+      requireWorkspaceRouteData(
+        actionFailure(ACTION_ERROR_CODE.NotFound, "Workspace not found."),
+        context,
+      ),
+    ).toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalledOnce();
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("maps FORBIDDEN to notFound and warns", async () => {
+    const { requireWorkspaceRouteData } = await import("./workspace-route");
+    expect(() =>
+      requireWorkspaceRouteData(
+        actionFailure(
+          ACTION_ERROR_CODE.Forbidden,
+          "You do not have access to this workspace.",
+        ),
+        context,
+      ),
+    ).toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalledOnce();
+    expect(console.warn).toHaveBeenCalledWith(
+      "[workspace-route]",
+      expect.objectContaining({
+        code: ACTION_ERROR_CODE.Forbidden,
+        operation: "list_workspace_members",
+        workspaceSlug: "acme",
+      }),
+    );
+  });
+
+  it("maps AUTHENTICATION_REQUIRED to a login redirect with next", async () => {
+    const { requireWorkspaceRouteData } = await import("./workspace-route");
+    expect(() =>
+      requireWorkspaceRouteData(
+        actionFailure(
+          ACTION_ERROR_CODE.AuthenticationRequired,
+          "Sign in to continue.",
+        ),
+        context,
+      ),
+    ).toThrow("NEXT_REDIRECT:/login?next=%2Fworkspace%2Facme%2Fsettings");
+    expect(redirect).toHaveBeenCalledWith(
+      "/login?next=%2Fworkspace%2Facme%2Fsettings",
+    );
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [ACTION_ERROR_CODE.Internal, "Could not load workspace members."],
+    [ACTION_ERROR_CODE.Conflict, "That change conflicts with existing data."],
+    [ACTION_ERROR_CODE.Validation, "Check the highlighted fields."],
+    [ACTION_ERROR_CODE.Storage, "Storage failed."],
+  ] as const)(
+    "maps %s to a thrown server error instead of notFound",
+    async (code, message) => {
+      const { requireWorkspaceRouteData } = await import("./workspace-route");
+      expect(() =>
+        requireWorkspaceRouteData(actionFailure(code, message), context),
+      ).toThrow(`${context.operation} failed (${code}): ${message}`);
+      expect(notFound).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        "[workspace-route]",
+        expect.objectContaining({
+          code,
+          operation: context.operation,
+          workspaceSlug: context.workspaceSlug,
+        }),
+      );
+    },
+  );
+});

--- a/apps/web/lib/actions/workspace-route.ts
+++ b/apps/web/lib/actions/workspace-route.ts
@@ -1,0 +1,71 @@
+import { notFound, redirect } from "next/navigation";
+import {
+  ACTION_ERROR_CODE,
+  type ActionErrorCode,
+  type ActionResult,
+} from "@/lib/actions/result";
+
+export type WorkspaceRouteFailureContext = {
+  readonly loginNext: string;
+  readonly operation: string;
+  readonly route: string;
+  readonly workspaceSlug: string;
+};
+
+const logWorkspaceRouteFailure = (
+  level: "error" | "warn",
+  context: WorkspaceRouteFailureContext,
+  code: ActionErrorCode,
+  message: string,
+): void => {
+  const payload = {
+    code,
+    message,
+    operation: context.operation,
+    route: context.route,
+    workspaceSlug: context.workspaceSlug,
+  };
+  if (level === "error") {
+    console.error("[workspace-route]", payload);
+    return;
+  }
+  console.warn("[workspace-route]", payload);
+};
+
+/**
+ * Maps a failed workspace ActionResult to HTTP/route behavior.
+ *
+ * - Missing or inaccessible resources → notFound() (resource hiding)
+ * - Missing/expired auth → login redirect
+ * - Internal/validation/conflict/storage → throw for the nearest error boundary
+ */
+export const settleWorkspaceRouteFailure = (
+  result: Extract<ActionResult<unknown>, { readonly ok: false }>,
+  context: WorkspaceRouteFailureContext,
+): never => {
+  if (result.code === ACTION_ERROR_CODE.NotFound) {
+    notFound();
+  }
+
+  if (result.code === ACTION_ERROR_CODE.Forbidden) {
+    logWorkspaceRouteFailure("warn", context, result.code, result.message);
+    notFound();
+  }
+
+  if (result.code === ACTION_ERROR_CODE.AuthenticationRequired) {
+    redirect(`/login?next=${encodeURIComponent(context.loginNext)}`);
+  }
+
+  logWorkspaceRouteFailure("error", context, result.code, result.message);
+  throw new Error(
+    `${context.operation} failed (${result.code}): ${result.message}`,
+  );
+};
+
+export const requireWorkspaceRouteData = <T>(
+  result: ActionResult<T>,
+  context: WorkspaceRouteFailureContext,
+): T => {
+  if (result.ok) return result.data;
+  return settleWorkspaceRouteFailure(result, context);
+};

--- a/apps/web/modules/workspaces/workspace-dropdown.tsx
+++ b/apps/web/modules/workspaces/workspace-dropdown.tsx
@@ -9,26 +9,18 @@ import {
 } from "@softmaple/ui/components/dropdown-menu";
 import { Button } from "@softmaple/ui/components/button";
 import { ChevronDown, FileText, Plus, Settings } from "lucide-react";
-import { cachedGetWorkspaces } from "@/app/actions/workspaces";
+import type { WorkspaceSummary } from "@/app/actions/workspaces";
 import Link from "next/link";
 
 export type WorkspaceDropdownProps = {
   workspaceSlug: string;
-  workspacesResource: Awaited<ReturnType<typeof cachedGetWorkspaces>>;
+  workspaces: ReadonlyArray<WorkspaceSummary>;
 };
 
 export const WorkspaceDropdown: FC<WorkspaceDropdownProps> = (props) => {
-  const { workspaceSlug, workspacesResource } = props;
+  const { workspaceSlug, workspaces: workspaceSummaries } = props;
 
-  if (!workspacesResource.ok) {
-    return (
-      <div className="p-2 text-sm text-destructive">
-        {workspacesResource.message}
-      </div>
-    );
-  }
-
-  const workspaces = workspacesResource.data.map((workspace) => ({
+  const workspaces = workspaceSummaries.map((workspace) => ({
     ...workspace,
     key: workspace.id,
   }));

--- a/apps/web/modules/workspaces/workspace-navigation.test.tsx
+++ b/apps/web/modules/workspaces/workspace-navigation.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceNavigation } from "./workspace-navigation";
+
+const usePathname = vi.hoisted(() => vi.fn(() => "/workspace/acme"));
+const useSearchParams = vi.hoisted(
+  () => vi.fn(() => new URLSearchParams()),
+);
+
+vi.mock("next/navigation", () => ({
+  usePathname,
+  useSearchParams,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    prefetch,
+    ...props
+  }: {
+    readonly children: ReactNode;
+    readonly href: string;
+    readonly onClick?: () => void;
+    readonly prefetch?: boolean;
+  }) =>
+    createElement(
+      "a",
+      {
+        href,
+        "data-prefetch":
+          prefetch === undefined ? "default" : String(prefetch),
+        ...props,
+      },
+      children,
+    ),
+}));
+
+describe("WorkspaceNavigation", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    usePathname.mockReturnValue("/workspace/acme");
+    useSearchParams.mockReturnValue(new URLSearchParams());
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("disables automatic prefetch for Settings and Members admin links", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        createElement(WorkspaceNavigation, { workspaceSlug: "acme" }),
+      );
+    });
+
+    const prefetchByHref = Object.fromEntries(
+      Array.from(container.querySelectorAll("a")).map((link) => [
+        link.getAttribute("href"),
+        link.getAttribute("data-prefetch"),
+      ]),
+    );
+
+    expect(prefetchByHref["/workspace/acme"]).toBe("default");
+    expect(prefetchByHref["/workspace/acme/settings?tab=members"]).toBe(
+      "false",
+    );
+    expect(prefetchByHref["/workspace/acme/settings"]).toBe("false");
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/modules/workspaces/workspace-navigation.test.tsx
+++ b/apps/web/modules/workspaces/workspace-navigation.test.tsx
@@ -6,9 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceNavigation } from "./workspace-navigation";
 
 const usePathname = vi.hoisted(() => vi.fn(() => "/workspace/acme"));
-const useSearchParams = vi.hoisted(
-  () => vi.fn(() => new URLSearchParams()),
-);
+const useSearchParams = vi.hoisted(() => vi.fn(() => new URLSearchParams()));
 
 vi.mock("next/navigation", () => ({
   usePathname,
@@ -31,8 +29,7 @@ vi.mock("next/link", () => ({
       "a",
       {
         href,
-        "data-prefetch":
-          prefetch === undefined ? "default" : String(prefetch),
+        "data-prefetch": prefetch === undefined ? "default" : String(prefetch),
         ...props,
       },
       children,

--- a/apps/web/modules/workspaces/workspace-navigation.tsx
+++ b/apps/web/modules/workspaces/workspace-navigation.tsx
@@ -32,9 +32,15 @@ export const WorkspaceNavigation: FC<WorkspaceNavigationProps> = (props) => {
           Overview
         </Button>
       </Link>
+      {/*
+        Settings/Members are auth- and membership-sensitive admin routes.
+        Speculative Link prefetch can race session refresh and historically
+        collapsed ActionResult failures into cacheable 404s; load on navigate.
+      */}
       <Link
         href={`/workspace/${workspaceSlug}/settings?tab=members`}
         onClick={onNavigate}
+        prefetch={false}
       >
         <Button
           className="w-full justify-start"
@@ -48,7 +54,11 @@ export const WorkspaceNavigation: FC<WorkspaceNavigationProps> = (props) => {
           Members
         </Button>
       </Link>
-      <Link href={`/workspace/${workspaceSlug}/settings`} onClick={onNavigate}>
+      <Link
+        href={`/workspace/${workspaceSlug}/settings`}
+        onClick={onNavigate}
+        prefetch={false}
+      >
         <Button
           variant={
             isSettings && searchParams.get("tab") !== "members"

--- a/apps/web/utils/supabase/middleware.test.ts
+++ b/apps/web/utils/supabase/middleware.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUser = vi.hoisted(() => vi.fn());
+const createServerClient = vi.hoisted(() => vi.fn());
+const resolveSupabasePublicConfig = vi.hoisted(() =>
+  vi.fn(() => ({
+    publishableKey: "test-key",
+    url: "https://example.supabase.co",
+  })),
+);
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient,
+}));
+
+vi.mock("./config", () => ({
+  resolveSupabasePublicConfig,
+}));
+
+describe("updateSession protected-route redirects", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createServerClient.mockImplementation((_url, _key, options) => {
+      options.cookies.getAll();
+      options.cookies.setAll([{ name: "sb", value: "1", options: {} }]);
+      return {
+        auth: {
+          getUser,
+        },
+      };
+    });
+  });
+
+  it("redirects unauthenticated workspace Settings requests to login with next", async () => {
+    getUser.mockResolvedValue({ data: { user: null } });
+    const { updateSession } = await import("./middleware");
+    const request = {
+      cookies: {
+        getAll: () => [],
+        set: vi.fn(),
+      },
+      nextUrl: {
+        clone() {
+          return new URL(
+            "http://localhost:3000/workspace/acme/settings?tab=members",
+          );
+        },
+        pathname: "/workspace/acme/settings",
+        search: "?tab=members",
+      },
+    };
+
+    const response = await updateSession(request as never);
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/login?next=%2Fworkspace%2Facme%2Fsettings%3Ftab%3Dmembers",
+    );
+  });
+
+  it("allows authenticated workspace requests through", async () => {
+    getUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+    const { updateSession } = await import("./middleware");
+    const request = {
+      cookies: {
+        getAll: () => [{ name: "sb", value: "1" }],
+        set: vi.fn(),
+      },
+      nextUrl: {
+        clone() {
+          return new URL("http://localhost:3000/workspace/acme/settings");
+        },
+        pathname: "/workspace/acme/settings",
+        search: "",
+      },
+    };
+
+    const response = await updateSession(request as never);
+    expect(response.status).toBe(200);
+  });
+});

--- a/apps/web/utils/supabase/middleware.test.ts
+++ b/apps/web/utils/supabase/middleware.test.ts
@@ -22,7 +22,14 @@ describe("updateSession protected-route redirects", () => {
     vi.clearAllMocks();
     createServerClient.mockImplementation((_url, _key, options) => {
       options.cookies.getAll();
-      options.cookies.setAll([{ name: "sb", value: "1", options: {} }]);
+      options.cookies.setAll([
+        { name: "sb-access-token", value: "refreshed", options: {} },
+        {
+          name: "sb-refresh-token",
+          value: "",
+          options: { maxAge: 0 },
+        },
+      ]);
       return {
         auth: {
           getUser,
@@ -55,6 +62,8 @@ describe("updateSession protected-route redirects", () => {
     expect(response.headers.get("location")).toBe(
       "http://localhost:3000/login?next=%2Fworkspace%2Facme%2Fsettings%3Ftab%3Dmembers",
     );
+    expect(response.cookies.get("sb-access-token")?.value).toBe("refreshed");
+    expect(response.cookies.get("sb-refresh-token")?.value).toBe("");
   });
 
   it("allows authenticated workspace requests through", async () => {
@@ -78,5 +87,6 @@ describe("updateSession protected-route redirects", () => {
 
     const response = await updateSession(request as never);
     expect(response.status).toBe(200);
+    expect(response.cookies.get("sb-access-token")?.value).toBe("refreshed");
   });
 });

--- a/apps/web/utils/supabase/middleware.ts
+++ b/apps/web/utils/supabase/middleware.ts
@@ -50,7 +50,13 @@ export async function updateSession(request: NextRequest) {
     url.pathname = "/login";
     url.search = "";
     url.searchParams.set("next", returnPath);
-    return NextResponse.redirect(url);
+    const redirectResponse = NextResponse.redirect(url);
+    // Preserve any cookies Supabase refreshed/cleared during getUser().
+    // ResponseCookies has no setAll(); copy each cookie from supabaseResponse.
+    for (const cookie of supabaseResponse.cookies.getAll()) {
+      redirectResponse.cookies.set(cookie);
+    }
+    return redirectResponse;
   }
 
   // IMPORTANT: You *must* return the supabaseResponse object as it is.

--- a/apps/web/utils/supabase/middleware.ts
+++ b/apps/web/utils/supabase/middleware.ts
@@ -46,7 +46,10 @@ export async function updateSession(request: NextRequest) {
   ) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone();
+    const returnPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
     url.pathname = "/login";
+    url.search = "";
+    url.searchParams.set("next", returnPath);
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes intermittent/incorrect `404` responses on authenticated workspace admin routes (especially `/workspace/[workspaceSlug]/settings` and `?tab=members`) by mapping `ActionResult` error codes to the correct route behavior instead of treating every failure as `notFound()`.

**Root cause (confirmed):** Settings (and related workspace pages) used patterns like `if (!result.ok) notFound()`, which converted `AUTHENTICATION_REQUIRED`, `INTERNAL`, and RPC/database failures into normal 404s. Those 404 RSC payloads can later be reused (`Cache: HIT`) during prefetch/navigation.

## Changes

- Add `requireWorkspaceRouteData` / `settleWorkspaceRouteFailure` helper with structured server logs
- Apply correct semantics on Settings, document, overview, and workspace layout routes
- Disable `<Link prefetch={false}>` only for Settings/Members admin links
- Preserve `next=` return path on middleware login redirects for protected routes
- Add Vitest coverage for error mapping, nav prefetch, and middleware login redirects
- Add Playwright settings regression suite (`e2e/workspace-settings.spec.ts`)

## Error semantics

| Condition | Behavior |
| --- | --- |
| Missing / RLS-hidden workspace or non-member | `notFound()` (intentional resource hiding) |
| Auth missing/expired | redirect to `/login?next=...` |
| Internal / RPC / unexpected failures | throw → error boundary (not 404) |

## Caching / prefetch

- No global cache or `force-dynamic` changes. `cache(getWorkspaceBySlug)` remains request-scoped React `cache()` dedupe.
- Settings/Members links use `prefetch={false}` because they are auth/membership-sensitive admin routes with little benefit from speculative preload.

## Test plan

- [x] `pnpm --filter @softmaple/web typecheck`
- [x] `pnpm --filter @softmaple/web lint`
- [x] `pnpm --filter @softmaple/web exec vitest run lib/actions/workspace-route.test.ts modules/workspaces/workspace-navigation.test.tsx utils/supabase/middleware.test.ts`
- [ ] `pnpm --filter @softmaple/web test:e2e e2e/workspace-settings.spec.ts` (needs Supabase/`E2E_SEED_SECRET` in this environment)
- [ ] Manual: sign in → open doc → Settings / Members → verify no false 404s
- [ ] Manual: unauthenticated Settings → login redirect with `next`
- [ ] Manual: missing/inaccessible workspace → intentional 404

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85dbb4bd-807c-4f22-a1eb-ef76d06619f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85dbb4bd-807c-4f22-a1eb-ef76d06619f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing, restricted, unauthenticated, and server-error scenarios across workspace, document, and settings pages.
  * Unauthenticated visitors are redirected to login and returned to their original destination.
  * Restricted workspace settings are now correctly unavailable to non-members.
  * Reduced unnecessary prefetching for Settings and Members links.
  * Improved workspace navigation and dropdown behavior.

* **Tests**
  * Added coverage for navigation, protected routes, redirects, permissions, missing workspaces, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->