### PR TITLE
test(apps/collab): harden collaboration consistency baseline

### DIFF
--- a/apps/collab/package.json
+++ b/apps/collab/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@softmaple/typescript-config": "workspace:*",
     "@types/node": "^24.10.4",
+    "fast-check": "^4.8.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }

--- a/apps/collab/test/collaboration-convergence.property.test.ts
+++ b/apps/collab/test/collaboration-convergence.property.test.ts
@@ -11,9 +11,20 @@ const ACTORS = [
   "00000000-0000-4000-8000-0000000000c3",
 ] as const;
 
-const CI_NUM_RUNS = Number(process.env.COLLAB_CONVERGENCE_RUNS ?? 40);
-const SOAK_NUM_RUNS = Number(process.env.COLLAB_CONVERGENCE_SOAK_RUNS ?? 200);
+const positiveIntEnv = (raw: string | undefined, fallback: number): number => {
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
+  return parsed;
+};
+
+const CI_NUM_RUNS = positiveIntEnv(process.env.COLLAB_CONVERGENCE_RUNS, 40);
+const SOAK_NUM_RUNS = positiveIntEnv(
+  process.env.COLLAB_CONVERGENCE_SOAK_RUNS,
+  200,
+);
 const isSoak = process.env.COLLAB_CONVERGENCE_SOAK === "1";
+const PROPERTY_TIMEOUT_MS = isSoak ? 120_000 : 30_000;
 
 type TraceOp =
   | { readonly kind: "edit"; readonly client: number; readonly text: string }
@@ -175,20 +186,24 @@ const runTrace = async (trace: Trace): Promise<void> => {
 };
 
 describe("randomized collaboration convergence", () => {
-  it("should converge for seeded multi-client collaboration traces", async () => {
-    await fc.assert(
-      fc.asyncProperty(traceArb, async (trace) => {
-        await runTrace(trace);
-      }),
-      {
-        numRuns: isSoak ? SOAK_NUM_RUNS : CI_NUM_RUNS,
-        // Fixed seed keeps CI deterministic; override with fc seed on failure.
-        seed: 868_001,
-        verbose: true,
-        endOnFailure: true,
-      },
-    );
-  });
+  it(
+    "should converge for seeded multi-client collaboration traces",
+    { timeout: PROPERTY_TIMEOUT_MS },
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(traceArb, async (trace) => {
+          await runTrace(trace);
+        }),
+        {
+          numRuns: isSoak ? SOAK_NUM_RUNS : CI_NUM_RUNS,
+          // Fixed seed keeps CI deterministic; override with fc seed on failure.
+          seed: 868_001,
+          verbose: true,
+          endOnFailure: true,
+        },
+      );
+    },
+  );
 
   it("should reproduce a known reconnect-and-duplicate interleaving", async () => {
     // Arrange / Act / Assert: explicit regression seed path for debugging.

--- a/apps/collab/test/collaboration-convergence.property.test.ts
+++ b/apps/collab/test/collaboration-convergence.property.test.ts
@@ -1,0 +1,213 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import {
+  createCollabConsistencyHarness,
+  type HarnessClient,
+} from "./helpers/collabConsistencyHarness";
+
+const ACTORS = [
+  "00000000-0000-4000-8000-0000000000c1",
+  "00000000-0000-4000-8000-0000000000c2",
+  "00000000-0000-4000-8000-0000000000c3",
+] as const;
+
+const CI_NUM_RUNS = Number(process.env.COLLAB_CONVERGENCE_RUNS ?? 40);
+const SOAK_NUM_RUNS = Number(process.env.COLLAB_CONVERGENCE_SOAK_RUNS ?? 200);
+const isSoak = process.env.COLLAB_CONVERGENCE_SOAK === "1";
+
+type TraceOp =
+  | { readonly kind: "edit"; readonly client: number; readonly text: string }
+  | { readonly kind: "disconnect"; readonly client: number }
+  | { readonly kind: "reconnect"; readonly client: number }
+  | { readonly kind: "deliver" }
+  | { readonly kind: "duplicate" }
+  | { readonly kind: "reorder" }
+  | { readonly kind: "settle" };
+
+type Trace = {
+  readonly clientCount: 2 | 3;
+  readonly ops: ReadonlyArray<TraceOp>;
+};
+
+const textArb = fc.constantFrom("a", "b", "c", "x", "y", "z");
+
+const opArb = (clientCount: 2 | 3): fc.Arbitrary<TraceOp> =>
+  fc.oneof(
+    {
+      arbitrary: fc.record({
+        kind: fc.constant("edit" as const),
+        client: fc.integer({ min: 0, max: clientCount - 1 }),
+        text: textArb,
+      }),
+      weight: 5,
+    },
+    {
+      arbitrary: fc.record({
+        kind: fc.constant("disconnect" as const),
+        client: fc.integer({ min: 0, max: clientCount - 1 }),
+      }),
+      weight: 1,
+    },
+    {
+      arbitrary: fc.record({
+        kind: fc.constant("reconnect" as const),
+        client: fc.integer({ min: 0, max: clientCount - 1 }),
+      }),
+      weight: 1,
+    },
+    { arbitrary: fc.constant({ kind: "deliver" as const }), weight: 3 },
+    { arbitrary: fc.constant({ kind: "duplicate" as const }), weight: 1 },
+    { arbitrary: fc.constant({ kind: "reorder" as const }), weight: 1 },
+    { arbitrary: fc.constant({ kind: "settle" as const }), weight: 2 },
+  );
+
+const traceArb: fc.Arbitrary<Trace> = fc
+  .constantFrom(2, 3)
+  .chain((clientCount) =>
+    fc.record({
+      clientCount: fc.constant(clientCount as 2 | 3),
+      ops: fc.array(opArb(clientCount as 2 | 3), {
+        minLength: 4,
+        maxLength: isSoak ? 40 : 18,
+      }),
+    }),
+  );
+
+const formatTrace = (trace: Trace): string =>
+  JSON.stringify(
+    {
+      clientCount: trace.clientCount,
+      ops: trace.ops,
+    },
+    null,
+    2,
+  );
+
+const runTrace = async (trace: Trace): Promise<void> => {
+  const harness = createCollabConsistencyHarness({ pageSize: 2 });
+  harness.setDeliveryMode("deferred");
+  try {
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+    const clients: HarnessClient[] = [];
+
+    for (let index = 0; index < trace.clientCount; index += 1) {
+      const instance = index % 2 === 0 ? instanceA : instanceB;
+      const client = await instance.connectClient({
+        id: `client-${index}`,
+        actorId: ACTORS[index]!,
+      });
+      clients.push(client);
+    }
+
+    await harness.settle();
+    for (const client of clients) {
+      await client.waitUntilSynced();
+    }
+
+    for (const [opIndex, op] of trace.ops.entries()) {
+      try {
+        switch (op.kind) {
+          case "edit": {
+            const client = clients[op.client]!;
+            if (!client.isConnected()) break;
+            // Insert at start so concurrent branches remain valid.
+            client.localInsert(op.text, 0);
+            break;
+          }
+          case "disconnect": {
+            const client = clients[op.client]!;
+            if (client.isConnected()) await client.disconnect();
+            break;
+          }
+          case "reconnect": {
+            const client = clients[op.client]!;
+            if (!client.isConnected()) await client.connect();
+            break;
+          }
+          case "deliver":
+            await harness.deliverNext();
+            break;
+          case "duplicate":
+            harness.duplicateNextDelivery();
+            break;
+          case "reorder":
+            harness.reorderNextDeliveryPair();
+            break;
+          case "settle":
+            await harness.settle();
+            break;
+        }
+        await harness.pumpProtocol(32);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Trace failed at op ${opIndex} (${JSON.stringify(op)}): ${message}\n${formatTrace(trace)}`,
+        );
+      }
+    }
+
+    // Reconnect anyone left offline and drain the pipeline.
+    for (const client of clients) {
+      if (!client.isConnected()) await client.connect();
+    }
+    await harness.settle();
+    for (const client of clients) {
+      await client.waitUntilIdle();
+    }
+
+    for (const client of clients) {
+      expect(client.conflicts(), formatTrace(trace)).toEqual([]);
+    }
+
+    const durableIds = new Set(harness.store.listBatchIds(harness.documentId));
+    for (const client of clients) {
+      for (const batchId of client.acknowledgedBatchIds()) {
+        expect(durableIds.has(batchId), formatTrace(trace)).toBe(true);
+      }
+      expect(client.pendingBatchIds(), formatTrace(trace)).toEqual([]);
+    }
+
+    harness.assertReplicasConverged(clients);
+  } finally {
+    await harness.close();
+  }
+};
+
+describe("randomized collaboration convergence", () => {
+  it("should converge for seeded multi-client collaboration traces", async () => {
+    await fc.assert(
+      fc.asyncProperty(traceArb, async (trace) => {
+        await runTrace(trace);
+      }),
+      {
+        numRuns: isSoak ? SOAK_NUM_RUNS : CI_NUM_RUNS,
+        // Fixed seed keeps CI deterministic; override with fc seed on failure.
+        seed: 868_001,
+        verbose: true,
+        endOnFailure: true,
+      },
+    );
+  });
+
+  it("should reproduce a known reconnect-and-duplicate interleaving", async () => {
+    // Arrange / Act / Assert: explicit regression seed path for debugging.
+    const trace: Trace = {
+      clientCount: 2,
+      ops: [
+        { kind: "edit", client: 0, text: "a" },
+        { kind: "edit", client: 1, text: "b" },
+        { kind: "disconnect", client: 1 },
+        { kind: "edit", client: 0, text: "c" },
+        { kind: "deliver" },
+        { kind: "duplicate" },
+        { kind: "reconnect", client: 1 },
+        { kind: "settle" },
+        { kind: "edit", client: 1, text: "d" },
+        { kind: "reorder" },
+        { kind: "settle" },
+      ],
+    };
+    await runTrace(trace);
+  });
+});

--- a/apps/collab/test/helpers/collabConsistencyHarness.ts
+++ b/apps/collab/test/helpers/collabConsistencyHarness.ts
@@ -1,0 +1,715 @@
+import {
+  BOOTSTRAP_BLOCK_ID,
+  createBlockReplica,
+  type BlockReplica,
+  type RichTextEventBatch,
+} from "@softmaple/block-model";
+import {
+  COLLAB_ACCESS_MODE,
+  COLLAB_ERROR_CODE,
+  COLLAB_MESSAGE_TYPE,
+  COLLAB_PROTOCOL_VERSION,
+  type ClientCollabMessage,
+  type CollabErrorMessage,
+  type ServerCollabMessage,
+} from "@softmaple/collab-protocol";
+import { randomUUID } from "node:crypto";
+import { EventConflictError } from "../../server/utils/event-conflict";
+import {
+  documentRealtimeChannel,
+  LocalTopicHub,
+  TopicBridge,
+  type RealtimePeer,
+} from "../../server/utils/realtime";
+import type {
+  RealtimeBus,
+  RealtimeHandler,
+} from "../../server/utils/realtime/types";
+import {
+  createInMemoryEventStore,
+  type InMemoryEventStore,
+} from "./inMemoryEventStore";
+
+const MAX_BATCHES_PER_SEND = 64;
+
+type OutgoingQueue = {
+  readonly add: (batches: ReadonlyArray<RichTextEventBatch>) => void;
+  readonly flush: () => boolean;
+  readonly acknowledge: (batchIds: ReadonlyArray<string>) => boolean;
+  readonly resetInFlight: () => void;
+  readonly peekPending: () => ReadonlyArray<RichTextEventBatch>;
+  readonly hasPending: () => boolean;
+  readonly hasInFlight: () => boolean;
+};
+
+/**
+ * Minimal copy of the browser outgoing-queue invariant for harness clients.
+ * Kept local so collab tests do not import apps/web modules.
+ */
+const createOutgoingQueue = (
+  send: (batches: ReadonlyArray<RichTextEventBatch>) => boolean,
+): OutgoingQueue => {
+  const pending = new Map<string, RichTextEventBatch>();
+  const inFlight = new Set<string>();
+
+  const flush = (): boolean => {
+    if (inFlight.size > 0 || pending.size === 0) return false;
+    const chunk = [...pending.values()].slice(0, MAX_BATCHES_PER_SEND);
+    if (chunk.length === 0 || !send(chunk)) return false;
+    for (const batch of chunk) {
+      inFlight.add(batch.batchId);
+    }
+    return true;
+  };
+
+  return {
+    add(batches) {
+      for (const batch of batches) {
+        pending.set(batch.batchId, batch);
+      }
+    },
+    flush,
+    acknowledge(batchIds) {
+      for (const batchId of batchIds) {
+        pending.delete(batchId);
+        inFlight.delete(batchId);
+      }
+      return flush();
+    },
+    resetInFlight() {
+      inFlight.clear();
+    },
+    peekPending: () => [...pending.values()],
+    hasPending: () => pending.size > 0,
+    hasInFlight: () => inFlight.size > 0,
+  };
+};
+
+type PendingDelivery = {
+  readonly channel: string;
+  readonly payload: unknown;
+  readonly handler: RealtimeHandler;
+};
+
+/**
+ * Shared bus that can defer/duplicate fan-out while keeping instance hubs
+ * independently owned. Immediate mode matches MemoryRealtimeBus timing.
+ */
+class ControllableRealtimeBus implements RealtimeBus {
+  private readonly handlers = new Map<string, Set<RealtimeHandler>>();
+  private readonly pending: PendingDelivery[] = [];
+  private closed = false;
+  deliveryMode: "immediate" | "deferred" = "immediate";
+
+  async publish(channel: string, payload: unknown): Promise<void> {
+    if (this.closed) throw new Error("Realtime bus is closed");
+    const handlers = [...(this.handlers.get(channel) ?? [])];
+    if (this.deliveryMode === "immediate") {
+      await Promise.all(
+        handlers.map(async (handler) => {
+          await handler(payload);
+        }),
+      );
+      return;
+    }
+    for (const handler of handlers) {
+      this.pending.push({ channel, payload, handler });
+    }
+  }
+
+  async subscribe(
+    channel: string,
+    handler: RealtimeHandler,
+  ): Promise<() => Promise<void>> {
+    if (this.closed) throw new Error("Realtime bus is closed");
+    const existing = this.handlers.get(channel) ?? new Set<RealtimeHandler>();
+    existing.add(handler);
+    this.handlers.set(channel, existing);
+    return async () => {
+      const current = this.handlers.get(channel);
+      current?.delete(handler);
+      if (current?.size === 0) this.handlers.delete(channel);
+    };
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.handlers.clear();
+    this.pending.length = 0;
+  }
+
+  pendingCount(): number {
+    return this.pending.length;
+  }
+
+  async deliverNext(): Promise<boolean> {
+    const next = this.pending.shift();
+    if (next === undefined) return false;
+    await next.handler(next.payload);
+    return true;
+  }
+
+  async deliverAll(): Promise<number> {
+    let count = 0;
+    while (await this.deliverNext()) {
+      count += 1;
+    }
+    return count;
+  }
+
+  /** Re-queue the front delivery so the same payload is applied twice. */
+  duplicateNext(): boolean {
+    const next = this.pending[0];
+    if (next === undefined) return false;
+    this.pending.splice(1, 0, { ...next });
+    return true;
+  }
+
+  /** Move the front delivery behind the next one when both exist. */
+  reorderNextPair(): boolean {
+    if (this.pending.length < 2) return false;
+    const [first, second, ...rest] = this.pending;
+    this.pending.length = 0;
+    this.pending.push(second, first, ...rest);
+    return true;
+  }
+}
+
+type WorkItem = () => Promise<void>;
+
+class WorkQueue {
+  private readonly items: WorkItem[] = [];
+  private running = false;
+
+  enqueue(work: WorkItem): void {
+    this.items.push(work);
+  }
+
+  size(): number {
+    return this.items.length;
+  }
+
+  async runOne(): Promise<boolean> {
+    if (this.running || this.items.length === 0) return false;
+    this.running = true;
+    const work = this.items.shift();
+    try {
+      if (work) await work();
+    } finally {
+      this.running = false;
+    }
+    return true;
+  }
+
+  async runAll(): Promise<number> {
+    let count = 0;
+    while (await this.runOne()) {
+      count += 1;
+    }
+    return count;
+  }
+}
+
+export type HarnessConflict = {
+  readonly code: typeof COLLAB_ERROR_CODE.Conflict;
+  readonly message: string;
+  readonly retryable: boolean;
+};
+
+export type HarnessClient = {
+  readonly id: string;
+  readonly actorId: string;
+  readonly sessionId: string;
+  readonly instanceName: string;
+  readonly replica: BlockReplica;
+  readonly connect: () => Promise<void>;
+  readonly disconnect: () => Promise<void>;
+  readonly isConnected: () => boolean;
+  readonly isSynced: () => boolean;
+  readonly localInsert: (text: string, offset?: number) => RichTextEventBatch;
+  readonly flushOutgoing: () => Promise<void>;
+  readonly waitUntilSynced: () => Promise<void>;
+  readonly waitUntilIdle: () => Promise<void>;
+  readonly pendingBatchIds: () => ReadonlyArray<string>;
+  readonly acknowledgedBatchIds: () => ReadonlySet<string>;
+  readonly knownBatchIds: () => ReadonlySet<string>;
+  readonly conflicts: () => ReadonlyArray<HarnessConflict>;
+  readonly repairRequestCount: () => number;
+  readonly documentFingerprint: () => string;
+};
+
+type ConnectedPeer = RealtimePeer & {
+  readonly client: HarnessClientInternal;
+  readonly context: {
+    unsubscribeLocal?: () => void;
+    realtimeChannel?: string;
+  };
+};
+
+type HarnessClientInternal = HarnessClient & {
+  readonly receive: (message: ServerCollabMessage) => Promise<void>;
+  readonly enqueueClientMessage: (message: ClientCollabMessage) => void;
+};
+
+export type CollabInstance = {
+  readonly name: string;
+  readonly hub: LocalTopicHub;
+  readonly bridge: TopicBridge;
+  readonly localPeerCount: (documentId: string) => number;
+  readonly connectClient: (options: {
+    readonly id: string;
+    readonly actorId: string;
+  }) => Promise<HarnessClient>;
+  readonly close: () => Promise<void>;
+};
+
+export type CollabConsistencyHarness = {
+  readonly documentId: string;
+  readonly store: InMemoryEventStore;
+  readonly bus: ControllableRealtimeBus;
+  readonly createInstance: (name: string) => CollabInstance;
+  readonly setDeliveryMode: (mode: "immediate" | "deferred") => void;
+  readonly deliverNext: () => Promise<boolean>;
+  readonly deliverAll: () => Promise<number>;
+  readonly duplicateNextDelivery: () => boolean;
+  readonly reorderNextDeliveryPair: () => boolean;
+  readonly pendingDeliveries: () => number;
+  /** Drain protocol work + deferred fan-out until quiescent. */
+  readonly settle: () => Promise<void>;
+  /**
+   * Run a bounded number of protocol queue turns without draining fan-out.
+   * Used to interleave repair pages with live commits.
+   */
+  readonly pumpProtocol: (maxTurns?: number) => Promise<number>;
+  readonly protocolQueueSize: () => number;
+  readonly assertReplicasConverged: (
+    clients: ReadonlyArray<HarnessClient>,
+  ) => void;
+  readonly close: () => Promise<void>;
+};
+
+const fingerprintDocument = (replica: BlockReplica): string =>
+  JSON.stringify(replica.getDocument());
+
+const waitFor = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 2_000,
+): Promise<void> => {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error(`Timed out waiting for ${label}`);
+    }
+    await Promise.resolve();
+  }
+};
+
+export const createCollabConsistencyHarness = (options?: {
+  readonly documentId?: string;
+  readonly pageSize?: number;
+}): CollabConsistencyHarness => {
+  const documentId =
+    options?.documentId ?? "00000000-0000-4000-8000-000000000099";
+  const store = createInMemoryEventStore({
+    pageSize: options?.pageSize ?? 100,
+  });
+  const bus = new ControllableRealtimeBus();
+  const protocolQueue = new WorkQueue();
+  const instances = new Map<string, CollabInstance>();
+  const channel = documentRealtimeChannel(documentId, COLLAB_PROTOCOL_VERSION);
+
+  const enqueueProtocol = (work: WorkItem): void => {
+    protocolQueue.enqueue(work);
+  };
+
+  const handleClientMessage = async (
+    instance: {
+      readonly hub: LocalTopicHub;
+      readonly bridge: TopicBridge;
+    },
+    peer: ConnectedPeer,
+    message: ClientCollabMessage,
+  ): Promise<void> => {
+    if (message.type === COLLAB_MESSAGE_TYPE.Auth) {
+      peer.context.unsubscribeLocal = instance.hub.subscribe(channel, peer);
+      await instance.bridge.retain(channel);
+      peer.context.realtimeChannel = channel;
+      enqueueProtocol(async () => {
+        await peer.client.receive({
+          protocolVersion: COLLAB_PROTOCOL_VERSION,
+          type: COLLAB_MESSAGE_TYPE.Ready,
+          accessMode: COLLAB_ACCESS_MODE.Authenticated,
+          documentId,
+          userId: peer.client.actorId,
+          role: "EDITOR",
+          canWrite: true,
+        });
+      });
+      return;
+    }
+
+    if (message.type === COLLAB_MESSAGE_TYPE.RepairRequest) {
+      const page = await store.readEventPage(documentId, message.afterCursor);
+      enqueueProtocol(async () => {
+        await peer.client.receive({
+          protocolVersion: COLLAB_PROTOCOL_VERSION,
+          type: COLLAB_MESSAGE_TYPE.RepairResponse,
+          requestId: message.requestId,
+          ...page,
+        });
+      });
+      return;
+    }
+
+    if (message.type === COLLAB_MESSAGE_TYPE.Event) {
+      let batchIds: ReadonlyArray<string>;
+      try {
+        batchIds = await store.appendEventBatches(
+          documentId,
+          peer.client.actorId,
+          message.batches,
+        );
+      } catch (error) {
+        const conflict = error instanceof EventConflictError;
+        const errorMessage: CollabErrorMessage = {
+          protocolVersion: COLLAB_PROTOCOL_VERSION,
+          type: COLLAB_MESSAGE_TYPE.Error,
+          code: conflict
+            ? COLLAB_ERROR_CODE.Conflict
+            : COLLAB_ERROR_CODE.PersistenceFailed,
+          message: conflict
+            ? "The event batch conflicts with stored document history"
+            : "The event batch was not saved",
+          // Mirror production: conflicts are never reconnect-retried.
+          retryable: !conflict,
+        };
+        enqueueProtocol(async () => {
+          await peer.client.receive(errorMessage);
+        });
+        return;
+      }
+
+      // Durable commit before DurableAck and before fan-out.
+      enqueueProtocol(async () => {
+        await peer.client.receive({
+          protocolVersion: COLLAB_PROTOCOL_VERSION,
+          type: COLLAB_MESSAGE_TYPE.DurableAck,
+          batchIds,
+        });
+      });
+      await bus.publish(channel, {
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Event,
+        batches: message.batches,
+      });
+    }
+  };
+
+  const createClient = (
+    instance: CollabInstance,
+    clientOptions: { readonly id: string; readonly actorId: string },
+  ): HarnessClientInternal => {
+    const replica = createBlockReplica(clientOptions.id);
+    const knownBatches = new Map(
+      replica.exportEvents().map((batch) => [batch.batchId, batch] as const),
+    );
+    const acknowledged = new Set<string>();
+    const conflicts: HarnessConflict[] = [];
+    let peer: ConnectedPeer | null = null;
+    let synced = false;
+    let connected = false;
+    let activeRepairRequestId: string | null = null;
+    let repairCursor: string | null = null;
+    let repairRequests = 0;
+
+    const applyBatches = (batches: ReadonlyArray<RichTextEventBatch>): void => {
+      for (const batch of batches) {
+        if (knownBatches.has(batch.batchId)) continue;
+        knownBatches.set(batch.batchId, batch);
+        replica.applyRemoteEvents(batch);
+      }
+    };
+
+    const enqueueClientMessage = (message: ClientCollabMessage): void => {
+      if (peer === null) {
+        throw new Error(`Client ${clientOptions.id} is not connected`);
+      }
+      const activePeer = peer;
+      enqueueProtocol(async () => {
+        await handleClientMessage(instance, activePeer, message);
+      });
+    };
+
+    const outgoing = createOutgoingQueue((batches) => {
+      enqueueClientMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Event,
+        batches,
+      });
+      return true;
+    });
+
+    const requestRepair = (afterCursor: string): void => {
+      const requestId = randomUUID();
+      activeRepairRequestId = requestId;
+      repairRequests += 1;
+      enqueueClientMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.RepairRequest,
+        requestId,
+        afterCursor,
+      });
+    };
+
+    const publishPending = (): void => {
+      if (!synced) return;
+      outgoing.flush();
+    };
+
+    const client: HarnessClientInternal = {
+      id: clientOptions.id,
+      actorId: clientOptions.actorId,
+      sessionId: randomUUID(),
+      instanceName: instance.name,
+      replica,
+      enqueueClientMessage,
+      async connect() {
+        if (connected) return;
+        peer = {
+          client: undefined as unknown as HarnessClientInternal,
+          context: {},
+          send(payload: unknown) {
+            const message = payload as ServerCollabMessage;
+            enqueueProtocol(async () => {
+              await client.receive(message);
+            });
+          },
+        };
+        // Assign after object creation so send can close over `client`.
+        (peer as { client: HarnessClientInternal }).client = client;
+        connected = true;
+        enqueueClientMessage({
+          protocolVersion: COLLAB_PROTOCOL_VERSION,
+          type: COLLAB_MESSAGE_TYPE.Auth,
+          credential: { kind: "access-token", token: "test-token" },
+          documentId,
+          sessionId: client.sessionId,
+        });
+      },
+      async disconnect() {
+        if (!connected || peer === null) return;
+        peer.context.unsubscribeLocal?.();
+        if (peer.context.realtimeChannel !== undefined) {
+          await instance.bridge.release(peer.context.realtimeChannel);
+        }
+        peer = null;
+        connected = false;
+        synced = false;
+        activeRepairRequestId = null;
+        outgoing.resetInFlight();
+      },
+      isConnected: () => connected,
+      isSynced: () => synced,
+      localInsert(text, offset = 0) {
+        const batch = replica.transact((transaction) => {
+          transaction.insertText(BOOTSTRAP_BLOCK_ID, offset, text);
+        });
+        if (batch === null) {
+          throw new Error("expected local batch from insert");
+        }
+        knownBatches.set(batch.batchId, batch);
+        outgoing.add([batch]);
+        publishPending();
+        return batch;
+      },
+      async flushOutgoing() {
+        publishPending();
+        await settleLoop();
+        await waitFor(
+          () => !outgoing.hasPending() && !outgoing.hasInFlight(),
+          `client ${clientOptions.id} outgoing drain`,
+        );
+      },
+      async waitUntilSynced() {
+        await settleLoop();
+        await waitFor(() => synced, `client ${clientOptions.id} sync`);
+      },
+      async waitUntilIdle() {
+        await settleLoop();
+        await waitFor(
+          () => synced && !outgoing.hasPending() && !outgoing.hasInFlight(),
+          `client ${clientOptions.id} idle`,
+        );
+      },
+      pendingBatchIds: () =>
+        outgoing.peekPending().map((batch) => batch.batchId),
+      acknowledgedBatchIds: () => acknowledged,
+      knownBatchIds: () => new Set(knownBatches.keys()),
+      conflicts: () => [...conflicts],
+      repairRequestCount: () => repairRequests,
+      documentFingerprint: () => fingerprintDocument(replica),
+      async receive(message) {
+        switch (message.type) {
+          case COLLAB_MESSAGE_TYPE.Ready:
+            synced = false;
+            requestRepair(repairCursor ?? "0");
+            return;
+          case COLLAB_MESSAGE_TYPE.RepairResponse:
+            if (message.requestId !== activeRepairRequestId) return;
+            applyBatches(message.batches);
+            if (
+              repairCursor === null ||
+              BigInt(message.nextCursor) > BigInt(repairCursor)
+            ) {
+              repairCursor = message.nextCursor;
+            }
+            if (!message.complete) {
+              requestRepair(message.nextCursor);
+              return;
+            }
+            activeRepairRequestId = null;
+            synced = true;
+            publishPending();
+            return;
+          case COLLAB_MESSAGE_TYPE.Event:
+            applyBatches(message.batches);
+            return;
+          case COLLAB_MESSAGE_TYPE.DurableAck:
+            for (const batchId of message.batchIds) {
+              acknowledged.add(batchId);
+            }
+            outgoing.acknowledge(message.batchIds);
+            return;
+          case COLLAB_MESSAGE_TYPE.Error:
+            if (message.code === COLLAB_ERROR_CODE.Conflict) {
+              conflicts.push({
+                code: COLLAB_ERROR_CODE.Conflict,
+                message: message.message,
+                retryable: message.retryable,
+              });
+              // Fatal conflicts do not auto-reconnect in this harness.
+              synced = false;
+              return;
+            }
+            return;
+        }
+      },
+    };
+
+    return client;
+  };
+
+  const settleLoop = async (): Promise<void> => {
+    for (let turn = 0; turn < 10_000; turn += 1) {
+      const protocolWork = await protocolQueue.runAll();
+      const fanoutWork =
+        bus.deliveryMode === "deferred" ? await bus.deliverAll() : 0;
+      if (protocolWork === 0 && fanoutWork === 0) return;
+    }
+    throw new Error("Harness settle exceeded turn budget");
+  };
+
+  const createInstance = (name: string): CollabInstance => {
+    if (instances.has(name)) {
+      throw new Error(`Instance ${name} already exists`);
+    }
+    const hub = new LocalTopicHub();
+    const bridge = new TopicBridge(bus, hub);
+    const instance: CollabInstance = {
+      name,
+      hub,
+      bridge,
+      localPeerCount: (id) =>
+        hub.localSubscriberCount(
+          documentRealtimeChannel(id, COLLAB_PROTOCOL_VERSION),
+        ),
+      async connectClient(connectOptions) {
+        const client = createClient(instance, connectOptions);
+        await client.connect();
+        return client;
+      },
+      async close() {
+        await bridge.close();
+        hub.clear();
+        instances.delete(name);
+      },
+    };
+    instances.set(name, instance);
+    return instance;
+  };
+
+  return {
+    documentId,
+    store,
+    bus,
+    createInstance,
+    setDeliveryMode: (mode) => {
+      bus.deliveryMode = mode;
+    },
+    deliverNext: () => bus.deliverNext(),
+    deliverAll: () => bus.deliverAll(),
+    duplicateNextDelivery: () => bus.duplicateNext(),
+    reorderNextDeliveryPair: () => bus.reorderNextPair(),
+    pendingDeliveries: () => bus.pendingCount(),
+    settle: settleLoop,
+    pumpProtocol: (maxTurns = 1) => {
+      let count = 0;
+      const run = async (): Promise<number> => {
+        while (count < maxTurns && (await protocolQueue.runOne())) {
+          count += 1;
+        }
+        return count;
+      };
+      return run();
+    },
+    protocolQueueSize: () => protocolQueue.size(),
+    assertReplicasConverged(clients) {
+      if (clients.length === 0) return;
+      const expected = clients[0]!.documentFingerprint();
+      for (const client of clients) {
+        if (client.documentFingerprint() !== expected) {
+          throw new Error(
+            `Replicas diverged: ${client.id} !== ${clients[0]!.id}`,
+          );
+        }
+      }
+      const durableIds = new Set(store.listBatchIds(documentId));
+      for (const client of clients) {
+        for (const batchId of client.acknowledgedBatchIds()) {
+          if (!durableIds.has(batchId)) {
+            throw new Error(
+              `Acknowledged batch ${batchId} missing from durable history`,
+            );
+          }
+        }
+      }
+    },
+    async close() {
+      await Promise.all(
+        [...instances.values()].map((instance) => instance.close()),
+      );
+      await bus.close();
+    },
+  };
+};
+
+/** Shared causal batch helper for consistency tests. */
+export const createCausalBatches = (
+  replicaId = "replica-a",
+): {
+  readonly first: RichTextEventBatch;
+  readonly second: RichTextEventBatch;
+} => {
+  const replica = createBlockReplica(replicaId);
+  const first = replica.transact((transaction) => {
+    transaction.insertText(BOOTSTRAP_BLOCK_ID, 0, "A");
+  });
+  const second = replica.transact((transaction) => {
+    transaction.insertText(BOOTSTRAP_BLOCK_ID, 1, "B");
+  });
+  if (first === null || second === null) {
+    throw new Error("expected local batches");
+  }
+  return { first, second };
+};

--- a/apps/collab/test/helpers/collabConsistencyHarness.ts
+++ b/apps/collab/test/helpers/collabConsistencyHarness.ts
@@ -233,13 +233,16 @@ export type HarnessClient = {
   readonly pendingBatchIds: () => ReadonlyArray<string>;
   readonly acknowledgedBatchIds: () => ReadonlySet<string>;
   readonly knownBatchIds: () => ReadonlySet<string>;
+  /** Event batch IDs enqueued on the current connection generation. */
+  readonly sentBatchIdsSinceConnect: () => ReadonlyArray<string>;
   readonly conflicts: () => ReadonlyArray<HarnessConflict>;
   readonly repairRequestCount: () => number;
   readonly documentFingerprint: () => string;
 };
 
 type ConnectedPeer = RealtimePeer & {
-  readonly client: HarnessClientInternal;
+  client?: HarnessClientInternal;
+  readonly generation: number;
   readonly context: {
     unsubscribeLocal?: () => void;
     realtimeChannel?: string;
@@ -281,6 +284,14 @@ export type CollabConsistencyHarness = {
    * Used to interleave repair pages with live commits.
    */
   readonly pumpProtocol: (maxTurns?: number) => Promise<number>;
+  /**
+   * Advance the protocol queue one turn at a time until `predicate` holds.
+   * Fails clearly when the turn budget is exhausted.
+   */
+  readonly pumpUntil: (
+    predicate: () => boolean,
+    maxTurns?: number,
+  ) => Promise<number>;
   readonly protocolQueueSize: () => number;
   readonly assertReplicasConverged: (
     clients: ReadonlyArray<HarnessClient>,
@@ -301,7 +312,10 @@ const waitFor = async (
     if (Date.now() - started > timeoutMs) {
       throw new Error(`Timed out waiting for ${label}`);
     }
-    await Promise.resolve();
+    // Macrotask yield so timer-/IO-backed work can progress between polls.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
   }
 };
 
@@ -318,9 +332,33 @@ export const createCollabConsistencyHarness = (options?: {
   const protocolQueue = new WorkQueue();
   const instances = new Map<string, CollabInstance>();
   const channel = documentRealtimeChannel(documentId, COLLAB_PROTOCOL_VERSION);
+  let settleInFlight: Promise<void> | null = null;
 
   const enqueueProtocol = (work: WorkItem): void => {
     protocolQueue.enqueue(work);
+  };
+
+  const isActivePeer = (
+    peer: ConnectedPeer,
+    generation: number,
+    activeGeneration: () => number,
+    currentPeer: () => ConnectedPeer | null,
+  ): peer is ConnectedPeer & { readonly client: HarnessClientInternal } =>
+    peer.generation === generation &&
+    activeGeneration() === generation &&
+    currentPeer() === peer &&
+    peer.client !== undefined;
+
+  const releasePeerChannel = async (
+    instance: { readonly bridge: TopicBridge },
+    peer: ConnectedPeer,
+  ): Promise<void> => {
+    peer.context.unsubscribeLocal?.();
+    delete peer.context.unsubscribeLocal;
+    if (peer.context.realtimeChannel !== undefined) {
+      await instance.bridge.release(peer.context.realtimeChannel);
+      delete peer.context.realtimeChannel;
+    }
   };
 
   const handleClientMessage = async (
@@ -330,12 +368,27 @@ export const createCollabConsistencyHarness = (options?: {
     },
     peer: ConnectedPeer,
     message: ClientCollabMessage,
+    generation: number,
+    activeGeneration: () => number,
+    currentPeer: () => ConnectedPeer | null,
   ): Promise<void> => {
+    if (!isActivePeer(peer, generation, activeGeneration, currentPeer)) {
+      return;
+    }
+
     if (message.type === COLLAB_MESSAGE_TYPE.Auth) {
       peer.context.unsubscribeLocal = instance.hub.subscribe(channel, peer);
       await instance.bridge.retain(channel);
+      if (!isActivePeer(peer, generation, activeGeneration, currentPeer)) {
+        // Dropped Auth after retain: release so the channel is not leaked.
+        await releasePeerChannel(instance, peer);
+        return;
+      }
       peer.context.realtimeChannel = channel;
       enqueueProtocol(async () => {
+        if (!isActivePeer(peer, generation, activeGeneration, currentPeer)) {
+          return;
+        }
         await peer.client.receive({
           protocolVersion: COLLAB_PROTOCOL_VERSION,
           type: COLLAB_MESSAGE_TYPE.Ready,
@@ -352,6 +405,9 @@ export const createCollabConsistencyHarness = (options?: {
     if (message.type === COLLAB_MESSAGE_TYPE.RepairRequest) {
       const page = await store.readEventPage(documentId, message.afterCursor);
       enqueueProtocol(async () => {
+        if (!isActivePeer(peer, generation, activeGeneration, currentPeer)) {
+          return;
+        }
         await peer.client.receive({
           protocolVersion: COLLAB_PROTOCOL_VERSION,
           type: COLLAB_MESSAGE_TYPE.RepairResponse,
@@ -385,13 +441,23 @@ export const createCollabConsistencyHarness = (options?: {
           retryable: !conflict,
         };
         enqueueProtocol(async () => {
+          if (!isActivePeer(peer, generation, activeGeneration, currentPeer)) {
+            return;
+          }
           await peer.client.receive(errorMessage);
         });
         return;
       }
 
+      if (!isActivePeer(peer, generation, activeGeneration, currentPeer)) {
+        return;
+      }
+
       // Durable commit before DurableAck and before fan-out.
       enqueueProtocol(async () => {
+        if (!isActivePeer(peer, generation, activeGeneration, currentPeer)) {
+          return;
+        }
         await peer.client.receive({
           protocolVersion: COLLAB_PROTOCOL_VERSION,
           type: COLLAB_MESSAGE_TYPE.DurableAck,
@@ -416,7 +482,9 @@ export const createCollabConsistencyHarness = (options?: {
     );
     const acknowledged = new Set<string>();
     const conflicts: HarnessConflict[] = [];
+    const sentSinceConnect: string[] = [];
     let peer: ConnectedPeer | null = null;
+    let peerGeneration = 0;
     let synced = false;
     let connected = false;
     let activeRepairRequestId: string | null = null;
@@ -432,12 +500,25 @@ export const createCollabConsistencyHarness = (options?: {
     };
 
     const enqueueClientMessage = (message: ClientCollabMessage): void => {
-      if (peer === null) {
+      if (peer === null || !connected) {
         throw new Error(`Client ${clientOptions.id} is not connected`);
       }
       const activePeer = peer;
+      const generation = activePeer.generation;
+      if (message.type === COLLAB_MESSAGE_TYPE.Event) {
+        for (const batch of message.batches) {
+          sentSinceConnect.push(batch.batchId);
+        }
+      }
       enqueueProtocol(async () => {
-        await handleClientMessage(instance, activePeer, message);
+        await handleClientMessage(
+          instance,
+          activePeer,
+          message,
+          generation,
+          () => peerGeneration,
+          () => peer,
+        );
       });
     };
 
@@ -476,18 +557,31 @@ export const createCollabConsistencyHarness = (options?: {
       enqueueClientMessage,
       async connect() {
         if (connected) return;
-        peer = {
-          client: undefined as unknown as HarnessClientInternal,
+        peerGeneration += 1;
+        sentSinceConnect.length = 0;
+        const nextPeer: ConnectedPeer = {
+          generation: peerGeneration,
           context: {},
           send(payload: unknown) {
             const message = payload as ServerCollabMessage;
+            const generation = nextPeer.generation;
             enqueueProtocol(async () => {
+              if (
+                !isActivePeer(
+                  nextPeer,
+                  generation,
+                  () => peerGeneration,
+                  () => peer,
+                )
+              ) {
+                return;
+              }
               await client.receive(message);
             });
           },
         };
-        // Assign after object creation so send can close over `client`.
-        (peer as { client: HarnessClientInternal }).client = client;
+        nextPeer.client = client;
+        peer = nextPeer;
         connected = true;
         enqueueClientMessage({
           protocolVersion: COLLAB_PROTOCOL_VERSION,
@@ -499,10 +593,10 @@ export const createCollabConsistencyHarness = (options?: {
       },
       async disconnect() {
         if (!connected || peer === null) return;
-        peer.context.unsubscribeLocal?.();
-        if (peer.context.realtimeChannel !== undefined) {
-          await instance.bridge.release(peer.context.realtimeChannel);
-        }
+        const disconnecting = peer;
+        // Invalidate queued work for this connection generation first.
+        peerGeneration += 1;
+        await releasePeerChannel(instance, disconnecting);
         peer = null;
         connected = false;
         synced = false;
@@ -546,6 +640,7 @@ export const createCollabConsistencyHarness = (options?: {
         outgoing.peekPending().map((batch) => batch.batchId),
       acknowledgedBatchIds: () => acknowledged,
       knownBatchIds: () => new Set(knownBatches.keys()),
+      sentBatchIdsSinceConnect: () => [...sentSinceConnect],
       conflicts: () => [...conflicts],
       repairRequestCount: () => repairRequests,
       documentFingerprint: () => fingerprintDocument(replica),
@@ -600,14 +695,22 @@ export const createCollabConsistencyHarness = (options?: {
     return client;
   };
 
-  const settleLoop = async (): Promise<void> => {
-    for (let turn = 0; turn < 10_000; turn += 1) {
-      const protocolWork = await protocolQueue.runAll();
-      const fanoutWork =
-        bus.deliveryMode === "deferred" ? await bus.deliverAll() : 0;
-      if (protocolWork === 0 && fanoutWork === 0) return;
-    }
-    throw new Error("Harness settle exceeded turn budget");
+  const settleLoop = (): Promise<void> => {
+    if (settleInFlight !== null) return settleInFlight;
+    settleInFlight = (async () => {
+      try {
+        for (let turn = 0; turn < 10_000; turn += 1) {
+          const protocolWork = await protocolQueue.runAll();
+          const fanoutWork =
+            bus.deliveryMode === "deferred" ? await bus.deliverAll() : 0;
+          if (protocolWork === 0 && fanoutWork === 0) return;
+        }
+        throw new Error("Harness settle exceeded turn budget");
+      } finally {
+        settleInFlight = null;
+      }
+    })();
+    return settleInFlight;
   };
 
   const createInstance = (name: string): CollabInstance => {
@@ -662,6 +765,20 @@ export const createCollabConsistencyHarness = (options?: {
         return count;
       };
       return run();
+    },
+    async pumpUntil(predicate, maxTurns = 100) {
+      for (let turns = 0; turns < maxTurns; turns += 1) {
+        if (predicate()) return turns;
+        const advanced = await protocolQueue.runOne();
+        if (!advanced) {
+          if (predicate()) return turns;
+          throw new Error(
+            `pumpUntil exhausted with an empty protocol queue after ${turns} turns`,
+          );
+        }
+      }
+      if (predicate()) return maxTurns;
+      throw new Error(`pumpUntil exceeded turn budget (${maxTurns})`);
     },
     protocolQueueSize: () => protocolQueue.size(),
     assertReplicasConverged(clients) {

--- a/apps/collab/test/helpers/inMemoryEventStore.ts
+++ b/apps/collab/test/helpers/inMemoryEventStore.ts
@@ -1,0 +1,268 @@
+import { createHash } from "node:crypto";
+import {
+  BOOTSTRAP_EVENT_ID,
+  type RichTextEventBatch,
+} from "@softmaple/block-model";
+import {
+  EVENT_CONFLICT_TYPE,
+  EventConflictError,
+} from "../../server/utils/event-conflict";
+
+export type { EventPage } from "../../server/utils/event-store";
+import type { EventPage } from "../../server/utils/event-store";
+
+type StoredBatch = {
+  readonly id: bigint;
+  readonly batchId: string;
+  readonly payloadHash: string;
+  readonly payload: RichTextEventBatch;
+};
+
+/**
+ * Infrastructure-independent durable event log for collaboration consistency
+ * tests. Mirrors production append/repair conflict semantics without Prisma.
+ */
+export type InMemoryEventStore = {
+  readonly appendEventBatches: (
+    documentId: string,
+    actorId: string,
+    batches: ReadonlyArray<RichTextEventBatch>,
+  ) => Promise<ReadonlyArray<string>>;
+  readonly readEventPage: (
+    documentId: string,
+    afterCursor: string,
+  ) => Promise<EventPage>;
+  readonly listBatchIds: (documentId: string) => ReadonlyArray<string>;
+  readonly listBatches: (
+    documentId: string,
+  ) => ReadonlyArray<RichTextEventBatch>;
+  readonly hasBatch: (documentId: string, batchId: string) => boolean;
+  readonly setPageSize: (pageSize: number) => void;
+  readonly pageSize: () => number;
+};
+
+const canonicalJson = (value: unknown): string => {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+  throw new Error("event batch contains a non-JSON value");
+};
+
+const hashBatch = (batch: RichTextEventBatch): string =>
+  createHash("sha256").update(canonicalJson(batch)).digest("hex");
+
+type DocumentLog = {
+  readonly batchesById: Map<string, StoredBatch>;
+  readonly ordered: StoredBatch[];
+  readonly eventIds: Set<string>;
+  lockHolders: number;
+  readonly lockWaiters: Array<() => void>;
+};
+
+const createDocumentLog = (): DocumentLog => ({
+  batchesById: new Map(),
+  ordered: [],
+  eventIds: new Set(),
+  lockHolders: 0,
+  lockWaiters: [],
+});
+
+const acquireLock = async (log: DocumentLog): Promise<void> => {
+  if (log.lockHolders === 0) {
+    log.lockHolders = 1;
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    log.lockWaiters.push(resolve);
+  });
+};
+
+const releaseLock = (log: DocumentLog): void => {
+  const next = log.lockWaiters.shift();
+  if (next) {
+    next();
+    return;
+  }
+  log.lockHolders = 0;
+};
+
+export const createInMemoryEventStore = (options?: {
+  readonly pageSize?: number;
+}): InMemoryEventStore => {
+  const documents = new Map<string, DocumentLog>();
+  let pageSize = Math.max(1, options?.pageSize ?? 100);
+
+  const getLog = (documentId: string): DocumentLog => {
+    const existing = documents.get(documentId);
+    if (existing) return existing;
+    const created = createDocumentLog();
+    documents.set(documentId, created);
+    return created;
+  };
+
+  const appendEventBatches = async (
+    documentId: string,
+    _actorId: string,
+    batches: ReadonlyArray<RichTextEventBatch>,
+  ): Promise<ReadonlyArray<string>> => {
+    const incomingEventIds = batches.flatMap((batch) =>
+      batch.events.map((event) => event.id),
+    );
+    if (new Set(incomingEventIds).size !== incomingEventIds.length) {
+      throw new EventConflictError("duplicate event IDs in incoming batches", {
+        conflictType: EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
+        documentId,
+        batchIds: batches.map((batch) => batch.batchId),
+        eventIds: incomingEventIds,
+      });
+    }
+
+    const log = getLog(documentId);
+    await acquireLock(log);
+    try {
+      const availableEventIds = new Set<string>();
+      for (const batch of batches) {
+        const requiredParentIds = new Set<string>();
+        const knownAtBatchStart = availableEventIds;
+        const seenInBatch = new Set<string>();
+        for (const parentId of batch.parentVersion) {
+          if (
+            parentId !== BOOTSTRAP_EVENT_ID &&
+            !knownAtBatchStart.has(parentId)
+          ) {
+            requiredParentIds.add(parentId);
+          }
+        }
+        for (const event of batch.events) {
+          for (const parentId of event.parentVersion) {
+            if (
+              parentId !== BOOTSTRAP_EVENT_ID &&
+              !knownAtBatchStart.has(parentId) &&
+              !seenInBatch.has(parentId)
+            ) {
+              requiredParentIds.add(parentId);
+            }
+          }
+          seenInBatch.add(event.id);
+        }
+
+        for (const parentId of requiredParentIds) {
+          if (!log.eventIds.has(parentId) && !availableEventIds.has(parentId)) {
+            const missingParentIds = [...requiredParentIds]
+              .filter(
+                (eventId) =>
+                  !log.eventIds.has(eventId) && !availableEventIds.has(eventId),
+              )
+              .sort();
+            throw new EventConflictError(
+              "event batch references document history that has not been stored",
+              {
+                conflictType: EVENT_CONFLICT_TYPE.MissingParentHistory,
+                documentId,
+                batchIds: [batch.batchId],
+                missingParentIds,
+              },
+            );
+          }
+          availableEventIds.add(parentId);
+        }
+
+        const payloadHash = hashBatch(batch);
+        const existing = log.batchesById.get(batch.batchId);
+        if (existing !== undefined) {
+          if (existing.payloadHash !== payloadHash) {
+            throw new EventConflictError(
+              `conflicting payload for batch ${batch.batchId}`,
+              {
+                conflictType: EVENT_CONFLICT_TYPE.BatchPayloadConflict,
+                documentId,
+                batchIds: [batch.batchId],
+              },
+            );
+          }
+          for (const event of batch.events) {
+            availableEventIds.add(event.id);
+          }
+          continue;
+        }
+
+        for (const event of batch.events) {
+          if (log.eventIds.has(event.id)) {
+            throw new EventConflictError(
+              "event IDs conflict with stored document history",
+              {
+                conflictType: EVENT_CONFLICT_TYPE.StoredEventIdConflict,
+                documentId,
+                batchIds: batches.map((entry) => entry.batchId),
+                eventIds: incomingEventIds,
+              },
+            );
+          }
+        }
+
+        const row: StoredBatch = {
+          id: BigInt(log.ordered.length + 1),
+          batchId: batch.batchId,
+          payloadHash,
+          payload: batch,
+        };
+        log.batchesById.set(batch.batchId, row);
+        log.ordered.push(row);
+        for (const event of batch.events) {
+          log.eventIds.add(event.id);
+          availableEventIds.add(event.id);
+        }
+      }
+    } finally {
+      releaseLock(log);
+    }
+
+    return batches.map((batch) => batch.batchId);
+  };
+
+  const readEventPage = async (
+    documentId: string,
+    afterCursor: string,
+  ): Promise<EventPage> => {
+    const log = getLog(documentId);
+    const after = BigInt(afterCursor);
+    const rows = log.ordered.filter((row) => row.id > after);
+    const pageRows = rows.slice(0, pageSize);
+    const lastRow = pageRows.at(-1);
+    return {
+      batches: pageRows.map((row) => row.payload),
+      nextCursor: lastRow?.id.toString() ?? afterCursor,
+      complete: rows.length <= pageSize,
+    };
+  };
+
+  return {
+    appendEventBatches,
+    readEventPage,
+    listBatchIds: (documentId) =>
+      getLog(documentId).ordered.map((row) => row.batchId),
+    listBatches: (documentId) =>
+      getLog(documentId).ordered.map((row) => row.payload),
+    hasBatch: (documentId, batchId) =>
+      getLog(documentId).batchesById.has(batchId),
+    setPageSize: (next) => {
+      pageSize = Math.max(1, next);
+    },
+    pageSize: () => pageSize,
+  };
+};

--- a/apps/collab/test/helpers/inMemoryEventStore.ts
+++ b/apps/collab/test/helpers/inMemoryEventStore.ts
@@ -57,7 +57,12 @@ const canonicalJson = (value: unknown): string => {
     const record = value as Record<string, unknown>;
     return `{${Object.keys(record)
       .sort()
-      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .flatMap((key) => {
+        const entry = record[key];
+        // Match JSON.stringify: omit undefined-valued properties.
+        if (entry === undefined) return [];
+        return [`${JSON.stringify(key)}:${canonicalJson(entry)}`];
+      })
       .join(",")}}`;
   }
   throw new Error("event batch contains a non-JSON value");
@@ -135,10 +140,14 @@ export const createInMemoryEventStore = (options?: {
     const log = getLog(documentId);
     await acquireLock(log);
     try {
+      // Stage first so a mid-request conflict cannot partially mutate the log.
+      const stagedRows: StoredBatch[] = [];
+      const stagedEventIds = new Set<string>();
       const availableEventIds = new Set<string>();
+
       for (const batch of batches) {
         const requiredParentIds = new Set<string>();
-        const knownAtBatchStart = availableEventIds;
+        const knownAtBatchStart = new Set(availableEventIds);
         const seenInBatch = new Set<string>();
         for (const parentId of batch.parentVersion) {
           if (
@@ -162,11 +171,17 @@ export const createInMemoryEventStore = (options?: {
         }
 
         for (const parentId of requiredParentIds) {
-          if (!log.eventIds.has(parentId) && !availableEventIds.has(parentId)) {
+          if (
+            !log.eventIds.has(parentId) &&
+            !stagedEventIds.has(parentId) &&
+            !availableEventIds.has(parentId)
+          ) {
             const missingParentIds = [...requiredParentIds]
               .filter(
                 (eventId) =>
-                  !log.eventIds.has(eventId) && !availableEventIds.has(eventId),
+                  !log.eventIds.has(eventId) &&
+                  !stagedEventIds.has(eventId) &&
+                  !availableEventIds.has(eventId),
               )
               .sort();
             throw new EventConflictError(
@@ -183,7 +198,9 @@ export const createInMemoryEventStore = (options?: {
         }
 
         const payloadHash = hashBatch(batch);
-        const existing = log.batchesById.get(batch.batchId);
+        const existing =
+          log.batchesById.get(batch.batchId) ??
+          stagedRows.find((row) => row.batchId === batch.batchId);
         if (existing !== undefined) {
           if (existing.payloadHash !== payloadHash) {
             throw new EventConflictError(
@@ -202,7 +219,7 @@ export const createInMemoryEventStore = (options?: {
         }
 
         for (const event of batch.events) {
-          if (log.eventIds.has(event.id)) {
+          if (log.eventIds.has(event.id) || stagedEventIds.has(event.id)) {
             throw new EventConflictError(
               "event IDs conflict with stored document history",
               {
@@ -216,16 +233,23 @@ export const createInMemoryEventStore = (options?: {
         }
 
         const row: StoredBatch = {
-          id: BigInt(log.ordered.length + 1),
+          id: BigInt(log.ordered.length + stagedRows.length + 1),
           batchId: batch.batchId,
           payloadHash,
           payload: batch,
         };
-        log.batchesById.set(batch.batchId, row);
-        log.ordered.push(row);
+        stagedRows.push(row);
         for (const event of batch.events) {
-          log.eventIds.add(event.id);
+          stagedEventIds.add(event.id);
           availableEventIds.add(event.id);
+        }
+      }
+
+      for (const row of stagedRows) {
+        log.batchesById.set(row.batchId, row);
+        log.ordered.push(row);
+        for (const event of row.payload.events) {
+          log.eventIds.add(event.id);
         }
       }
     } finally {

--- a/apps/collab/test/multi-instance-collab.test.ts
+++ b/apps/collab/test/multi-instance-collab.test.ts
@@ -9,10 +9,10 @@ const ACTOR_A = "00000000-0000-4000-8000-0000000000b1";
 const ACTOR_B = "00000000-0000-4000-8000-0000000000b2";
 
 describe("multi-instance collaboration harness", () => {
-  let harness: CollabConsistencyHarness;
+  let harness: CollabConsistencyHarness | undefined;
 
   afterEach(async () => {
-    await harness.close();
+    await harness?.close();
   });
 
   it("should keep local peer state isolated across instances while sharing durable history", async () => {
@@ -92,7 +92,9 @@ describe("multi-instance collaboration harness", () => {
 
     // Act
     const batch = clientA.localInsert("fan", 0);
-    await harness.pumpProtocol(20);
+    await harness.pumpUntil(() =>
+      clientA.acknowledgedBatchIds().has(batch.batchId),
+    );
     expect(clientA.acknowledgedBatchIds().has(batch.batchId)).toBe(true);
     expect(harness.pendingDeliveries()).toBeGreaterThan(0);
 

--- a/apps/collab/test/multi-instance-collab.test.ts
+++ b/apps/collab/test/multi-instance-collab.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createCollabConsistencyHarness,
+  type CollabConsistencyHarness,
+  type HarnessClient,
+} from "./helpers/collabConsistencyHarness";
+
+const ACTOR_A = "00000000-0000-4000-8000-0000000000b1";
+const ACTOR_B = "00000000-0000-4000-8000-0000000000b2";
+
+describe("multi-instance collaboration harness", () => {
+  let harness: CollabConsistencyHarness;
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  it("should keep local peer state isolated across instances while sharing durable history", async () => {
+    // Arrange
+    harness = createCollabConsistencyHarness();
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+
+    const clientA = await instanceA.connectClient({
+      id: "a",
+      actorId: ACTOR_A,
+    });
+    const clientB = await instanceB.connectClient({
+      id: "b",
+      actorId: ACTOR_B,
+    });
+    await harness.settle();
+    await Promise.all([clientA.waitUntilSynced(), clientB.waitUntilSynced()]);
+
+    // Assert: each instance only tracks its own local peers.
+    expect(instanceA.localPeerCount(harness.documentId)).toBe(1);
+    expect(instanceB.localPeerCount(harness.documentId)).toBe(1);
+    expect(instanceA.hub).not.toBe(instanceB.hub);
+  });
+
+  it("should serialize concurrent writes from different instances into durable order", async () => {
+    // Arrange
+    harness = createCollabConsistencyHarness();
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+    const clientA = await instanceA.connectClient({
+      id: "a",
+      actorId: ACTOR_A,
+    });
+    const clientB = await instanceB.connectClient({
+      id: "b",
+      actorId: ACTOR_B,
+    });
+    await harness.settle();
+    await Promise.all([clientA.waitUntilSynced(), clientB.waitUntilSynced()]);
+
+    // Act: concurrent local edits from independently owned rooms.
+    const batchA = clientA.localInsert("A", 0);
+    const batchB = clientB.localInsert("B", 0);
+    await Promise.all([clientA.flushOutgoing(), clientB.flushOutgoing()]);
+    await harness.settle();
+    await Promise.all([clientA.waitUntilIdle(), clientB.waitUntilIdle()]);
+
+    // Assert
+    expect(harness.store.hasBatch(harness.documentId, batchA.batchId)).toBe(
+      true,
+    );
+    expect(harness.store.hasBatch(harness.documentId, batchB.batchId)).toBe(
+      true,
+    );
+    expect(clientA.conflicts()).toEqual([]);
+    expect(clientB.conflicts()).toEqual([]);
+    harness.assertReplicasConverged([clientA, clientB]);
+  });
+
+  it("should fan out committed events across instances and tolerate duplicate delivery", async () => {
+    // Arrange
+    harness = createCollabConsistencyHarness();
+    harness.setDeliveryMode("deferred");
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+    const clientA = await instanceA.connectClient({
+      id: "a",
+      actorId: ACTOR_A,
+    });
+    const clientB = await instanceB.connectClient({
+      id: "b",
+      actorId: ACTOR_B,
+    });
+    await harness.settle();
+    await Promise.all([clientA.waitUntilSynced(), clientB.waitUntilSynced()]);
+
+    // Act
+    const batch = clientA.localInsert("fan", 0);
+    await harness.pumpProtocol(20);
+    expect(clientA.acknowledgedBatchIds().has(batch.batchId)).toBe(true);
+    expect(harness.pendingDeliveries()).toBeGreaterThan(0);
+
+    expect(harness.duplicateNextDelivery()).toBe(true);
+    await harness.deliverAll();
+    await harness.settle();
+
+    // Assert: duplicate Event delivery does not corrupt state.
+    expect(clientB.knownBatchIds().has(batch.batchId)).toBe(true);
+    expect(clientA.conflicts()).toEqual([]);
+    expect(clientB.conflicts()).toEqual([]);
+    harness.assertReplicasConverged([clientA, clientB]);
+  });
+
+  it("should support disconnect, repair, and reconnect across instance boundaries", async () => {
+    // Arrange
+    harness = createCollabConsistencyHarness({ pageSize: 1 });
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+    const clientA = await instanceA.connectClient({
+      id: "a",
+      actorId: ACTOR_A,
+    });
+    const clientB = await instanceB.connectClient({
+      id: "b",
+      actorId: ACTOR_B,
+    });
+    await harness.settle();
+    await Promise.all([clientA.waitUntilSynced(), clientB.waitUntilSynced()]);
+
+    const first = clientA.localInsert("1", 0);
+    await clientA.flushOutgoing();
+    await harness.settle();
+
+    // Act: B disconnects, A keeps writing, B reconnects and repairs.
+    await clientB.disconnect();
+    const second = clientA.localInsert("2", 1);
+    await clientA.flushOutgoing();
+    await harness.settle();
+
+    await clientB.connect();
+    await harness.settle();
+    await clientB.waitUntilIdle();
+
+    // Assert
+    expect(clientB.knownBatchIds().has(first.batchId)).toBe(true);
+    expect(clientB.knownBatchIds().has(second.batchId)).toBe(true);
+    expect(clientB.conflicts()).toEqual([]);
+    harness.assertReplicasConverged([clientA, clientB]);
+  });
+
+  it("should not share process-local topic state between instances", async () => {
+    // Arrange
+    harness = createCollabConsistencyHarness();
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+    const clients: HarnessClient[] = [];
+    clients.push(
+      await instanceA.connectClient({ id: "a1", actorId: ACTOR_A }),
+      await instanceA.connectClient({ id: "a2", actorId: ACTOR_A }),
+      await instanceB.connectClient({ id: "b1", actorId: ACTOR_B }),
+    );
+    await harness.settle();
+
+    // Assert
+    expect(instanceA.localPeerCount(harness.documentId)).toBe(2);
+    expect(instanceB.localPeerCount(harness.documentId)).toBe(1);
+  });
+});

--- a/apps/collab/test/repair-live-interleave.test.ts
+++ b/apps/collab/test/repair-live-interleave.test.ts
@@ -9,10 +9,10 @@ const ACTOR_A = "00000000-0000-4000-8000-0000000000a1";
 const ACTOR_B = "00000000-0000-4000-8000-0000000000a2";
 
 describe("repair and live-event interleaving", () => {
-  let harness: CollabConsistencyHarness;
+  let harness: CollabConsistencyHarness | undefined;
 
   afterEach(async () => {
-    await harness.close();
+    await harness?.close();
   });
 
   it("should apply live Event after a partial repair page without losing history", async () => {
@@ -26,13 +26,17 @@ describe("repair and live-event interleaving", () => {
     const instanceA = harness.createInstance("A");
     const instanceB = harness.createInstance("B");
 
-    // Act: start client A repair, but only complete the first page turn.
+    // Act: start client A repair, but stop once page 1 is applied.
     const clientA = await instanceA.connectClient({
       id: "client-a",
       actorId: ACTOR_A,
     });
-    // Auth -> Ready enqueue -> RepairRequest -> RepairResponse(page1) -> next RepairRequest
-    await harness.pumpProtocol(5);
+    await harness.pumpUntil(
+      () =>
+        clientA.knownBatchIds().has(first.batchId) &&
+        !clientA.knownBatchIds().has(second.batchId) &&
+        !clientA.isSynced(),
+    );
     expect(clientA.isSynced()).toBe(false);
     expect(clientA.knownBatchIds().has(first.batchId)).toBe(true);
     expect(clientA.knownBatchIds().has(second.batchId)).toBe(false);
@@ -122,7 +126,12 @@ describe("repair and live-event interleaving", () => {
     });
 
     // Act: stop after first repair response applied and next request queued.
-    await harness.pumpProtocol(5);
+    await harness.pumpUntil(
+      () =>
+        clientA.knownBatchIds().has(seed.first.batchId) &&
+        !clientA.knownBatchIds().has(seed.second.batchId) &&
+        !clientA.isSynced(),
+    );
     expect(clientA.knownBatchIds().has(seed.first.batchId)).toBe(true);
     expect(clientA.isSynced()).toBe(false);
 
@@ -169,7 +178,9 @@ describe("repair and live-event interleaving", () => {
     await harness.settle();
     await client.waitUntilIdle();
 
-    // Assert
+    // Assert: stale pre-disconnect Event work is discarded; only the new
+    // connection generation resends the exact pending batch identity.
+    expect(client.sentBatchIdsSinceConnect()).toEqual([pending.batchId]);
     expect(harness.store.hasBatch(harness.documentId, pending.batchId)).toBe(
       true,
     );

--- a/apps/collab/test/repair-live-interleave.test.ts
+++ b/apps/collab/test/repair-live-interleave.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createCausalBatches,
+  createCollabConsistencyHarness,
+  type CollabConsistencyHarness,
+} from "./helpers/collabConsistencyHarness";
+
+const ACTOR_A = "00000000-0000-4000-8000-0000000000a1";
+const ACTOR_B = "00000000-0000-4000-8000-0000000000a2";
+
+describe("repair and live-event interleaving", () => {
+  let harness: CollabConsistencyHarness;
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  it("should apply live Event after a partial repair page without losing history", async () => {
+    // Arrange: durable history of two causal batches; repair pages of size 1.
+    harness = createCollabConsistencyHarness({ pageSize: 1 });
+    const { first, second } = createCausalBatches("seed");
+    await harness.store.appendEventBatches(harness.documentId, ACTOR_A, [
+      first,
+      second,
+    ]);
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+
+    // Act: start client A repair, but only complete the first page turn.
+    const clientA = await instanceA.connectClient({
+      id: "client-a",
+      actorId: ACTOR_A,
+    });
+    // Auth -> Ready enqueue -> RepairRequest -> RepairResponse(page1) -> next RepairRequest
+    await harness.pumpProtocol(5);
+    expect(clientA.isSynced()).toBe(false);
+    expect(clientA.knownBatchIds().has(first.batchId)).toBe(true);
+    expect(clientA.knownBatchIds().has(second.batchId)).toBe(false);
+
+    const clientB = await instanceB.connectClient({
+      id: "client-b",
+      actorId: ACTOR_B,
+    });
+    await harness.settle();
+    await clientB.waitUntilSynced();
+    const live = clientB.localInsert("Z", 2);
+    await clientB.flushOutgoing();
+
+    // Finish A's remaining repair pages and live fan-out.
+    await harness.settle();
+    await clientA.waitUntilSynced();
+
+    // Assert
+    expect(clientA.knownBatchIds().has(second.batchId)).toBe(true);
+    expect(clientA.knownBatchIds().has(live.batchId)).toBe(true);
+    expect(clientA.conflicts()).toEqual([]);
+    expect(clientA.repairRequestCount()).toBeGreaterThanOrEqual(2);
+    harness.assertReplicasConverged([clientA, clientB]);
+  });
+
+  it("should tolerate live Event arriving before the first repair page", async () => {
+    // Arrange
+    harness = createCollabConsistencyHarness({ pageSize: 1 });
+    const { first, second } = createCausalBatches("seed");
+    await harness.store.appendEventBatches(harness.documentId, ACTOR_A, [
+      first,
+      second,
+    ]);
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+
+    const clientB = await instanceB.connectClient({
+      id: "client-b",
+      actorId: ACTOR_B,
+    });
+    await harness.settle();
+    await clientB.waitUntilSynced();
+    const live = clientB.localInsert("L", 2);
+    await clientB.flushOutgoing();
+
+    // Act: connect A after the live commit already happened.
+    const clientA = await instanceA.connectClient({
+      id: "client-a",
+      actorId: ACTOR_A,
+    });
+    await harness.settle();
+    await clientA.waitUntilSynced();
+
+    // Assert: repair + live delivery converge; no missing-parent conflict.
+    expect(clientA.knownBatchIds().has(first.batchId)).toBe(true);
+    expect(clientA.knownBatchIds().has(second.batchId)).toBe(true);
+    expect(clientA.knownBatchIds().has(live.batchId)).toBe(true);
+    expect(clientA.conflicts()).toEqual([]);
+    harness.assertReplicasConverged([clientA, clientB]);
+  });
+
+  it("should keep repair page 1, live Event, repair page 2 ordering correct", async () => {
+    // Arrange: three durable batches so repair needs multiple pages around a live write.
+    harness = createCollabConsistencyHarness({ pageSize: 1 });
+    const seed = createCausalBatches("seed-1");
+    await harness.store.appendEventBatches(harness.documentId, ACTOR_A, [
+      seed.first,
+      seed.second,
+    ]);
+    // Third durable batch via a temporary writer.
+    const bootstrapInstance = harness.createInstance("bootstrap");
+    const seeder = await bootstrapInstance.connectClient({
+      id: "seeder",
+      actorId: ACTOR_A,
+    });
+    await harness.settle();
+    await seeder.waitUntilSynced();
+    const third = seeder.localInsert("C", 2);
+    await seeder.flushOutgoing();
+    await seeder.disconnect();
+
+    const instanceA = harness.createInstance("A");
+    const instanceB = harness.createInstance("B");
+    const clientA = await instanceA.connectClient({
+      id: "client-a",
+      actorId: ACTOR_A,
+    });
+
+    // Act: stop after first repair response applied and next request queued.
+    await harness.pumpProtocol(5);
+    expect(clientA.knownBatchIds().has(seed.first.batchId)).toBe(true);
+    expect(clientA.isSynced()).toBe(false);
+
+    const clientB = await instanceB.connectClient({
+      id: "client-b",
+      actorId: ACTOR_B,
+    });
+    await harness.settle();
+    await clientB.waitUntilSynced();
+    const live = clientB.localInsert("X", 3);
+    await clientB.flushOutgoing();
+    await harness.settle();
+    await clientA.waitUntilSynced();
+
+    // Assert
+    expect(clientA.knownBatchIds().has(seed.second.batchId)).toBe(true);
+    expect(clientA.knownBatchIds().has(third.batchId)).toBe(true);
+    expect(clientA.knownBatchIds().has(live.batchId)).toBe(true);
+    expect(clientA.conflicts()).toEqual([]);
+    // No repair loop: requests stay proportional to page count + reconnects.
+    expect(clientA.repairRequestCount()).toBeLessThanOrEqual(8);
+    harness.assertReplicasConverged([clientA, clientB]);
+  });
+
+  it("should repair then exact-resend pending batches after reconnect", async () => {
+    // Arrange
+    harness = createCollabConsistencyHarness({ pageSize: 2 });
+    const instance = harness.createInstance("A");
+    const client = await instance.connectClient({
+      id: "client-a",
+      actorId: ACTOR_A,
+    });
+    await harness.settle();
+    await client.waitUntilSynced();
+
+    const pending = client.localInsert("P", 0);
+    // Disconnect before DurableAck while the Event is still queued.
+    await client.disconnect();
+    expect(client.pendingBatchIds()).toEqual([pending.batchId]);
+    expect(client.acknowledgedBatchIds().has(pending.batchId)).toBe(false);
+
+    // Act: reconnect resumes repair from cursor, then exact pending resend.
+    await client.connect();
+    await harness.settle();
+    await client.waitUntilIdle();
+
+    // Assert
+    expect(harness.store.hasBatch(harness.documentId, pending.batchId)).toBe(
+      true,
+    );
+    expect(client.acknowledgedBatchIds().has(pending.batchId)).toBe(true);
+    expect(client.pendingBatchIds()).toEqual([]);
+    expect(client.conflicts()).toEqual([]);
+    // Initial connect + reconnect each start repair; no loop beyond that.
+    expect(client.repairRequestCount()).toBeGreaterThanOrEqual(2);
+    expect(client.repairRequestCount()).toBeLessThanOrEqual(4);
+  });
+});

--- a/docs/design/collaboration-consistency.md
+++ b/docs/design/collaboration-consistency.md
@@ -44,7 +44,7 @@ The server order is:
 2. Send `DurableAck` to the writing peer.
 3. Publish the `Event` on the realtime bus for local and remote peers.
 
-If persistence fails, nothing is faned out. If fan-out fails after commit,
+If persistence fails, nothing is fanned out. If fan-out fails after commit,
 peers recover through repair/resync.
 
 ### 4. Idempotent exact resend
@@ -68,11 +68,17 @@ document history or durable batch appends.
 
 ## EventConflictError semantics
 
-Conflicts are surfaced to clients as non-retryable protocol `Error` messages
-with code `conflict`. The browser does **not** enter a conflict-driven
-reconnect/retry loop. Missing history is recovered on the next intentional
-repair/resync after a clean reconnect path, not by blindly retrying the
-conflicting payload.
+On the **realtime** transport, conflicts are surfaced to clients as
+non-retryable protocol `Error` messages with code `conflict`. The browser does
+**not** enter a conflict-driven reconnect/retry loop. Missing history is
+recovered on the next intentional repair/resync after a clean reconnect path,
+not by blindly retrying the conflicting payload.
+
+HTTP appends use a different surface. In `document-events.post.ts`,
+`EventConflictError` maps to **HTTP 409** with an `{ error }` body. Structured
+fields such as `missingParentIds` remain on the server-side
+`EventConflictError` for diagnostics and recovery context; they are not
+included in that HTTP response (they stay on the WebSocket/server log path).
 
 Implementation: `EVENT_CONFLICT_TYPE` / `EventConflictError` in
 `apps/collab/server/utils/event-conflict.ts`.

--- a/docs/design/collaboration-consistency.md
+++ b/docs/design/collaboration-consistency.md
@@ -75,10 +75,12 @@ recovered on the next intentional repair/resync after a clean reconnect path,
 not by blindly retrying the conflicting payload.
 
 HTTP appends use a different surface. In `document-events.post.ts`,
-`EventConflictError` maps to **HTTP 409** with an `{ error }` body. Structured
-fields such as `missingParentIds` remain on the server-side
-`EventConflictError` for diagnostics and recovery context; they are not
-included in that HTTP response (they stay on the WebSocket/server log path).
+`EventConflictError` maps to **HTTP 409** with an `{ error }` body (the conflict
+message string only). Structured fields such as `missingParentIds` exist on the
+server-side `EventConflictError` instance; they are not included in that HTTP
+response. On the realtime route, the same details are written to server logs via
+`logRouteError` as bounded samples and are not sent on the WebSocket `Error`
+payload.
 
 Implementation: `EVENT_CONFLICT_TYPE` / `EventConflictError` in
 `apps/collab/server/utils/event-conflict.ts`.

--- a/docs/design/collaboration-consistency.md
+++ b/docs/design/collaboration-consistency.md
@@ -1,0 +1,159 @@
+---
+title: Collaboration Consistency
+description: Durable write invariants and EventConflictError semantics for Softmaple's hosted collaboration pipeline.
+---
+
+# Collaboration Consistency
+
+This document records the **current** collaboration consistency model after
+[#865](https://github.com/softmaple/softmaple/pull/865). It is a companion to
+[`collaboration-layers.md`](./collaboration-layers.md) (layering) and
+[`collaboration-models.md`](./collaboration-models.md) (engine contracts).
+
+It describes what the Nitro/Postgres collaboration host and browser session
+guarantee today. It is not an aspirational redesign and does not introduce a
+`DocumentRoom` or Durable Objects runtime.
+
+## Durable write invariants
+
+These invariants are load-bearing. Consistency tests treat them as the
+conformance baseline for future runtime hosts.
+
+### 1. One causally dependent write in flight per client session
+
+A browser document session keeps at most one durable `Event` write in flight.
+
+- Later local edits stay **pending** until `DurableAck`.
+- The outgoing queue preserves exact batch identity across disconnect.
+- After reconnect, the session repairs first, then exact-resends pending
+  batches.
+
+Independent remote collaborators are unaffected; the queue is per session.
+
+### 2. Per-document durable serialization
+
+Same-document durable appends serialize through a Postgres
+transaction-scoped advisory lock (`pg_advisory_xact_lock`). This works across
+serverless instances that share the database.
+
+### 3. Durable commit before DurableAck and fan-out
+
+The server order is:
+
+1. Validate and append batches in the locked transaction.
+2. Send `DurableAck` to the writing peer.
+3. Publish the `Event` on the realtime bus for local and remote peers.
+
+If persistence fails, nothing is faned out. If fan-out fails after commit,
+peers recover through repair/resync.
+
+### 4. Idempotent exact resend
+
+Resending the same `batchId` with the same payload is a no-op success.
+Resending the same `batchId` with a different payload is a conflict.
+
+### 5. Repair is explicit synchronization
+
+`RepairRequest` / `RepairResponse` pages catch clients up from a cursor over
+durable history. Repair is intentional synchronization, not an automatic
+reaction to every conflict.
+
+Live `Event` messages may arrive during an incomplete repair. Clients apply
+both paths with batch-id deduplication and must still converge.
+
+### 6. Presence is not durable convergence
+
+Awareness/presence remains ephemeral. It must not be mixed into EG-walker
+document history or durable batch appends.
+
+## EventConflictError semantics
+
+Conflicts are surfaced to clients as non-retryable protocol `Error` messages
+with code `conflict`. The browser does **not** enter a conflict-driven
+reconnect/retry loop. Missing history is recovered on the next intentional
+repair/resync after a clean reconnect path, not by blindly retrying the
+conflicting payload.
+
+Implementation: `EVENT_CONFLICT_TYPE` / `EventConflictError` in
+`apps/collab/server/utils/event-conflict.ts`.
+
+### `DuplicateIncomingEventId`
+
+| Field | Current behavior |
+| --- | --- |
+| Violated invariant | Event IDs inside one append request must be unique. |
+| Expected cause | Malformed client payload or buggy batch packing. |
+| Automatic retry safe? | No. |
+| Repair/resync recover? | No for the bad request. A correct later submission can proceed. |
+| Classification | Client misuse / protocol inconsistency. |
+| Server behavior | Reject the request; no durable write; no fan-out. |
+| Client behavior | Treat as fatal sync error for this write; do not reconnect-loop. |
+
+### `MissingParentHistory`
+
+| Field | Current behavior |
+| --- | --- |
+| Violated invariant | Every non-bootstrap parent must already be durable or appear earlier in the same causally ordered request. |
+| Expected cause | Client sent a child before its parents were acknowledged; truncated history; or reversed batch order in one request. After #865, transient races from overlapping in-flight dependent writes should no longer reach this path. |
+| Automatic retry safe? | No as a conflict-driven reconnect loop. |
+| Repair/resync recover? | Yes, once parents are durable: repair catches the client up, then an exact pending resend can succeed. |
+| Classification | Synchronization gap (or client misuse if parents were never created). |
+| Server behavior | Reject the request; structured details include `missingParentIds`. |
+| Client behavior | Non-retryable conflict close. Next intentional connect repairs, then exact-resends pending batches. |
+
+### `BatchPayloadConflict`
+
+| Field | Current behavior |
+| --- | --- |
+| Violated invariant | A `batchId` identifies exactly one payload forever. |
+| Expected cause | Client reused a batch id with different event contents. |
+| Automatic retry safe? | No. |
+| Repair/resync recover? | No for the conflicting payload. Durable history keeps the original. |
+| Classification | Client misuse / protocol inconsistency. |
+| Server behavior | Reject the request; no overwrite of durable history. |
+| Client behavior | Fatal for that write identity; do not mutate and retry under the same id. |
+
+### `StoredEventIdConflict`
+
+| Field | Current behavior |
+| --- | --- |
+| Violated invariant | Event IDs are unique in durable document history. |
+| Expected cause | Distinct batches claiming the same event id, or a unique-constraint race that fails post-commit verification. |
+| Automatic retry safe? | No when verification shows a real id clash. Exact duplicate batch resend is handled separately and succeeds idempotently. |
+| Repair/resync recover? | Repair can load authoritative history. The conflicting new payload must not be forced in. |
+| Classification | Protocol inconsistency or durable-history integrity failure. |
+| Server behavior | After P2002, verify whether the request is an exact duplicate; otherwise reject with this conflict type. |
+| Client behavior | Non-retryable conflict; inspect/repair rather than blind resend of a different payload. |
+
+## Multi-instance ownership model
+
+The consistency harness models the intended ownership boundary:
+
+```text
+instance A
+  local peers
+  local topic/room state
+        |
+shared distributed bus + durable event store
+        |
+instance B
+  local peers
+  local topic/room state
+```
+
+Process-local hubs must not accidentally share peer sets. Cross-instance
+delivery happens only through the shared bus after durable commit.
+
+## Conformance coverage
+
+Phase 1 hardening tests live under `apps/collab/test/`:
+
+- `repair-live-interleave.test.ts` — repair ↔ live Event races
+- `multi-instance-collab.test.ts` — write / repair / reconnect across instances
+- `collaboration-convergence.property.test.ts` — seeded randomized 2–3 client traces
+
+Optional soak:
+
+```bash
+COLLAB_CONVERGENCE_SOAK=1 pnpm --filter @softmaple/collab test
+```

--- a/docs/design/collaboration-layers.md
+++ b/docs/design/collaboration-layers.md
@@ -8,7 +8,9 @@ description: Layering boundaries between the EG-walker sequence core, block mode
 This document is the **source of truth** for how Softmaple's real-time
 collaboration code is layered. It defines what each layer owns, what it
 must not depend on, and how model bindings and awareness compose inside
-`apps/*`.
+`apps/*`. Durable write invariants and `EventConflictError` semantics are
+documented in
+[`collaboration-consistency.md`](./collaboration-consistency.md).
 
 The split is enforced by shared ESLint `no-restricted-imports` patterns and
 awareness's equivalent Biome rule (see [Enforcement](#enforcement) below).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,7 +41,8 @@
         "group": "Design Documents",
         "pages": [
           "design/awareness-and-presence",
-          "design/collaboration-layers"
+          "design/collaboration-layers",
+          "design/collaboration-consistency"
         ]
       },
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.4
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -466,7 +469,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.10.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@24.10.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.10)(yaml@2.8.1))
+        version: 4.1.10(@types/node@24.10.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.10)(yaml@2.8.1))
 
   packages/binding-lexical:
     dependencies:
@@ -802,7 +805,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.10.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.10)(yaml@2.8.1))
+        version: 4.1.10(@types/node@24.10.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@24.10.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.10)(yaml@2.8.1))
 
   packages/eslint-config:
     devDependencies:
@@ -8309,7 +8312,7 @@ snapshots:
   '@fast-check/vitest@0.4.1(vitest@4.1.10)':
     dependencies:
       fast-check: 4.8.0
-      vitest: 4.1.10(@types/node@24.10.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.10)(yaml@2.8.1))
+      vitest: 4.1.10(@types/node@24.10.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@24.10.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.10)(yaml@2.8.1))
 
   '@floating-ui/core@1.7.3':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the remaining Phase 1 collaboration consistency baseline hardening from #868. Does **not** redesign or undo the #865 rapid-edit `EventConflictError` fix.

### What #865 already solved

- One causally dependent durable write in flight per client session
- Per-document Postgres advisory-lock serialization
- Exact pending batch identity across disconnect/reconnect
- Idempotent exact duplicate resend
- Structured `EventConflictError` categories + non-retryable conflict wire behavior
- Fan-out only after durable persistence
- Deterministic regression coverage for the original concurrent pending-batch failure

### What this PR adds

1. **Repair/live-event interleaving suite** (`apps/collab/test/repair-live-interleave.test.ts`)
2. **Randomized 2–3 client collaboration convergence suite** (`apps/collab/test/collaboration-convergence.property.test.ts`)
3. **Stronger multi-instance collaboration harness** (`apps/collab/test/helpers/*` + `multi-instance-collab.test.ts`)
4. **Consistency design doc** (`docs/design/collaboration-consistency.md`)

### Review follow-ups (this iteration)

- Peer-generation discard on disconnect (stale Auth releases retained channels)
- Atomic in-memory append staging before mutating durable log state
- Shared in-flight `settle()` drain + macrotask `waitFor` yielding
- Condition-based `pumpUntil` instead of fixed turn counts
- Explicit reconnect resend batch-id assertion
- Property-test timeout + positive-integer env parsing for run counts
- Docs: realtime vs HTTP 409 conflict surfaces; “fanned” spelling fix

## Repair / live-event interleavings covered

- repair page → live Event
- live Event → repair page
- repair page 1 → live Event → repair page 2
- reconnect → repair → exact pending resend

Assertions: no lost committed events, duplicate delivery safe via batch-id dedupe, no false missing-parent conflicts, no repair loops, final replicas converge.

## Randomized test strategy and seed reproduction

- Hosted collaboration pipeline traces (not EG-walker engine properties)
- Exercises 2–3 clients across two simulated runtime instances with concurrent edits, deferred/reordered/duplicated fan-out, disconnect/reconnect, pending exact resend, and repair
- Deterministic CI seed `868001` with default `numRuns=40` (override via `COLLAB_CONVERGENCE_RUNS`)
- Optional soak: `COLLAB_CONVERGENCE_SOAK=1` (larger traces / more runs)
- Failures include the op index and full JSON trace for reproduction

## Multi-instance harness architecture

```text
instance A local peers / LocalTopicHub
        |
shared ControllableRealtimeBus + InMemoryEventStore
        |
instance B local peers / LocalTopicHub
```

- Independently owned local hubs/bridges (no shared process-local peer state)
- Shared durable store mirrors production conflict semantics without Prisma/Upstash
- Controllable deferred fan-out for duplicate/reorder delivery
- Protocol work queue enables deterministic repair↔live interleaving without sleeps

## Documentation added

- `docs/design/collaboration-consistency.md` — durable write invariants + full `EventConflictError` semantics for all four conflict types (realtime `conflict` Error vs HTTP 409 `{ error }`)
- Linked from `collaboration-layers.md` and `docs/docs.json`

## Acceptance criteria checklist (#868 remaining)

- [x] Repair + live-event races are explicitly covered
- [x] A randomized 2–3 client collaboration soak/property-style test repeatedly converges
- [x] The stronger multi-instance collaboration harness covers write + repair + reconnect, not only fan-out
- [x] Conflict semantics are recorded in a durable design document

Previously completed by #865 (unchanged here):

- [x] Original rapid-edit regression fixed and locked
- [x] Normal concurrent writes not rejected merely for overlapping in time
- [x] Duplicate/idempotent submissions handled deterministically
- [x] Reconnect preserves exact batch identity
- [x] Multi-instance fan-out has deterministic simulated coverage
- [x] Conflict logs are actionable and bounded

## Test plan

Executed:

- [x] `pnpm --filter @softmaple/collab test` (56 tests)
- [x] `pnpm --filter @softmaple/collab typecheck`
- [x] `pnpm --filter @softmaple/web exec vitest run modules/docs/collab-outgoing-queue.test.ts modules/docs/use-collab-document.test.ts`
- [x] `pnpm --filter @softmaple/web typecheck`
- [x] Biome format via lint-staged on commit

Not executed:

- [ ] Playwright collaboration E2E (`apps/web/e2e/core.spec.ts`) — local DB migrate fails with `role "anon" does not exist` in this environment; existing E2E coverage from #865 remains unchanged and was not invalidated by these test-only/docs changes

## Remaining limitations

- Harness is infrastructure-independent and intentionally does not require real Upstash/Postgres in unit CI
- Does not implement Cloudflare Durable Objects / `DocumentRoom` (#869+)
- Does not close #868 automatically in case reviewers want a final human pass against the issue checklist
- Optional soak mode is env-gated for CI runtime bounds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f52678d7-414c-4e4d-beec-48033a09ea8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f52678d7-414c-4e4d-beec-48033a09ea8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collaboration reliability during reconnects, duplicate or reordered updates, concurrent edits, and multi-instance synchronization.
  * Ensured replicas converge consistently while preserving durable acknowledgements and pending changes.

* **Documentation**
  * Added guidance on collaboration consistency, conflict handling, synchronization, and write guarantees.
  * Added the new design document to documentation navigation.

* **Tests**
  * Expanded coverage for convergence, repair flows, event delivery, and multi-instance behavior.
  * Added deterministic and property-based scenarios for complex collaboration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->