### PR TITLE
feat(packages/collab-runtime): add runtime-independent DocumentRoom contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,22 @@ jobs:
         run: pnpm format:check
       - name: Lint Web with zero warnings
         run: pnpm --filter @softmaple/web lint
+      - name: Lint collaboration runtime boundaries with zero warnings
+        run: pnpm --filter @softmaple/collab-runtime lint
+      - name: Lint awareness collaboration boundaries
+        run: pnpm --filter @softmaple/awareness exec biome lint --only=style/noRestrictedImports .
+      - name: Check workspace package boundaries
+        run: pnpm turbo boundaries
       - name: Typecheck affected product packages
-        run: pnpm turbo run typecheck --filter=@softmaple/web --filter=@softmaple/collab --filter=@softmaple/editor --filter=@softmaple/awareness --filter=@softmaple/md2latex --filter=@softmaple/collab-protocol
+        run: pnpm turbo run typecheck --filter=@softmaple/web --filter=@softmaple/collab --filter=@softmaple/editor --filter=@softmaple/awareness --filter=@softmaple/md2latex --filter=@softmaple/collab-protocol --filter=@softmaple/collab-runtime
       - name: Run product unit and integration tests
         run: |
+          pnpm --filter @softmaple/eslint-config test
           pnpm --filter @softmaple/web test -- --run
           pnpm --filter @softmaple/collab test
           pnpm --filter @softmaple/collab-protocol test
           pnpm --filter @softmaple/md2latex test -- --run
           pnpm --filter @softmaple/editor exec vitest run --project=unit src/markdown.test.ts
           pnpm --filter @softmaple/awareness exec vitest run --project=unit
-      - name: Build Web and Collab
-        run: pnpm turbo run build --filter=@softmaple/web --filter=@softmaple/collab
+      - name: Build Web, Collab, and collaboration runtime
+        run: pnpm turbo run build --filter=@softmaple/web --filter=@softmaple/collab --filter=@softmaple/collab-runtime

--- a/docs/design/collaboration-consistency.md
+++ b/docs/design/collaboration-consistency.md
@@ -11,8 +11,9 @@ This document records the **current** collaboration consistency model after
 [`collaboration-models.md`](./collaboration-models.md) (engine contracts).
 
 It describes what the Nitro/Postgres collaboration host and browser session
-guarantee today. It is not an aspirational redesign and does not introduce a
-`DocumentRoom` or Durable Objects runtime.
+guarantee today. The runtime-independent `DocumentRoom` contracts are defined
+in [`collaboration-runtime.md`](./collaboration-runtime.md), but production is
+not wired to them yet. This page does not describe a Durable Objects runtime.
 
 ## Durable write invariants
 

--- a/docs/design/collaboration-layers.md
+++ b/docs/design/collaboration-layers.md
@@ -10,7 +10,9 @@ collaboration code is layered. It defines what each layer owns, what it
 must not depend on, and how model bindings and awareness compose inside
 `apps/*`. Durable write invariants and `EventConflictError` semantics are
 documented in
-[`collaboration-consistency.md`](./collaboration-consistency.md).
+[`collaboration-consistency.md`](./collaboration-consistency.md). The
+runtime-independent room/session contract is specified in
+[`collaboration-runtime.md`](./collaboration-runtime.md).
 
 The split is enforced by shared ESLint `no-restricted-imports` patterns and
 awareness's equivalent Biome rule (see [Enforcement](#enforcement) below).
@@ -23,24 +25,26 @@ awareness's equivalent Biome rule (see [Enforcement](#enforcement) below).
                  ↓
 @softmaple/block-model
     - blocks, structure, marks, rich-text event batches
-        ↙                 ↘
+        ↙                  ↓
 @softmaple/binding-lexical
     - Lexical ↔ block-model projection
                             @softmaple/collab-protocol
                             - versioned wire messages and validation
-        ↘                 ↙
-              apps/*
-    - persistence, transport, identity, UI composition
+                                      ↓
+                            @softmaple/collab-runtime
+                            - room/session and capability contracts
+        ↘                             ↓
+              apps/* and apps/collab adapters
+    - persistence, transport, identity, routing, UI composition
 
 @softmaple/awareness
     - ephemeral presence, transport adapters, rendering helpers
                  ↓
               apps/*
 
-apps/collab realtime coordination
+apps/collab runtime adapters
     - Redis Pub/Sub, presence TTLs, connection leases
-                 ↓
-              apps/collab
+    - Nitro transport, Prisma event store, Supabase authorization
 ```
 
 The document path is directional: a lower model layer never imports a
@@ -78,6 +82,8 @@ The CRDT runtime. Implements the Eg-walker paper directly.
 - Depend on `@softmaple/block-model` or any `@softmaple/binding-*`
   package; those are higher layers.
 - Depend on `@softmaple/collab-protocol`; wire contracts are host-facing.
+- Depend on `@softmaple/collab-runtime`; room semantics are a still higher
+  host-facing layer.
 - Depend on any editor framework — `lexical`, `prosemirror-*`,
   `slate` / `slate-*`, or equivalent.
 - Expose block IDs, DOM types, or editor selections. Stable sequence
@@ -115,6 +121,8 @@ sequence and causal DAG supplied by EG-walker.
 - Depend on a surface binding or editor framework.
 - Depend on `@softmaple/collab-protocol`; the protocol depends on model
   batches, never the reverse.
+- Depend on `@softmaple/collab-runtime`; host room semantics depend on model
+  values, never the reverse.
 - Expose Lexical node keys, DOM types, React components, or awareness users.
 
 It may depend on `@softmaple/eg-walker` and its `./anchors` entry; that is
@@ -146,6 +154,8 @@ The presence and cursor layer. Editor-class-agnostic.
   structurally mirrored JSON anchor types do not require a runtime import.
 - Depend on `@softmaple/collab-protocol`; presence and durable document sync
   remain independent channels.
+- Depend on `@softmaple/collab-runtime`; presence remains independent from
+  durable room/session lifecycle.
 - Depend on any editor framework — `lexical`, `prosemirror-*`, or
   `slate` / `slate-*`.
 
@@ -180,6 +190,8 @@ entry supplies lifecycle wiring with peer dependencies.
   boundary.
 - Import `@softmaple/collab-protocol`; the binding owns projection, not wire
   transport.
+- Import `@softmaple/collab-runtime`; bindings do not own hosted room
+  lifecycle.
 - Own network transport, durable persistence, user identity, awareness
   state, or remote-cursor rendering.
 
@@ -204,17 +216,52 @@ server hosts.
   framework. Rich-text payloads enter through `@softmaple/block-model`.
 - Own WebSocket connections, Supabase clients, database access, JWT checks,
   React components, or any other host runtime.
+- Import `@softmaple/collab-runtime`; wire contracts remain below room
+  semantics.
+
+## Layer 6: `@softmaple/collab-runtime`
+
+The runtime-independent server-side collaboration boundary. It defines how a
+document room talks to peers and to host-provided capabilities without
+choosing a deployment runtime or persistence implementation.
+
+### Responsibilities
+
+- Define `DocumentRoom`, `RoomPeer`, normalized document sessions, and room
+  lifecycle contracts.
+- Define capabilities for durable event append/history reads, committed-event
+  fan-out, connection admission/leases, and authorization refresh.
+- Reuse `@softmaple/collab-protocol` messages and validated batch shapes rather
+  than creating a second browser protocol.
+- Specify durable append, `DurableAck`, fan-out, and repair/resync ordering.
+
+The complete behavioral contract is in
+[`collaboration-runtime.md`](./collaboration-runtime.md).
+
+### Forbidden
+
+`@softmaple/collab-runtime` **MUST NOT**:
+
+- Import Nitro, H3, Next.js, Node built-ins, `ioredis`, Prisma,
+  `@softmaple/db`, Supabase SDKs, `cloudflare:workers`, or other concrete host
+  infrastructure.
+- Import EG-walker directly, awareness, a surface binding, an editor
+  framework, React, UI packages, or app routing.
+- Implement convergence, block integration, or another CRDT. EG-walker and
+  block-model retain those responsibilities.
+- Own a browser transport or alter the wire protocol.
 
 ## Host realtime coordination: `apps/collab` Redis adapters
 
 Cross-instance fan-out, presence TTLs, and connection leases live in
 `apps/collab/server/utils/realtime`. They are host-only concerns: model
-packages, awareness, and `@softmaple/collab-protocol` must not import Redis
-clients or deployment topology helpers. Browser Origin checks replace the
-former HMAC web-gateway boundary; Supabase JWT and workspace authorization
-remain the user auth boundary.
+packages, awareness, `@softmaple/collab-protocol`, and
+`@softmaple/collab-runtime` must not import Redis clients or deployment
+topology helpers. Browser Origin checks replace the former HMAC web-gateway
+boundary; Supabase JWT and workspace authorization remain the user auth
+boundary.
 
-## Layer 6: `apps/*`
+## Layer 7: `apps/*`
 
 The integration layer. Today that is `apps/web` (Next.js + Lexical)
 and `apps/playground` (CRDT experiments).
@@ -230,6 +277,9 @@ and `apps/playground` (CRDT experiments).
   `PresenceUser`.
 - **Routing and persistence** — document IDs, room IDs, hydration from
   the database.
+- **Runtime adapters** — connect Nitro peers, Prisma/Postgres history, Redis
+  fan-out/leases, and Supabase authorization to `@softmaple/collab-runtime`
+  contracts.
 
 ### Forbidden
 
@@ -260,10 +310,16 @@ awareness expresses the same independence boundary in Biome:
   `collabProtocolCollaborationPatterns`. It allows block-model wire values,
   while forbidding lower-layer bypasses, bindings, awareness, editors, and
   app-owned database/auth/server/UI runtimes.
+- **`@softmaple/collab-runtime`** (ESLint) — uses
+  `collabRuntimeCollaborationPatterns` as an import allowlist. Production
+  sources may import local modules, `@softmaple/collab-protocol`, and
+  `@softmaple/block-model`; bare imports of deployment, persistence, auth,
+  server, editor, and UI runtimes fail lint. CI also runs `turbo boundaries`
+  for the package so a relative import cannot escape its workspace boundary.
 - **`@softmaple/awareness`** (Biome) — wired in via the
   `style/noRestrictedImports` rule in `packages/awareness/biome.jsonc`.
-  Forbids EG-walker, block-model, binding-lexical, and editor frameworks
-  (including subpath imports).
+  Forbids EG-walker, block-model, binding-lexical, collab-protocol,
+  collab-runtime, and editor frameworks (including subpath imports).
 
 Subpath patterns (`@lexical/*/**`, `prosemirror-*/**`, `slate-*/**`)
 are spelled out explicitly in both configs because the glob `*` does
@@ -277,10 +333,11 @@ rather than `patterns`, so those are listed separately in
 right above the rule restating this gotcha for the next editor.
 
 A unit test in `packages/eslint-config` lints deliberately-bad imports
-against all three ESLint pattern sets and also asserts each intended
-downward import remains legal. The awareness Biome boundary test runs
-the real config against generated import fixtures, including bare and
-subpath forms.
+against every ESLint pattern set and also asserts each intended
+downward import remains legal. The same test applies each pattern set to its
+real package source tree. The awareness Biome boundary test runs the real
+config against generated import fixtures, including bare and subpath forms,
+and CI lints the awareness source tree with that config.
 
 If you need to add a new editor framework, extend the
 module-internal `EDITOR_FRAMEWORK_PATTERNS` constant inside

--- a/docs/design/collaboration-runtime.md
+++ b/docs/design/collaboration-runtime.md
@@ -1,0 +1,186 @@
+---
+title: Collaboration Runtime Contract
+description: Runtime-independent document room, session, durability, fan-out, and repair semantics.
+---
+
+# Collaboration Runtime Contract
+
+`@softmaple/collab-runtime` is the server-side semantic boundary between the
+versioned collaboration protocol and concrete hosting infrastructure. It lets
+the same room behavior be implemented on the current Nitro/Redis/Postgres
+stack and on a future runtime without importing either environment into the
+contract package.
+
+This phase defines contracts only. The production route in `apps/collab`
+continues to own the current behavior until it is migrated separately.
+
+## Capability boundary
+
+| Contract | Owns | Does not own |
+| --- | --- | --- |
+| `DocumentRoom` | Peer join/receive/leave/close state machine | WebSocket upgrade, raw JSON parsing, or convergence |
+| `RoomPeer` | Sending validated server messages and closing a transport peer | Identity or authorization state |
+| `DocumentSessionHooks` | Resolving and refreshing normalized access | Supabase/JWT implementation details |
+| `DocumentEventStore` | Atomic durable append and ordered repair pages | Prisma/Postgres implementation details |
+| `RoomFanout` | Committed document-event delivery across room instances | Presence or durable acknowledgement |
+| `ConnectionLimiter` | Per-document admission and renewable leases | Redis or Durable Object implementation details |
+
+The room consumes parsed `ClientCollabMessage` values and sends existing
+`ServerCollabMessage` values. `DocumentEventPage` is derived from
+`RepairResponseMessage`, so this layer cannot silently invent a second wire
+shape.
+
+## Ownership and lifecycle
+
+A `DocumentRoom` represents one document. Its peer set is local to one room
+instance; durable history, cross-instance fan-out, and global connection
+admission arrive through shared capabilities. Two server instances may own
+different local peer sets for the same document and communicate only through
+those capabilities.
+
+Document identity is exact and immutable. An Auth message must match
+`DocumentRoom.documentId` before the authorization hook runs. Sessions,
+event-store calls, and fan-out subscriptions use that same id, and a room must
+discard a fan-out event for any other document. This is the cross-document
+isolation boundary for path-routed rooms and Durable Objects alike.
+
+`join` registers a transport peer. Authentication resolves a normalized
+access record, and the room constructs the session using the validated
+document id, session id, and protocol version from the Auth message. After
+authentication, that session protocol version is authoritative for outbound
+messages; later messages do not renegotiate it.
+
+Authenticated sessions have an actor, role, and write flag. Public sessions
+are protocol v3 only, anonymous, and always read-only. Authorization refresh
+may update role/write access, but an access-mode or actor change revokes the
+session instead of silently changing its identity.
+
+Connection admission happens before `Ready`. A partially completed join must
+release every acquired subscription and lease. `leave` and `close` must be
+safe after partial setup and must release resources even when authorization
+has already been invalidated. A lost lease or revoked authorization closes the
+peer. Operations for one peer may arrive concurrently. The room synchronizes
+their state transitions so receive/leave/close races cannot create two
+sessions or leak partial resources, while an Auth observed during pending
+authentication is still rejected.
+
+The current compatibility policy is 100 physical connections per document, a
+45-second lease TTL, and 15-second lease/authorization refresh. A
+`DocumentRoomPolicy` supplies the connection values and authorization cadence;
+`DEFAULT_DOCUMENT_ROOM_POLICY` records this compatibility baseline. Duplicate
+admission refers to the server-generated physical peer id;
+the client session id is correlation metadata and may be reused on reconnect.
+
+| Peer state/input | Required outcome |
+| --- | --- |
+| Event or RepairRequest before Auth | Direct non-retryable `AuthenticationFailed`; no room mutation |
+| A second Auth, including while Auth is pending | Close 1008; never create a second session |
+| Auth denied (`authorize` returns `null`) | Non-retryable `AuthenticationFailed`, then close 1008 |
+| Auth provider unavailable (`authorize` throws) | Retryable `AuthenticationFailed`; clean partial resources |
+| Connection capacity or duplicate peer rejection | Retryable `Forbidden`, then close 1013 |
+| Authorization revoked or lease refresh returns false | Close 1008 and clean room resources |
+| Periodic authorization/lease provider failure | Close 1011 and clean room resources |
+
+Origin validation, raw message byte limits, JSON parsing, and other
+transport-measured policies remain host adapter responsibilities. Protocol
+validation remains in `@softmaple/collab-protocol`. The adapter preserves the
+current 256 KiB limit (close 1009), 120 messages per 10 seconds limit
+(`InvalidMessage`, retryable, then close 1013), and malformed-message behavior
+(`InvalidMessage`, non-retryable). Browser clients close on protocol Error and
+reconnect only when it is retryable.
+
+## Durable append and acknowledgement
+
+`DocumentEventStore.append(documentId, actorId, batches)` has these
+requirements:
+
+1. The complete ordered request is atomic.
+2. Appends for one document serialize across independent room/runtime
+   instances; a process-local lock is insufficient.
+3. Parent references may resolve to bootstrap, durable history, or an earlier
+   event in the same request, never to a later event.
+4. An exact `batchId` plus payload resend succeeds idempotently. Reusing an id
+   for a different payload is a conflict.
+5. Returned batch ids correspond to every input batch in input order and are
+   returned only after durable commit.
+6. The store rechecks write authorization inside the serialized durable
+   boundary for every append; room-level cached authorization is not a
+   substitute.
+
+Store adapters translate infrastructure-specific failures into the runtime
+taxonomy before they reach `DocumentRoom`:
+
+| Runtime error | Protocol error | Retryable |
+| --- | --- | --- |
+| `DocumentEventAuthorizationError` | `Forbidden` | No |
+| `DocumentEventConflictError` | `Conflict` | No |
+| `DocumentEventStoreUnavailableError` | `PersistenceFailed` | Yes |
+
+`DocumentEventConflictError.details.conflictType` uses the same four conflict
+categories defined in the consistency document. A repair read can reject only
+with `DocumentEventStoreUnavailableError`.
+
+For a client Event message, the room ordering is:
+
+```text
+validate session/write access
+        ↓
+atomic durable append
+        ↓
+DurableAck to the origin
+        ↓
+publish the committed batches through RoomFanout
+```
+
+An append failure produces neither acknowledgement nor fan-out. An
+acknowledgement means durable commit, not delivery to every replica. Fan-out
+is best-effort after commit: a publish failure does not roll back the write or
+invalidate the acknowledgement, and peers recover through repair. If the
+origin disconnects before receiving its acknowledgement, an exact resend is
+idempotent.
+
+Fan-out contains document Event batches only. `Ready`, `DurableAck`, repair
+responses, and errors are direct peer messages. Delivery includes the writer
+and may be duplicated, delayed, lost, or reordered across publishers;
+consumers deduplicate by batch id. A failed send to one local peer must not
+prevent delivery to the remaining peers. `RoomFanout.publish` owns loopback as
+well as cross-instance delivery; the room does not need a second local
+broadcast path.
+
+## Repair and resync
+
+Repair is client-requested durable history synchronization:
+
+- Start at cursor `"0"`. Every cursor is a non-negative decimal string.
+- Read batches strictly after `afterCursor` in ascending durable order.
+- Echo the request's `requestId` and return the page's `batches`,
+  `nextCursor`, and `complete` fields only to that peer.
+- Keep every page within `DOCUMENT_EVENT_PAGE_LIMIT` (currently 100 batches).
+- An empty page preserves its input cursor. Every non-empty page strictly
+  advances `nextCursor` to its final durable row. A page with
+  `complete: false` is therefore non-empty; `complete` means that page read
+  observed no later durable row.
+- Keep public read-only repair available.
+- Do not pause live fan-out while repair is active.
+
+Repair pages are not a frozen snapshot. A committed live Event can arrive
+before, after, or between pages and may duplicate a batch in a page. The
+client's batch-id deduplication makes every supported interleaving converge.
+The server does not maintain a hidden repair cursor or trigger blind repair on
+every conflict.
+
+On reconnect, the browser repairs to completion before it exact-resends its
+pending write. That one-in-flight queue is a client invariant that the room
+must remain compatible with; it is not server-owned session state.
+
+## Not a convergence layer
+
+`DocumentRoom` coordinates validated dispatch, authorization, durable
+persistence, acknowledgement, repair, fan-out, connection policy, and
+lifecycle. It never integrates rich-text operations or decides convergence.
+EG-walker and `@softmaple/block-model` remain the only convergence/model
+layers, and awareness remains an independent ephemeral channel.
+
+The conflict categories and retry behavior that every runtime must preserve
+are defined in
+[`collaboration-consistency.md`](./collaboration-consistency.md).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,6 +42,7 @@
         "pages": [
           "design/awareness-and-presence",
           "design/collaboration-layers",
+          "design/collaboration-runtime",
           "design/collaboration-consistency"
         ]
       },

--- a/packages/awareness/biome.jsonc
+++ b/packages/awareness/biome.jsonc
@@ -55,7 +55,7 @@
         // `patterns.group` silently does not match
         // `import "@softmaple/eg-walker"`. Globs
         // (`@softmaple/eg-walker/**`, `@softmaple/block-model/**`,
-        // `@lexical/*`, etc.) stay in
+        // `@softmaple/collab-runtime/**`, `@lexical/*`, etc.) stay in
         // `patterns`. Keep this in sync with the matching ESLint rule
         // in `packages/eslint-config/collaboration-layers.js`; the
         // regression test in `test/biome-boundary.test.ts` will fail
@@ -68,6 +68,7 @@
               "@softmaple/block-model": "Cross-layer import: see docs/design/collaboration-layers.md. Awareness must not depend on a convergent document model.",
               "@softmaple/binding-lexical": "Reverse-layer import: see docs/design/collaboration-layers.md. Awareness must not depend on a surface binding.",
               "@softmaple/collab-protocol": "Cross-layer import: see docs/design/collaboration-layers.md. Awareness must not depend on the application wire protocol.",
+              "@softmaple/collab-runtime": "Cross-layer import: see docs/design/collaboration-layers.md. Awareness must not depend on host-level room semantics.",
               "lexical": "Editor-framework import: see docs/design/collaboration-layers.md. Awareness is surface-agnostic; Lexical integration belongs in @softmaple/binding-lexical.",
               "slate": "Editor-framework import: see docs/design/collaboration-layers.md. Awareness is surface-agnostic; Slate integration belongs in a binding package or app staging."
             },
@@ -87,6 +88,10 @@
               {
                 "group": ["@softmaple/collab-protocol/**"],
                 "message": "Cross-layer import: see docs/design/collaboration-layers.md. Awareness must not depend on the application wire protocol."
+              },
+              {
+                "group": ["@softmaple/collab-runtime/**"],
+                "message": "Cross-layer import: see docs/design/collaboration-layers.md. Awareness must not depend on host-level room semantics."
               },
               {
                 "group": ["lexical/**", "@lexical/*", "@lexical/*/**"],

--- a/packages/awareness/test/biome-boundary.test.ts
+++ b/packages/awareness/test/biome-boundary.test.ts
@@ -133,6 +133,8 @@ describe("biome collaboration-layers boundary", () => {
     "@softmaple/binding-lexical/react",
     "@softmaple/collab-protocol",
     "@softmaple/collab-protocol/internal",
+    "@softmaple/collab-runtime",
+    "@softmaple/collab-runtime/internal",
     "lexical",
     "lexical/LexicalEditor",
     "@lexical/react",

--- a/packages/collab-runtime/README.md
+++ b/packages/collab-runtime/README.md
@@ -1,0 +1,30 @@
+# `@softmaple/collab-runtime`
+
+Runtime-independent contracts for hosted document collaboration. The package
+owns room and session semantics while leaving every infrastructure choice to a
+host adapter.
+
+The public capabilities cover:
+
+- `DocumentRoom` and transport-neutral `RoomPeer` lifecycle
+- normalized authenticated and public document sessions
+- durable event append and repair-page reads
+- committed-event fan-out across room instances
+- per-document connection admission and renewable leases
+- runtime-neutral authorization, conflict, and store-unavailable failures
+
+A `DocumentRoom` implementation must preserve the collaboration consistency
+baseline: append before `DurableAck`, acknowledge before fan-out, never fan out
+a failed append, keep repair compatible with interleaved live events, and rely
+on the block model/EG-walker stack for convergence rather than implementing a
+second CRDT.
+
+Every capability call remains scoped to the room's immutable document id.
+Repair cursors retain the existing non-negative decimal wire format, and store
+adapters translate infrastructure errors into the exported runtime error
+taxonomy before room logic maps them to protocol errors.
+
+This package deliberately contains no Nitro, Redis, Prisma, Supabase,
+Cloudflare Workers, editor-framework, React, routing, or UI integrations. The
+current production host is not wired to these contracts yet; that migration is
+a separate phase.

--- a/packages/collab-runtime/eslint.config.js
+++ b/packages/collab-runtime/eslint.config.js
@@ -1,0 +1,15 @@
+import { config } from "@softmaple/eslint-config/base";
+import { collabRuntimeCollaborationPatterns } from "@softmaple/eslint-config/collaboration-layers";
+
+export default [
+  ...config,
+  {
+    files: ["src/**/*.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        { patterns: collabRuntimeCollaborationPatterns },
+      ],
+    },
+  },
+];

--- a/packages/collab-runtime/package.json
+++ b/packages/collab-runtime/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@softmaple/collab-runtime",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Runtime-independent document room and session contracts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint . --max-warnings=0",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@softmaple/collab-protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "@softmaple/eslint-config": "workspace:*",
+    "@softmaple/typescript-config": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/collab-runtime/src/connection-limiter.ts
+++ b/packages/collab-runtime/src/connection-limiter.ts
@@ -1,0 +1,48 @@
+export const CONNECTION_REJECTION_REASON = {
+  Capacity: "capacity",
+  Duplicate: "duplicate",
+} as const;
+
+export type ConnectionRejectionReason =
+  (typeof CONNECTION_REJECTION_REASON)[keyof typeof CONNECTION_REJECTION_REASON];
+
+export interface ConnectionAdmissionRequest {
+  readonly documentId: string;
+  /** Stable server-side identity for this physical connection. */
+  readonly peerId: string;
+  readonly policy: ConnectionPolicy;
+  /** Client correlation only; reconnects may reuse a session id. */
+  readonly sessionId: string;
+}
+
+export interface ConnectionPolicy {
+  /** All values are positive; refresh must be shorter than the lease TTL. */
+  readonly leaseRefreshIntervalMs: number;
+  readonly leaseTtlMs: number;
+  readonly maxConnectionsPerDocument: number;
+}
+
+/**
+ * A runtime-owned permit that supports expiring distributed leases. A false
+ * refresh means the permit is no longer held; release must be idempotent.
+ */
+export interface ConnectionLease {
+  refresh(): Promise<boolean>;
+  release(): Promise<void>;
+}
+
+export type ConnectionAdmission =
+  | {
+      readonly accepted: true;
+      readonly lease: ConnectionLease;
+    }
+  | {
+      readonly accepted: false;
+      /** Duplicate refers to peerId, never to the reconnectable sessionId. */
+      readonly reason: ConnectionRejectionReason;
+    };
+
+/** Applies per-document connection policy without exposing its backend. */
+export interface ConnectionLimiter {
+  acquire(request: ConnectionAdmissionRequest): Promise<ConnectionAdmission>;
+}

--- a/packages/collab-runtime/src/document-room.ts
+++ b/packages/collab-runtime/src/document-room.ts
@@ -1,0 +1,74 @@
+import type {
+  ClientCollabMessage,
+  ServerCollabMessage,
+} from "@softmaple/collab-protocol";
+import type { ConnectionLimiter, ConnectionPolicy } from "./connection-limiter";
+import type { DocumentSessionHooks } from "./document-session";
+import type { DocumentEventStore } from "./event-store";
+import type { RoomFanout } from "./room-fanout";
+
+/** Transport adapter presented to runtime-independent room semantics. */
+export interface RoomPeer {
+  readonly id: string;
+  close(code: number, reason: string): void | Promise<void>;
+  send(message: ServerCollabMessage): void | Promise<void>;
+}
+
+export const ROOM_LEAVE_REASON = {
+  AccessRevoked: "access-revoked",
+  ConnectionClosed: "connection-closed",
+  RuntimeShutdown: "runtime-shutdown",
+} as const;
+
+export type RoomLeaveReason =
+  (typeof ROOM_LEAVE_REASON)[keyof typeof ROOM_LEAVE_REASON];
+
+export interface DocumentRoomPolicy {
+  /** Positive cadence for revalidating cached document access. */
+  readonly authorizationRefreshIntervalMs: number;
+  readonly connection: ConnectionPolicy;
+}
+
+export const DEFAULT_DOCUMENT_ROOM_POLICY: DocumentRoomPolicy = Object.freeze({
+  authorizationRefreshIntervalMs: 15_000,
+  connection: Object.freeze({
+    leaseRefreshIntervalMs: 15_000,
+    leaseTtlMs: 45_000,
+    maxConnectionsPerDocument: 100,
+  }),
+});
+
+/** Infrastructure capabilities consumed by room/session semantics. */
+export interface DocumentRoomServices {
+  readonly connections: ConnectionLimiter;
+  readonly events: DocumentEventStore;
+  readonly fanout: RoomFanout;
+  readonly policy: DocumentRoomPolicy;
+  readonly sessions: DocumentSessionHooks;
+}
+
+/**
+ * Runtime-independent collaboration state-machine boundary for one document.
+ *
+ * Implementations receive already-parsed protocol messages. For Event
+ * messages they must append durably, send DurableAck, and only then fan out
+ * the committed batches. A failed append must never be acknowledged or
+ * published. RepairRequest messages are served from durable event pages and
+ * may interleave with committed live events; clients deduplicate by batch id.
+ * Leave and close must tolerate partial setup and release room subscriptions,
+ * sessions, and connection leases idempotently. Calls that affect the same
+ * peer may arrive concurrently; the room synchronizes their state transitions
+ * so receive/leave races cannot create duplicate sessions or leak resources.
+ *
+ * An Auth message is rejected before authorization unless its document id
+ * exactly matches this room. Every session, event-store call, and fan-out
+ * delivery remains scoped to the same document id; cross-document fan-out is
+ * never delivered.
+ */
+export interface DocumentRoom {
+  readonly documentId: string;
+  join(peer: RoomPeer): Promise<void>;
+  receive(peer: RoomPeer, message: ClientCollabMessage): Promise<void>;
+  leave(peer: RoomPeer, reason?: RoomLeaveReason): Promise<void>;
+  close(): Promise<void>;
+}

--- a/packages/collab-runtime/src/document-session.ts
+++ b/packages/collab-runtime/src/document-session.ts
@@ -1,0 +1,91 @@
+import {
+  COLLAB_ACCESS_MODE,
+  COLLAB_PROTOCOL_VERSION,
+  type CollabCredential,
+  type CollabRole,
+  type SupportedCollabProtocolVersion,
+} from "@softmaple/collab-protocol";
+
+/** Normalized authenticated access, including read-only viewer access. */
+export interface AuthenticatedDocumentAccess {
+  readonly accessMode: typeof COLLAB_ACCESS_MODE.Authenticated;
+  readonly actorId: string;
+  readonly canWrite: boolean;
+  readonly role: CollabRole;
+}
+
+/** Public access is deliberately anonymous and read-only. */
+export interface PublicDocumentAccess {
+  readonly accessMode: typeof COLLAB_ACCESS_MODE.Public;
+  readonly actorId: null;
+  readonly canWrite: false;
+  readonly role: null;
+}
+
+export type DocumentAccess = AuthenticatedDocumentAccess | PublicDocumentAccess;
+
+interface DocumentSessionBase {
+  readonly documentId: string;
+  readonly sessionId: string;
+}
+
+export interface AuthenticatedDocumentSession
+  extends AuthenticatedDocumentAccess,
+    DocumentSessionBase {
+  readonly protocolVersion: SupportedCollabProtocolVersion;
+}
+
+/** Legacy protocol clients cannot represent public sessions. */
+export interface PublicDocumentSession
+  extends PublicDocumentAccess,
+    DocumentSessionBase {
+  readonly protocolVersion: typeof COLLAB_PROTOCOL_VERSION;
+}
+
+export type DocumentSession =
+  | AuthenticatedDocumentSession
+  | PublicDocumentSession;
+
+export interface DocumentSessionAuthorizationRequest {
+  readonly credential: CollabCredential;
+  readonly documentId: string;
+  readonly peerId: string;
+  readonly protocolVersion: SupportedCollabProtocolVersion;
+  readonly sessionId: string;
+}
+
+export interface DocumentSessionRefreshRequest {
+  readonly credential: CollabCredential;
+  readonly peerId: string;
+  readonly session: DocumentSession;
+}
+
+export const DOCUMENT_SESSION_END_REASON = {
+  AccessRevoked: "access-revoked",
+  PeerLeft: "peer-left",
+  RoomClosed: "room-closed",
+} as const;
+
+export type DocumentSessionEndReason =
+  (typeof DOCUMENT_SESSION_END_REASON)[keyof typeof DOCUMENT_SESSION_END_REASON];
+
+/**
+ * Host-provided identity hooks. Implementations may use any auth provider, but
+ * room semantics only consume the normalized access returned here. Refresh
+ * may change role/write access; changing access mode or actor revokes the
+ * existing session.
+ */
+export interface DocumentSessionHooks {
+  /** Returns null for denied access; throws when the provider is unavailable. */
+  authorize(
+    request: DocumentSessionAuthorizationRequest,
+  ): Promise<DocumentAccess | null>;
+  /** Returns null for revoked access; throws when the provider is unavailable. */
+  refresh(
+    request: DocumentSessionRefreshRequest,
+  ): Promise<DocumentAccess | null>;
+  end?(
+    session: DocumentSession,
+    reason: DocumentSessionEndReason,
+  ): Promise<void>;
+}

--- a/packages/collab-runtime/src/event-store.ts
+++ b/packages/collab-runtime/src/event-store.ts
@@ -1,0 +1,113 @@
+import type {
+  ClientEventMessage,
+  RepairRequestMessage,
+  RepairResponseMessage,
+} from "@softmaple/collab-protocol";
+
+/** Reuses the protocol's validated block-model batch shape. */
+export type DocumentEventBatches = ClientEventMessage["batches"];
+
+/** A non-negative decimal string; the initial durable-history cursor is `0`. */
+export type DocumentEventCursor = RepairRequestMessage["afterCursor"];
+
+export const INITIAL_DOCUMENT_EVENT_CURSOR: DocumentEventCursor = "0";
+export const DOCUMENT_EVENT_PAGE_LIMIT = 100 as const;
+
+/**
+ * Durable history page before request identifiers and protocol metadata are
+ * added to a wire-level RepairResponse message. Reads are exclusive of the
+ * input cursor and ordered monotonically, with no more than
+ * DOCUMENT_EVENT_PAGE_LIMIT batches. An empty page preserves the input
+ * cursor; every non-empty page advances it to that page's final durable row.
+ * `complete` means no later durable row was observed by that page read.
+ */
+export type DocumentEventPage = Pick<
+  RepairResponseMessage,
+  "batches" | "complete" | "nextCursor"
+>;
+
+export const DOCUMENT_EVENT_CONFLICT_TYPE = {
+  BatchPayloadConflict: "batch-payload-conflict",
+  DuplicateIncomingEventId: "duplicate-incoming-event-id",
+  MissingParentHistory: "missing-parent-history",
+  StoredEventIdConflict: "stored-event-id-conflict",
+} as const;
+
+export type DocumentEventConflictType =
+  (typeof DOCUMENT_EVENT_CONFLICT_TYPE)[keyof typeof DOCUMENT_EVENT_CONFLICT_TYPE];
+
+export interface DocumentEventConflictDetails {
+  readonly batchIds?: ReadonlyArray<string>;
+  readonly conflictType: DocumentEventConflictType;
+  readonly documentId: string;
+  readonly eventIds?: ReadonlyArray<string>;
+  readonly missingParentIds?: ReadonlyArray<string>;
+}
+
+export const DOCUMENT_EVENT_STORE_ERROR_KIND = {
+  Authorization: "authorization",
+  Conflict: "conflict",
+  Unavailable: "unavailable",
+} as const;
+
+export class DocumentEventAuthorizationError extends Error {
+  readonly kind = DOCUMENT_EVENT_STORE_ERROR_KIND.Authorization;
+  readonly retryable = false;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "DocumentEventAuthorizationError";
+  }
+}
+
+export class DocumentEventConflictError extends Error {
+  readonly details: DocumentEventConflictDetails;
+  readonly kind = DOCUMENT_EVENT_STORE_ERROR_KIND.Conflict;
+  readonly retryable = false;
+
+  constructor(message: string, details: DocumentEventConflictDetails) {
+    super(message);
+    this.name = "DocumentEventConflictError";
+    this.details = details;
+  }
+}
+
+export class DocumentEventStoreUnavailableError extends Error {
+  readonly kind = DOCUMENT_EVENT_STORE_ERROR_KIND.Unavailable;
+  readonly retryable = true;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "DocumentEventStoreUnavailableError";
+  }
+}
+
+export type DocumentEventStoreError =
+  | DocumentEventAuthorizationError
+  | DocumentEventConflictError
+  | DocumentEventStoreUnavailableError;
+
+/**
+ * Durable event-log capability used by a DocumentRoom implementation.
+ *
+ * Each append is atomic, same-document appends serialize across room/runtime
+ * instances, and exact batch resends are idempotent. The returned ids must
+ * correspond to every input batch in input order, and append must not resolve
+ * until all of them are durable. The store must recheck actor write access
+ * inside that serialized durable boundary.
+ *
+ * Append rejects only with DocumentEventAuthorizationError,
+ * DocumentEventConflictError, or DocumentEventStoreUnavailableError. Read
+ * rejects with DocumentEventStoreUnavailableError.
+ */
+export interface DocumentEventStore {
+  append(
+    documentId: string,
+    actorId: string,
+    batches: DocumentEventBatches,
+  ): Promise<ReadonlyArray<string>>;
+  read(
+    documentId: string,
+    afterCursor: DocumentEventCursor,
+  ): Promise<DocumentEventPage>;
+}

--- a/packages/collab-runtime/src/index.ts
+++ b/packages/collab-runtime/src/index.ts
@@ -1,0 +1,53 @@
+export {
+  CONNECTION_REJECTION_REASON,
+  type ConnectionAdmission,
+  type ConnectionAdmissionRequest,
+  type ConnectionLease,
+  type ConnectionLimiter,
+  type ConnectionPolicy,
+  type ConnectionRejectionReason,
+} from "./connection-limiter";
+export {
+  DEFAULT_DOCUMENT_ROOM_POLICY,
+  type DocumentRoom,
+  type DocumentRoomPolicy,
+  type DocumentRoomServices,
+  ROOM_LEAVE_REASON,
+  type RoomLeaveReason,
+  type RoomPeer,
+} from "./document-room";
+export {
+  DOCUMENT_SESSION_END_REASON,
+  type AuthenticatedDocumentAccess,
+  type AuthenticatedDocumentSession,
+  type DocumentAccess,
+  type DocumentSession,
+  type DocumentSessionAuthorizationRequest,
+  type DocumentSessionEndReason,
+  type DocumentSessionHooks,
+  type DocumentSessionRefreshRequest,
+  type PublicDocumentSession,
+  type PublicDocumentAccess,
+} from "./document-session";
+export {
+  DOCUMENT_EVENT_CONFLICT_TYPE,
+  DOCUMENT_EVENT_PAGE_LIMIT,
+  DOCUMENT_EVENT_STORE_ERROR_KIND,
+  DocumentEventAuthorizationError,
+  type DocumentEventBatches,
+  type DocumentEventConflictDetails,
+  DocumentEventConflictError,
+  type DocumentEventConflictType,
+  type DocumentEventCursor,
+  type DocumentEventPage,
+  type DocumentEventStore,
+  type DocumentEventStoreError,
+  DocumentEventStoreUnavailableError,
+  INITIAL_DOCUMENT_EVENT_CURSOR,
+} from "./event-store";
+export {
+  type CommittedDocumentEvent,
+  type RoomFanout,
+  type RoomFanoutHandler,
+  type RoomFanoutSubscription,
+} from "./room-fanout";

--- a/packages/collab-runtime/src/room-fanout.ts
+++ b/packages/collab-runtime/src/room-fanout.ts
@@ -1,0 +1,31 @@
+import type { DocumentEventBatches } from "./event-store";
+
+/** A notification that may only be created after the batches are durable. */
+export interface CommittedDocumentEvent {
+  readonly batches: DocumentEventBatches;
+  readonly documentId: string;
+}
+
+export type RoomFanoutHandler = (
+  event: CommittedDocumentEvent,
+) => void | Promise<void>;
+
+export interface RoomFanoutSubscription {
+  /** Releases this subscription; repeated calls must be safe. */
+  unsubscribe(): Promise<void>;
+}
+
+/**
+ * Cross-room-instance committed-event delivery. Presence and connection
+ * leases are intentionally outside this channel. Publish must make the event
+ * observable to matching same-instance and remote subscriptions, including
+ * the publisher's own room. A subscriber must discard an event whose
+ * documentId does not match its subscription.
+ */
+export interface RoomFanout {
+  publish(event: CommittedDocumentEvent): Promise<void>;
+  subscribe(
+    documentId: string,
+    handler: RoomFanoutHandler,
+  ): Promise<RoomFanoutSubscription>;
+}

--- a/packages/collab-runtime/tsconfig.json
+++ b/packages/collab-runtime/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/collab-runtime/tsup.config.ts
+++ b/packages/collab-runtime/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+});

--- a/packages/eslint-config/__tests__/collaboration-layers.test.js
+++ b/packages/eslint-config/__tests__/collaboration-layers.test.js
@@ -1,12 +1,17 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { Linter } from "eslint";
+import typescriptParser from "@typescript-eslint/parser";
 
 import {
   blockModelBindingCollaborationPatterns,
   blockModelCollaborationPatterns,
   collabProtocolCollaborationPatterns,
+  collabRuntimeCollaborationPatterns,
   egWalkerCollaborationConfig,
   egWalkerCollaborationPatterns,
 } from "../collaboration-layers.js";
@@ -18,17 +23,24 @@ import {
  *
  * @param {Array<object>} patterns
  * @param {string} code
+ * @param {string} [filename]
  * @returns {ReturnType<Linter["verify"]>}
  */
-function lintWithPatterns(patterns, code) {
+function lintWithPatterns(patterns, code, filename = "fixture.ts") {
   const linter = new Linter();
-  return linter.verify(code, [
-    {
-      rules: {
-        "no-restricted-imports": ["error", { patterns }],
+  return linter.verify(
+    code,
+    [
+      {
+        files: ["**/*.ts", "**/*.tsx"],
+        languageOptions: { parser: typescriptParser },
+        rules: {
+          "no-restricted-imports": ["error", { patterns }],
+        },
       },
-    },
-  ]);
+    ],
+    { filename },
+  );
 }
 
 /**
@@ -47,6 +59,43 @@ function lintWithConfig(flatConfig, code, relativeFilename) {
 
 function findRestrictedImportMessages(messages) {
   return messages.filter((m) => m.ruleId === "no-restricted-imports");
+}
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function typescriptFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return typescriptFiles(path);
+    return [".ts", ".tsx"].includes(extname(entry.name)) ? [path] : [];
+  });
+}
+
+function assertSourceTreeConforms(relativeDirectory, patterns) {
+  const directory = resolve(REPO_ROOT, relativeDirectory);
+  for (const filename of typescriptFiles(directory)) {
+    const messages = lintWithPatterns(
+      patterns,
+      readFileSync(filename, "utf8"),
+      filename,
+    );
+    const fatal = messages.filter((message) => message.fatal);
+    assert.equal(
+      fatal.length,
+      0,
+      `${relative(REPO_ROOT, filename)} could not be parsed:\n${fatal
+        .map((message) => message.message)
+        .join("\n")}`,
+    );
+    const restricted = findRestrictedImportMessages(messages);
+    assert.equal(
+      restricted.length,
+      0,
+      `${relative(REPO_ROOT, filename)} violates collaboration layering:\n${restricted
+        .map((message) => message.message)
+        .join("\n")}`,
+    );
+  }
 }
 
 test("eg-walker patterns forbid importing @softmaple/awareness", () => {
@@ -78,6 +127,8 @@ test("eg-walker patterns forbid reverse imports from block models and bindings",
     "@softmaple/binding-lexical",
     "@softmaple/binding-lexical/react",
     "@softmaple/collab-protocol",
+    "@softmaple/collab-runtime",
+    "@softmaple/collab-runtime/internal/contracts",
   ]) {
     const messages = lintWithPatterns(
       egWalkerCollaborationPatterns,
@@ -168,6 +219,7 @@ test("block-model patterns allow EG-walker but forbid awareness, bindings, and e
     "@softmaple/binding-lexical",
     "@softmaple/binding-lexical/react",
     "@softmaple/collab-protocol",
+    "@softmaple/collab-runtime",
     "lexical",
     "@lexical/react/LexicalComposer",
   ]) {
@@ -195,6 +247,7 @@ test("block-model binding patterns prevent bypassing the model API", () => {
     "@softmaple/eg-walker",
     "@softmaple/eg-walker/anchors",
     "@softmaple/collab-protocol",
+    "@softmaple/collab-runtime",
   ]) {
     const messages = lintWithPatterns(
       blockModelBindingCollaborationPatterns,
@@ -214,6 +267,7 @@ test("collab-protocol allows block-model but forbids host and higher layers", ()
     "@softmaple/awareness",
     "@softmaple/eg-walker",
     "@softmaple/binding-lexical",
+    "@softmaple/collab-runtime",
     "@softmaple/db",
     "@prisma/adapter-pg",
     "@prisma/client",
@@ -239,4 +293,55 @@ test("collab-protocol allows block-model but forbids host and higher layers", ()
     'import { parseRichTextEventBatch } from "@softmaple/block-model";\n',
   );
   assert.equal(findRestrictedImportMessages(allowed).length, 0);
+});
+
+test("collab-runtime allows protocol contracts but forbids host infrastructure", () => {
+  for (const specifier of [
+    "@softmaple/awareness",
+    "@softmaple/eg-walker",
+    "@softmaple/binding-lexical",
+    "@softmaple/db",
+    "@softmaple/editor",
+    "@softmaple/ui",
+    "@cloudflare/workers-types",
+    "@prisma/client",
+    "@supabase/supabase-js",
+    "cloudflare:workers",
+    "h3",
+    "ioredis",
+    "next/server",
+    "nitro",
+    "node:crypto",
+    "prisma",
+    "react",
+    "lexical",
+    "lodash",
+  ]) {
+    const messages = lintWithPatterns(
+      collabRuntimeCollaborationPatterns,
+      `import x from "${specifier}";\n`,
+    );
+    assert.equal(
+      findRestrictedImportMessages(messages).length,
+      1,
+      `expected ${specifier} to be restricted`,
+    );
+  }
+  const allowed = lintWithPatterns(
+    collabRuntimeCollaborationPatterns,
+    'import type { ClientCollabMessage } from "@softmaple/collab-protocol";\nimport type { RichTextEventBatch } from "@softmaple/block-model";\nimport type { Local } from "./local";\nimport type { Parent } from "../parent";\n',
+  );
+  assert.equal(findRestrictedImportMessages(allowed).length, 0);
+});
+
+test("collaboration package source trees obey their dependency direction", () => {
+  for (const [directory, patterns] of [
+    ["packages/eg-walker/src", egWalkerCollaborationPatterns],
+    ["packages/block-model/src", blockModelCollaborationPatterns],
+    ["packages/binding-lexical/src", blockModelBindingCollaborationPatterns],
+    ["packages/collab-protocol/src", collabProtocolCollaborationPatterns],
+    ["packages/collab-runtime/src", collabRuntimeCollaborationPatterns],
+  ]) {
+    assertSourceTreeConforms(directory, patterns);
+  }
 });

--- a/packages/eslint-config/collaboration-layers.js
+++ b/packages/eslint-config/collaboration-layers.js
@@ -12,6 +12,8 @@
  *   MUST NOT bypass the block model to import EG-walker directly.
  * - `@softmaple/collab-protocol` may import the block model, but MUST NOT
  *   depend on a binding, awareness, editor framework, or host runtime.
+ * - `@softmaple/collab-runtime` may import protocol/model value contracts, but
+ *   MUST NOT depend on convergence internals, UI, or a concrete host runtime.
  * - `@softmaple/awareness` MUST NOT import a document model, surface binding,
  *   or editor framework. Awareness enforces this via Biome's
  *   `style/noRestrictedImports` in `packages/awareness/biome.jsonc`.
@@ -69,26 +71,61 @@ const COLLAB_PROTOCOL_PATTERNS = [
   },
 ];
 
+const COLLAB_RUNTIME_PATTERNS = [
+  {
+    group: ["@softmaple/collab-runtime", "@softmaple/collab-runtime/**"],
+    message:
+      "Reverse-layer import: see docs/design/collaboration-layers.md. " +
+      "Model, awareness, binding, and wire-protocol packages must not " +
+      "depend on host-level room semantics.",
+  },
+];
+
 const HOST_RUNTIME_PATTERNS = [
   {
     group: [
       "@softmaple/db",
       "@softmaple/db/*",
+      "@softmaple/editor",
+      "@softmaple/editor/*",
+      "@softmaple/ui",
+      "@softmaple/ui/*",
+      "@cloudflare/*",
+      "@cloudflare/*/**",
       "@prisma/*",
       "@prisma/*/**",
       "@supabase/*",
       "@supabase/*/**",
+      "cloudflare:*",
+      "h3",
+      "h3/**",
+      "ioredis",
+      "ioredis/**",
       "next",
       "next/**",
       "nitro",
       "nitro/**",
+      "prisma",
+      "prisma/**",
       "react",
       "react/**",
     ],
     message:
       "Host-runtime import: see docs/design/collaboration-layers.md. " +
-      "The collaboration protocol contains only wire contracts and parsers; " +
-      "database, auth, server, and UI integrations belong in apps/*.",
+      "Shared collaboration contracts contain no database, auth SDK, " +
+      "server framework, deployment-runtime, or UI integrations; those " +
+      "belong in apps/* adapters.",
+  },
+];
+
+const COLLAB_RUNTIME_IMPORT_ALLOWLIST = [
+  {
+    regex:
+      "^(?!(?:\\.{1,2}/|@softmaple/(?:block-model|collab-protocol)(?:/|$))).+",
+    message:
+      "Runtime boundary: see docs/design/collaboration-layers.md. " +
+      "@softmaple/collab-runtime may import only local modules, " +
+      "@softmaple/collab-protocol, and @softmaple/block-model.",
   },
 ];
 
@@ -138,6 +175,7 @@ export const egWalkerCollaborationPatterns = [
   ...BLOCK_MODEL_PATTERNS,
   ...SURFACE_BINDING_PATTERNS,
   ...COLLAB_PROTOCOL_PATTERNS,
+  ...COLLAB_RUNTIME_PATTERNS,
   ...EDITOR_FRAMEWORK_PATTERNS,
 ];
 
@@ -149,6 +187,7 @@ export const blockModelCollaborationPatterns = [
   ...AWARENESS_PATTERNS,
   ...SURFACE_BINDING_PATTERNS,
   ...COLLAB_PROTOCOL_PATTERNS,
+  ...COLLAB_RUNTIME_PATTERNS,
   ...EDITOR_FRAMEWORK_PATTERNS,
 ];
 
@@ -160,6 +199,7 @@ export const blockModelBindingCollaborationPatterns = [
   ...AWARENESS_PATTERNS,
   ...EG_WALKER_PATTERNS,
   ...COLLAB_PROTOCOL_PATTERNS,
+  ...COLLAB_RUNTIME_PATTERNS,
 ];
 
 /**
@@ -170,8 +210,18 @@ export const collabProtocolCollaborationPatterns = [
   ...AWARENESS_PATTERNS,
   ...EG_WALKER_PATTERNS,
   ...SURFACE_BINDING_PATTERNS,
+  ...COLLAB_RUNTIME_PATTERNS,
   ...EDITOR_FRAMEWORK_PATTERNS,
   ...HOST_RUNTIME_PATTERNS,
+];
+
+/**
+ * Patterns for host-level collaboration room/session contracts. The wire
+ * protocol is intentionally allowed; concrete persistence, transport,
+ * deployment, editor, and UI runtimes are not.
+ */
+export const collabRuntimeCollaborationPatterns = [
+  ...COLLAB_RUNTIME_IMPORT_ALLOWLIST,
 ];
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,25 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@types/node@24.10.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.1(@types/node@24.10.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.10)(yaml@2.8.1))
 
+  packages/collab-runtime:
+    dependencies:
+      '@softmaple/collab-protocol':
+        specifier: workspace:*
+        version: link:../collab-protocol
+    devDependencies:
+      '@softmaple/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@softmaple/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@24.10.4))(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.10)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/config:
     devDependencies:
       '@softmaple/eslint-config':


### PR DESCRIPTION
## Summary
- Introduce `@softmaple/collab-runtime` with infrastructure-agnostic contracts for `DocumentRoom`, sessions, event store, fan-out, and connection limiting (Phase 2 of the collab host refactor).
- Document room semantics and enforce dependency boundaries via ESLint collaboration-layer rules, Biome restrictions, and CI.
- No production host behavior or browser protocol changes; Nitro migration remains a follow-up phase.

Closes #869

## Test plan
- [ ] `pnpm --filter @softmaple/collab-runtime typecheck`
- [ ] `pnpm --filter @softmaple/collab-runtime lint`
- [ ] `pnpm --filter @softmaple/eslint-config test` (or the collaboration-layers boundary tests)
- [ ] Confirm CI package matrix includes `collab-runtime`
- [ ] Spot-check that `apps/collab` is unchanged and still owns current runtime behavior


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runtime-independent collaboration layer supporting document rooms, sessions, authorization, connection limits, event storage, and event fan-out.
  * Introduced standardized handling for acknowledgements, repairs, resynchronization, access changes, and connection failures.

* **Documentation**
  * Added comprehensive collaboration runtime design documentation and navigation.
  * Clarified architecture boundaries and current production rollout status.

* **Tests**
  * Expanded automated checks for collaboration package boundaries, type safety, linting, and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->