### PR TITLE
feat(apps/collab-cloudflare): add hibernatable WebSocket support to DocumentRoomDO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ Turborepo monorepo with `apps/web/` (Next.js 16), `packages/` (shared code), and
 
 - **Formatting:** 2-space indent, double quotes, semicolons (Biome)
 - **Components:** PascalCase filenames
-- **Utilities:** camelCase filenames
+- **Utilities:** camelCase filenames; kebab-case is also fine for multi-word
+  modules when that matches the local package convention (e.g. `apps/collab-cloudflare`)
 - **Routes:** lowercase-hyphenated
 - **Linting:** ESLint configs in `packages/eslint-config/`
 - Husky pre-commit hooks auto-format staged files

--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -17,9 +17,10 @@ object; there is no Cloudflare-specific wire format.
 
 `DocumentRoomDO` accepts its server sockets with the Durable Objects WebSocket
 Hibernation API. Each socket has a versioned attachment containing its stable
-peer and session identity, protocol/access metadata, reauthorization
-credential, and message quota. After constructor re-entry, the object restores
-all attached sockets before processing the wake-up message and revalidates each
+peer and session identity, protocol/access metadata, the caller's access token
+as the reauthorization credential (retained for the connection's lifetime), and
+message quota. After constructor re-entry, the object restores all attached
+sockets before processing the wake-up message and revalidates each
 authenticated session without sending another protocol `Ready` message. The
 runtime uses message-driven authorization and lease maintenance in this host,
 so no room timer prevents an idle object from hibernating.

--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -1,6 +1,7 @@
 # Cloudflare collaboration PoC
 
-This app is the issue #871 proof of concept. It leaves `apps/collab` and its
+This app started as the issue #871 proof of concept and now includes the
+hibernatable room lifecycle from issue #872. It leaves `apps/collab` and its
 Nitro/Redis deployment unchanged while hosting the same
 `@softmaple/collab-runtime` `DocumentRoom` semantics in Cloudflare Durable
 Objects.
@@ -14,12 +15,32 @@ connection for that document is therefore coordinated by one `DocumentRoomDO`.
 The Worker proxies the unchanged `@softmaple/collab-protocol` messages into the
 object; there is no Cloudflare-specific wire format.
 
+`DocumentRoomDO` accepts its server sockets with the Durable Objects WebSocket
+Hibernation API. Each socket has a versioned attachment containing its stable
+peer and session identity, protocol/access metadata, reauthorization
+credential, and message quota. After constructor re-entry, the object restores
+all attached sockets before processing the wake-up message and revalidates each
+authenticated session without sending another protocol `Ready` message. The
+runtime uses message-driven authorization and lease maintenance in this host,
+so no room timer prevents an idle object from hibernating.
+Expired peers are revalidated on room activity; if a persistence operation
+crosses a validation deadline, repair responses are checked again and expired
+fan-out recipients are closed so the existing reconnect-and-repair flow cannot
+silently miss a durable batch. A completely idle revoked socket may remain
+physically open until the next room wake-up, but it cannot receive data past
+its cached validation deadline.
+
 The Durable Object owns only live peer coordination, fan-out, and connection
 limits. Durable event append/repair goes through Supabase RPCs backed by the
 existing `document_event_batches` and `document_event_ids` Postgres tables.
 The RPC migration uses the same per-document transaction advisory lock as the
 Nitro host. No Redis dependency is needed for fan-out inside a single object,
 and Durable Object SQLite is not used as event history.
+
+A constructor wake revalidates every attached session against Supabase. The
+default 100-connection room policy therefore assumes a Workers plan with an
+external-subrequest budget large enough for full-room recovery; a lower-budget
+deployment must lower that policy or add batched reauthorization first.
 
 ## Local setup
 
@@ -52,6 +73,8 @@ pnpm --filter @softmaple/collab-cloudflare build
 ```
 
 The Cloudflare Vitest suite runs in `workerd` with a test entry point that
-subclasses the Durable Object and injects an in-memory event adapter. The
-production bundle imports only the Supabase/Postgres adapter, so test
-credentials cannot select a non-durable backend in a deployed Worker.
+subclasses the Durable Object and injects a test event adapter. The adapter uses
+test-only Durable Object storage to emulate an external durable history source
+across forced instance eviction. The production bundle imports only the
+Supabase/Postgres adapter, so test credentials cannot select that backend in a
+deployed Worker.

--- a/apps/collab-cloudflare/src/constants.ts
+++ b/apps/collab-cloudflare/src/constants.ts
@@ -9,6 +9,10 @@ import {
 export const MESSAGE_RATE_LIMIT_WINDOW_MS = 10_000;
 export const MESSAGE_RATE_LIMIT_MAX = 120;
 export const MAX_MESSAGE_BYTES = 256 * 1024;
+// WebSocket attachments are capped at 16 KiB by Cloudflare. Keep half of that
+// budget for the Ready/session snapshot, quota, structured-clone overhead, and
+// future versioned fields.
+export const MAX_PERSISTED_AUTH_BYTES = 8 * 1024;
 export const INITIAL_AUTH_TIMEOUT_MS = 10_000;
 
 export const errorMessage = (

--- a/apps/collab-cloudflare/src/document-room-do.ts
+++ b/apps/collab-cloudflare/src/document-room-do.ts
@@ -2,15 +2,19 @@ import { DurableObject } from "cloudflare:workers";
 import {
   COLLAB_ERROR_CODE,
   COLLAB_MESSAGE_TYPE,
-  COLLAB_PROTOCOL_VERSION,
   parseClientCollabMessage,
+  type AuthMessage,
   type ClientCollabMessage,
+  type LegacyAuthMessage,
+  type LegacyReadyMessage,
+  type ReadyMessage,
   type ServerCollabMessage,
-  type SupportedCollabProtocolVersion,
 } from "@softmaple/collab-protocol";
 import {
   createDocumentRoom,
+  DOCUMENT_ROOM_REFRESH_MODE,
   type DocumentRoom,
+  type DocumentRoomResumeState,
   type DocumentRoomServices,
   type RoomPeer,
 } from "@softmaple/collab-runtime";
@@ -18,16 +22,22 @@ import {
   errorMessage,
   logError,
   MAX_MESSAGE_BYTES,
+  MAX_PERSISTED_AUTH_BYTES,
   MESSAGE_RATE_LIMIT_MAX,
   MESSAGE_RATE_LIMIT_WINDOW_MS,
 } from "./constants";
 import { documentIdFromRoomPath } from "./document-id";
 import { createRoomServices } from "./room-services";
-
-interface MessageQuota {
-  readonly count: number;
-  readonly windowStartedAt: number;
-}
+import {
+  attachmentAfterReady,
+  attachmentAfterResume,
+  attachmentWithQuota,
+  createAwaitingAuthAttachment,
+  parseDocumentWebSocketAttachment,
+  protocolVersionFromAttachment,
+  resumeStateFromAttachment,
+  type DocumentWebSocketAttachment,
+} from "./websocket-attachment";
 
 const textFromMessage = (message: string | ArrayBuffer): string =>
   typeof message === "string" ? message : new TextDecoder().decode(message);
@@ -38,83 +48,186 @@ const messageBytes = (message: string | ArrayBuffer): number =>
     : message.byteLength;
 
 class DurableObjectRoomPeer implements RoomPeer {
-  readonly id = crypto.randomUUID();
+  readonly id: string;
 
+  private attachment: DocumentWebSocketAttachment;
   private cleanedUp = false;
   private closeRequested = false;
   private messageQueue: Promise<void> = Promise.resolve();
-  private protocolVersion: SupportedCollabProtocolVersion =
-    COLLAB_PROTOCOL_VERSION;
-  private quota: MessageQuota = { count: 0, windowStartedAt: Date.now() };
+  private pendingAuth: AuthMessage | LegacyAuthMessage | null = null;
 
   constructor(
-    private readonly documentId: string,
     private readonly room: DocumentRoom,
     private readonly socket: WebSocket,
-  ) {}
+    attachment: DocumentWebSocketAttachment,
+  ) {
+    this.attachment = attachment;
+    this.id = attachment.peerId;
+  }
 
-  start(): void {
-    this.socket.addEventListener("message", (event) => {
-      this.enqueue(async () => {
-        await this.receive(event.data);
-      });
+  get active(): boolean {
+    return !this.cleanedUp && !this.closeRequested;
+  }
+
+  get documentId(): string {
+    return this.attachment.documentId;
+  }
+
+  ownsSocket(socket: WebSocket): boolean {
+    return this.socket === socket;
+  }
+
+  dispatch(rawMessage: string | ArrayBuffer): Promise<void> {
+    return this.enqueue(async () => {
+      await this.receive(rawMessage);
     });
-    this.socket.addEventListener("close", () => {
-      this.enqueue(async () => {
-        await this.cleanup();
-      });
+  }
+
+  resume(state: DocumentRoomResumeState): Promise<void> {
+    return this.enqueue(async () => {
+      if (
+        this.cleanedUp ||
+        this.closeRequested ||
+        this.attachment.phase !== "authenticated"
+      ) {
+        return;
+      }
+      const session = await this.room.resume(this, state);
+      if (session === null) {
+        this.cleanedUp = true;
+        this.closeRequested = true;
+        return;
+      }
+      if (this.closeRequested) {
+        await this.cleanupNow();
+        return;
+      }
+      const attachment = attachmentAfterResume(
+        this.attachment,
+        session,
+        Date.now(),
+      );
+      if (attachment === null) {
+        throw new Error("Resumed collaboration session metadata is invalid");
+      }
+      this.replaceAttachment(attachment);
     });
-    this.socket.addEventListener("error", () => {
-      this.enqueue(async () => {
-        await this.cleanup();
-      });
+  }
+
+  transportClosed(): Promise<void> {
+    this.closeRequested = true;
+    return this.enqueue(async () => {
+      await this.cleanupNow();
+    });
+  }
+
+  transportError(error: unknown): Promise<void> {
+    logError(error, {
+      documentId: this.documentId,
+      messageType: "websocket-error",
+      peerId: this.id,
+    });
+    this.close(1011, "Collaboration transport failure");
+    return this.enqueue(async () => {
+      await this.cleanupNow();
+    });
+  }
+
+  fail(error: unknown, messageType: string): Promise<void> {
+    return this.enqueue(async () => {
+      await this.handleFailure(error, messageType);
     });
   }
 
   close(code: number, reason: string): void {
     if (this.closeRequested) return;
     this.closeRequested = true;
-    if (this.socket.readyState < 2) this.socket.close(code, reason);
-  }
-
-  send(message: ServerCollabMessage): void {
-    if (this.closeRequested || this.socket.readyState !== 1) return;
-    this.socket.send(JSON.stringify(message));
-    if (message.type === COLLAB_MESSAGE_TYPE.Ready) {
-      this.protocolVersion = message.protocolVersion;
+    if (this.socket.readyState < WebSocket.CLOSING) {
+      this.socket.close(code, reason);
     }
   }
 
-  private enqueue(operation: () => Promise<void>): void {
-    this.messageQueue = this.messageQueue
-      .then(operation)
-      .catch(async (error: unknown) => {
-        logError(error, {
-          documentId: this.documentId,
-          messageType: "websocket",
-          peerId: this.id,
-        });
-        this.close(1011, "Collaboration runtime failure");
+  send(message: ServerCollabMessage): void {
+    if (this.closeRequested || this.socket.readyState !== WebSocket.OPEN) {
+      if (message.type === COLLAB_MESSAGE_TYPE.Ready) {
+        throw new Error(
+          "Collaboration socket closed before authentication completed",
+        );
+      }
+      return;
+    }
+    const previousAttachment = this.attachment;
+    if (message.type === COLLAB_MESSAGE_TYPE.Ready) {
+      this.persistReady(message);
+    }
+    try {
+      this.socket.send(JSON.stringify(message));
+    } catch (error) {
+      if (message.type === COLLAB_MESSAGE_TYPE.Ready) {
         try {
-          await this.cleanup();
-        } catch (cleanupError) {
-          logError(cleanupError, {
+          this.replaceAttachment(previousAttachment);
+        } catch (rollbackError) {
+          logError(rollbackError, {
             documentId: this.documentId,
-            messageType: "websocket-cleanup",
+            messageType: "websocket-ready-rollback",
             peerId: this.id,
           });
+          this.close(1011, "Collaboration runtime failure");
         }
+      }
+      throw error;
+    }
+  }
+
+  private enqueue(operation: () => Promise<void>): Promise<void> {
+    const queued = this.messageQueue.then(operation, operation);
+    const guarded = queued.catch(async (error: unknown) => {
+      await this.handleFailure(error, "websocket");
+    });
+    this.messageQueue = guarded;
+    return guarded;
+  }
+
+  private async handleFailure(
+    error: unknown,
+    messageType: string,
+  ): Promise<void> {
+    logError(error, {
+      documentId: this.documentId,
+      messageType,
+      peerId: this.id,
+    });
+    this.close(1011, "Collaboration runtime failure");
+    try {
+      await this.cleanupNow();
+    } catch (cleanupError) {
+      logError(cleanupError, {
+        documentId: this.documentId,
+        messageType: "websocket-cleanup",
+        peerId: this.id,
       });
+    }
   }
 
   private consumeQuota(): boolean {
     const now = Date.now();
-    if (now - this.quota.windowStartedAt >= MESSAGE_RATE_LIMIT_WINDOW_MS) {
-      this.quota = { count: 1, windowStartedAt: now };
+    const quota = this.attachment.quota;
+    if (now - quota.windowStartedAt >= MESSAGE_RATE_LIMIT_WINDOW_MS) {
+      this.replaceAttachment(
+        attachmentWithQuota(this.attachment, {
+          count: 1,
+          windowStartedAt: now,
+        }),
+      );
       return true;
     }
-    if (this.quota.count >= MESSAGE_RATE_LIMIT_MAX) return false;
-    this.quota = { ...this.quota, count: this.quota.count + 1 };
+    if (quota.count >= MESSAGE_RATE_LIMIT_MAX) return false;
+    this.replaceAttachment(
+      attachmentWithQuota(this.attachment, {
+        ...quota,
+        count: quota.count + 1,
+      }),
+    );
     return true;
   }
 
@@ -122,7 +235,7 @@ class DurableObjectRoomPeer implements RoomPeer {
     if (this.cleanedUp || this.closeRequested) return;
     if (messageBytes(rawMessage) > MAX_MESSAGE_BYTES) {
       this.close(1009, "Collaboration message is too large");
-      await this.cleanup();
+      await this.cleanupNow();
       return;
     }
     if (!this.consumeQuota()) {
@@ -131,11 +244,11 @@ class DurableObjectRoomPeer implements RoomPeer {
           COLLAB_ERROR_CODE.InvalidMessage,
           "Too many collaboration messages",
           true,
-          this.protocolVersion,
+          protocolVersionFromAttachment(this.attachment),
         ),
       );
       this.close(1013, "Message rate limit exceeded");
-      await this.cleanup();
+      await this.cleanupNow();
       return;
     }
 
@@ -155,25 +268,69 @@ class DurableObjectRoomPeer implements RoomPeer {
           COLLAB_ERROR_CODE.InvalidMessage,
           "The collaboration message is invalid",
           false,
-          this.protocolVersion,
+          protocolVersionFromAttachment(this.attachment),
         ),
       );
       return;
     }
 
-    await this.room.receive(this, message);
-    if (this.closeRequested) await this.cleanup();
+    if (message.type === COLLAB_MESSAGE_TYPE.Auth) {
+      if (messageBytes(JSON.stringify(message)) > MAX_PERSISTED_AUTH_BYTES) {
+        this.close(1009, "Authentication metadata is too large");
+        await this.cleanupNow();
+        return;
+      }
+      this.pendingAuth = message;
+    }
+    try {
+      await this.room.receive(this, message);
+    } finally {
+      this.pendingAuth = null;
+    }
+    if (this.closeRequested) await this.cleanupNow();
   }
 
-  private async cleanup(): Promise<void> {
+  private persistReady(message: LegacyReadyMessage | ReadyMessage): void {
+    const auth = this.pendingAuth;
+    if (auth === null) {
+      throw new Error(
+        "Ready was sent without a pending authentication message",
+      );
+    }
+    const attachment = attachmentAfterReady(
+      this.attachment,
+      auth,
+      message,
+      Date.now(),
+    );
+    if (attachment === null) {
+      throw new Error("Authenticated collaboration metadata is inconsistent");
+    }
+    this.replaceAttachment(attachment);
+  }
+
+  private replaceAttachment(attachment: DocumentWebSocketAttachment): void {
+    this.socket.serializeAttachment(attachment);
+    this.attachment = attachment;
+  }
+
+  private async cleanupNow(): Promise<void> {
     if (this.cleanedUp) return;
     this.cleanedUp = true;
     await this.room.leave(this);
   }
 }
 
+interface RestoredPeer {
+  readonly attachment: DocumentWebSocketAttachment;
+  readonly peer: DurableObjectRoomPeer;
+  readonly socket: WebSocket;
+}
+
 export class DocumentRoomDO extends DurableObject<Env> {
   private documentId: string | null = null;
+  private initializationPromise: Promise<void> | null = null;
+  private readonly peers = new Map<string, DurableObjectRoomPeer>();
   private room: DocumentRoom | null = null;
 
   protected createServices(documentId: string): DocumentRoomServices {
@@ -192,42 +349,254 @@ export class DocumentRoomDO extends DurableObject<Env> {
     if (documentId === null) {
       return Response.json({ error: "Invalid document id" }, { status: 400 });
     }
-    if (this.documentId !== null && this.documentId !== documentId) {
+
+    let room: DocumentRoom | null;
+    try {
+      room = await this.ensureRoom(documentId);
+    } catch (error) {
+      logError(error, { documentId, messageType: "room-restore" });
+      return Response.json(
+        { error: "Document room unavailable" },
+        { status: 503 },
+      );
+    }
+    if (room === null) {
       return Response.json(
         { error: "Durable Object document mismatch" },
         { status: 409 },
-      );
-    }
-    if (this.room === null) {
-      this.documentId = documentId;
-      this.room = createDocumentRoom(
-        documentId,
-        this.createServices(documentId),
       );
     }
 
     const pair = new WebSocketPair();
     const client = pair[0];
     const server = pair[1];
-    server.accept();
-    const peer = new DurableObjectRoomPeer(documentId, this.room, server);
+    const attachment = createAwaitingAuthAttachment(documentId);
+    let peer: DurableObjectRoomPeer | null = null;
     try {
-      await this.room.join(peer);
+      this.ctx.acceptWebSocket(server);
+      server.serializeAttachment(attachment);
+      peer = new DurableObjectRoomPeer(room, server, attachment);
+      this.peers.set(peer.id, peer);
+      await room.join(peer);
     } catch (error) {
       logError(error, { documentId, messageType: "room-join" });
-      try {
-        if (server.readyState < 2) {
-          server.close(1011, "Document room unavailable");
-        }
-      } catch (closeError) {
-        logError(closeError, { documentId, messageType: "room-join-close" });
-      }
+      if (peer !== null) await peer.transportClosed();
+      this.failSocket(server, 1011, "Document room unavailable", {
+        documentId,
+        messageType: "room-join-close",
+      });
+      this.peers.delete(attachment.peerId);
       return Response.json(
         { error: "Document room unavailable" },
         { status: 503 },
       );
     }
-    peer.start();
     return new Response(null, { status: 101, webSocket: client });
+  }
+
+  async webSocketMessage(
+    socket: WebSocket,
+    message: string | ArrayBuffer,
+  ): Promise<void> {
+    const attachment = this.attachmentFromSocket(socket);
+    if (attachment === null) {
+      this.failSocket(socket, 1008, "Invalid collaboration connection", {
+        messageType: "invalid-websocket-attachment",
+      });
+      return;
+    }
+
+    try {
+      const room = await this.ensureRoom(attachment.documentId);
+      if (room === null) {
+        this.failSocket(socket, 1008, "Invalid collaboration document", {
+          documentId: attachment.documentId,
+          messageType: "websocket-document-mismatch",
+          peerId: attachment.peerId,
+        });
+        return;
+      }
+      const peer = await this.ensurePeer(socket, attachment, room);
+      if (peer === null) return;
+      await peer.dispatch(message);
+      if (!peer.active) this.peers.delete(peer.id);
+    } catch (error) {
+      logError(error, {
+        documentId: attachment.documentId,
+        messageType: "websocket-message",
+        peerId: attachment.peerId,
+      });
+      this.failSocket(socket, 1011, "Collaboration runtime failure", {
+        documentId: attachment.documentId,
+        messageType: "websocket-message-close",
+        peerId: attachment.peerId,
+      });
+    }
+  }
+
+  async webSocketClose(socket: WebSocket): Promise<void> {
+    const peer = this.peerFromSocket(socket);
+    if (peer === null) return;
+    await peer.transportClosed();
+    this.peers.delete(peer.id);
+  }
+
+  async webSocketError(socket: WebSocket, error: unknown): Promise<void> {
+    const peer = this.peerFromSocket(socket);
+    if (peer === null) {
+      logError(error, { messageType: "untracked-websocket-error" });
+      this.failSocket(socket, 1011, "Collaboration transport failure", {
+        messageType: "untracked-websocket-error-close",
+      });
+      return;
+    }
+    await peer.transportError(error);
+    this.peers.delete(peer.id);
+  }
+
+  private async ensureRoom(documentId: string): Promise<DocumentRoom | null> {
+    if (this.documentId !== null && this.documentId !== documentId) return null;
+    if (this.room === null) {
+      this.documentId = documentId;
+      this.room = createDocumentRoom(
+        documentId,
+        this.createServices(documentId),
+        { refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage },
+      );
+    }
+    if (this.initializationPromise === null) {
+      this.initializationPromise = this.restoreAttachedSockets(
+        documentId,
+        this.room,
+      );
+    }
+    await this.initializationPromise;
+    return this.room;
+  }
+
+  private async restoreAttachedSockets(
+    documentId: string,
+    room: DocumentRoom,
+  ): Promise<void> {
+    const restored: RestoredPeer[] = [];
+    for (const socket of this.ctx.getWebSockets()) {
+      if (socket.readyState !== WebSocket.OPEN) continue;
+      const attachment = this.attachmentFromSocket(socket);
+      if (attachment === null || attachment.documentId !== documentId) {
+        this.failSocket(socket, 1008, "Invalid collaboration connection", {
+          documentId,
+          messageType: "websocket-restore-invalid-attachment",
+        });
+        continue;
+      }
+      if (this.peers.has(attachment.peerId)) {
+        this.failSocket(socket, 1008, "Duplicate collaboration connection", {
+          documentId,
+          messageType: "websocket-restore-duplicate-peer",
+          peerId: attachment.peerId,
+        });
+        continue;
+      }
+      const peer = new DurableObjectRoomPeer(room, socket, attachment);
+      this.peers.set(peer.id, peer);
+      restored.push({ attachment, peer, socket });
+    }
+
+    await Promise.all(
+      restored.map(async ({ peer }) => {
+        try {
+          await room.join(peer);
+        } catch (error) {
+          await peer.fail(error, "websocket-restore-join");
+          this.peers.delete(peer.id);
+        }
+      }),
+    );
+    await Promise.all(
+      restored.map(async ({ attachment, peer, socket }) => {
+        if (
+          attachment.phase !== "authenticated" ||
+          this.peers.get(peer.id) !== peer
+        ) {
+          return;
+        }
+        const state = resumeStateFromAttachment(attachment);
+        if (state === null) {
+          this.failSocket(socket, 1008, "Invalid collaboration session", {
+            documentId,
+            messageType: "websocket-restore-invalid-session",
+            peerId: peer.id,
+          });
+          await peer.transportClosed();
+          this.peers.delete(peer.id);
+          return;
+        }
+        await peer.resume(state);
+        if (!peer.active) this.peers.delete(peer.id);
+      }),
+    );
+  }
+
+  private async ensurePeer(
+    socket: WebSocket,
+    attachment: DocumentWebSocketAttachment,
+    room: DocumentRoom,
+  ): Promise<DurableObjectRoomPeer | null> {
+    if (socket.readyState !== WebSocket.OPEN) return null;
+    const existing = this.peers.get(attachment.peerId);
+    if (existing !== undefined) return existing;
+    const peer = new DurableObjectRoomPeer(room, socket, attachment);
+    this.peers.set(peer.id, peer);
+    try {
+      await room.join(peer);
+      if (attachment.phase === "authenticated") {
+        const state = resumeStateFromAttachment(attachment);
+        if (state === null)
+          throw new Error("Invalid resumed collaboration state");
+        await peer.resume(state);
+      }
+    } catch (error) {
+      await peer.fail(error, "websocket-peer-restore");
+    }
+    if (peer.active) return peer;
+    this.peers.delete(peer.id);
+    return null;
+  }
+
+  private attachmentFromSocket(
+    socket: WebSocket,
+  ): DocumentWebSocketAttachment | null {
+    try {
+      const value: unknown = socket.deserializeAttachment();
+      return parseDocumentWebSocketAttachment(value);
+    } catch (error) {
+      logError(error, { messageType: "websocket-attachment-read" });
+      return null;
+    }
+  }
+
+  private peerFromSocket(socket: WebSocket): DurableObjectRoomPeer | null {
+    const attachment = this.attachmentFromSocket(socket);
+    if (attachment !== null) {
+      const peer = this.peers.get(attachment.peerId);
+      if (peer !== undefined) return peer;
+    }
+    return (
+      [...this.peers.values()].find((peer) => peer.ownsSocket(socket)) ?? null
+    );
+  }
+
+  private failSocket(
+    socket: WebSocket,
+    code: number,
+    reason: string,
+    context: Readonly<Record<string, unknown>>,
+  ): void {
+    logError(new Error(reason), context);
+    try {
+      if (socket.readyState < WebSocket.CLOSING) socket.close(code, reason);
+    } catch (error) {
+      logError(error, { ...context, messageType: "websocket-fail-close" });
+    }
   }
 }

--- a/apps/collab-cloudflare/src/document-room-do.ts
+++ b/apps/collab-cloudflare/src/document-room-do.ts
@@ -482,60 +482,84 @@ export class DocumentRoomDO extends DurableObject<Env> {
     room: DocumentRoom,
   ): Promise<void> {
     const restored: RestoredPeer[] = [];
-    for (const socket of this.ctx.getWebSockets()) {
-      if (socket.readyState !== WebSocket.OPEN) continue;
-      const attachment = this.attachmentFromSocket(socket);
-      if (attachment === null || attachment.documentId !== documentId) {
-        this.failSocket(socket, 1008, "Invalid collaboration connection", {
-          documentId,
-          messageType: "websocket-restore-invalid-attachment",
-        });
-        continue;
+    try {
+      for (const socket of this.ctx.getWebSockets()) {
+        if (socket.readyState !== WebSocket.OPEN) continue;
+        const attachment = this.attachmentFromSocket(socket);
+        if (attachment === null || attachment.documentId !== documentId) {
+          this.failSocket(socket, 1008, "Invalid collaboration connection", {
+            documentId,
+            messageType: "websocket-restore-invalid-attachment",
+          });
+          continue;
+        }
+        if (this.peers.has(attachment.peerId)) {
+          this.failSocket(socket, 1008, "Duplicate collaboration connection", {
+            documentId,
+            messageType: "websocket-restore-duplicate-peer",
+            peerId: attachment.peerId,
+          });
+          continue;
+        }
+        const peer = new DurableObjectRoomPeer(room, socket, attachment);
+        this.peers.set(peer.id, peer);
+        restored.push({ attachment, peer, socket });
       }
-      if (this.peers.has(attachment.peerId)) {
-        this.failSocket(socket, 1008, "Duplicate collaboration connection", {
-          documentId,
-          messageType: "websocket-restore-duplicate-peer",
-          peerId: attachment.peerId,
-        });
-        continue;
-      }
-      const peer = new DurableObjectRoomPeer(room, socket, attachment);
-      this.peers.set(peer.id, peer);
-      restored.push({ attachment, peer, socket });
-    }
 
+      await Promise.all(
+        restored.map(async ({ peer }) => {
+          try {
+            await room.join(peer);
+          } catch (error) {
+            await peer.fail(error, "websocket-restore-join");
+            this.peers.delete(peer.id);
+          }
+        }),
+      );
+      await Promise.all(
+        restored.map(async ({ attachment, peer, socket }) => {
+          if (
+            attachment.phase !== "authenticated" ||
+            this.peers.get(peer.id) !== peer
+          ) {
+            return;
+          }
+          const state = resumeStateFromAttachment(attachment);
+          if (state === null) {
+            this.failSocket(socket, 1008, "Invalid collaboration session", {
+              documentId,
+              messageType: "websocket-restore-invalid-session",
+              peerId: peer.id,
+            });
+            await peer.transportClosed();
+            this.peers.delete(peer.id);
+            return;
+          }
+          try {
+            await peer.resume(state);
+          } catch (error) {
+            await peer.fail(error, "websocket-restore-resume");
+            this.peers.delete(peer.id);
+            return;
+          }
+          if (!peer.active) this.peers.delete(peer.id);
+        }),
+      );
+    } catch (error) {
+      await this.discardRestoredPeers(restored);
+      this.room = null;
+      throw error;
+    }
+  }
+
+  private async discardRestoredPeers(
+    restored: ReadonlyArray<RestoredPeer>,
+  ): Promise<void> {
     await Promise.all(
       restored.map(async ({ peer }) => {
-        try {
-          await room.join(peer);
-        } catch (error) {
-          await peer.fail(error, "websocket-restore-join");
-          this.peers.delete(peer.id);
-        }
-      }),
-    );
-    await Promise.all(
-      restored.map(async ({ attachment, peer, socket }) => {
-        if (
-          attachment.phase !== "authenticated" ||
-          this.peers.get(peer.id) !== peer
-        ) {
-          return;
-        }
-        const state = resumeStateFromAttachment(attachment);
-        if (state === null) {
-          this.failSocket(socket, 1008, "Invalid collaboration session", {
-            documentId,
-            messageType: "websocket-restore-invalid-session",
-            peerId: peer.id,
-          });
-          await peer.transportClosed();
-          this.peers.delete(peer.id);
-          return;
-        }
-        await peer.resume(state);
-        if (!peer.active) this.peers.delete(peer.id);
+        if (this.peers.get(peer.id) !== peer) return;
+        await peer.transportClosed();
+        this.peers.delete(peer.id);
       }),
     );
   }
@@ -548,7 +572,13 @@ export class DocumentRoomDO extends DurableObject<Env> {
     if (socket.readyState !== WebSocket.OPEN) return null;
     const existing = this.peers.get(attachment.peerId);
     if (existing !== undefined) {
-      return existing.ownsSocket(socket) ? existing : null;
+      if (existing.ownsSocket(socket)) return existing;
+      this.failSocket(socket, 1008, "Duplicate collaboration connection", {
+        documentId: attachment.documentId,
+        messageType: "websocket-duplicate-peer",
+        peerId: attachment.peerId,
+      });
+      return null;
     }
     const peer = new DurableObjectRoomPeer(room, socket, attachment);
     this.peers.set(peer.id, peer);
@@ -584,7 +614,9 @@ export class DocumentRoomDO extends DurableObject<Env> {
     const attachment = this.attachmentFromSocket(socket);
     if (attachment !== null) {
       const peer = this.peers.get(attachment.peerId);
-      if (peer !== undefined) return peer;
+      if (peer !== undefined) {
+        return peer.ownsSocket(socket) ? peer : null;
+      }
     }
     return (
       [...this.peers.values()].find((peer) => peer.ownsSocket(socket)) ?? null

--- a/apps/collab-cloudflare/src/document-room-do.ts
+++ b/apps/collab-cloudflare/src/document-room-do.ts
@@ -53,8 +53,10 @@ class DurableObjectRoomPeer implements RoomPeer {
   private attachment: DocumentWebSocketAttachment;
   private cleanedUp = false;
   private closeRequested = false;
+  private messageCount: number;
   private messageQueue: Promise<void> = Promise.resolve();
   private pendingAuth: AuthMessage | LegacyAuthMessage | null = null;
+  private windowStartedAt: number;
 
   constructor(
     private readonly room: DocumentRoom,
@@ -63,6 +65,8 @@ class DurableObjectRoomPeer implements RoomPeer {
   ) {
     this.attachment = attachment;
     this.id = attachment.peerId;
+    this.messageCount = attachment.quota.count;
+    this.windowStartedAt = attachment.quota.windowStartedAt;
   }
 
   get active(): boolean {
@@ -211,8 +215,9 @@ class DurableObjectRoomPeer implements RoomPeer {
 
   private consumeQuota(): boolean {
     const now = Date.now();
-    const quota = this.attachment.quota;
-    if (now - quota.windowStartedAt >= MESSAGE_RATE_LIMIT_WINDOW_MS) {
+    if (now - this.windowStartedAt >= MESSAGE_RATE_LIMIT_WINDOW_MS) {
+      this.messageCount = 1;
+      this.windowStartedAt = now;
       this.replaceAttachment(
         attachmentWithQuota(this.attachment, {
           count: 1,
@@ -221,13 +226,8 @@ class DurableObjectRoomPeer implements RoomPeer {
       );
       return true;
     }
-    if (quota.count >= MESSAGE_RATE_LIMIT_MAX) return false;
-    this.replaceAttachment(
-      attachmentWithQuota(this.attachment, {
-        ...quota,
-        count: quota.count + 1,
-      }),
-    );
+    if (this.messageCount >= MESSAGE_RATE_LIMIT_MAX) return false;
+    this.messageCount += 1;
     return true;
   }
 
@@ -468,7 +468,10 @@ export class DocumentRoomDO extends DurableObject<Env> {
       this.initializationPromise = this.restoreAttachedSockets(
         documentId,
         this.room,
-      );
+      ).catch((error: unknown) => {
+        this.initializationPromise = null;
+        throw error;
+      });
     }
     await this.initializationPromise;
     return this.room;
@@ -544,7 +547,9 @@ export class DocumentRoomDO extends DurableObject<Env> {
   ): Promise<DurableObjectRoomPeer | null> {
     if (socket.readyState !== WebSocket.OPEN) return null;
     const existing = this.peers.get(attachment.peerId);
-    if (existing !== undefined) return existing;
+    if (existing !== undefined) {
+      return existing.ownsSocket(socket) ? existing : null;
+    }
     const peer = new DurableObjectRoomPeer(room, socket, attachment);
     this.peers.set(peer.id, peer);
     try {

--- a/apps/collab-cloudflare/src/supabase-backend.ts
+++ b/apps/collab-cloudflare/src/supabase-backend.ts
@@ -245,9 +245,7 @@ const authorizeAuthenticated = async (
     .maybeSingle();
   if (memberError !== null) throw memberError;
   const member = memberRow(rawMember as unknown);
-  if (member === null) {
-    return document.is_public ? publicDocumentAccess() : null;
-  }
+  if (member === null) return null;
 
   return {
     accessMode: COLLAB_ACCESS_MODE.Authenticated,

--- a/apps/collab-cloudflare/src/supabase-backend.ts
+++ b/apps/collab-cloudflare/src/supabase-backend.ts
@@ -245,7 +245,9 @@ const authorizeAuthenticated = async (
     .maybeSingle();
   if (memberError !== null) throw memberError;
   const member = memberRow(rawMember as unknown);
-  if (member === null) return null;
+  if (member === null) {
+    return document.is_public ? publicDocumentAccess() : null;
+  }
 
   return {
     accessMode: COLLAB_ACCESS_MODE.Authenticated,

--- a/apps/collab-cloudflare/src/websocket-attachment.ts
+++ b/apps/collab-cloudflare/src/websocket-attachment.ts
@@ -1,0 +1,302 @@
+import {
+  COLLAB_ACCESS_MODE,
+  COLLAB_MESSAGE_TYPE,
+  COLLAB_PROTOCOL_VERSION,
+  LEGACY_COLLAB_PROTOCOL_VERSION,
+  parseClientCollabMessage,
+  parseServerCollabMessage,
+  type AuthMessage,
+  type CollabCredential,
+  type LegacyAuthMessage,
+  type LegacyReadyMessage,
+  type ReadyMessage,
+  type SupportedCollabProtocolVersion,
+} from "@softmaple/collab-protocol";
+import type {
+  DocumentRoomResumeState,
+  DocumentSession,
+} from "@softmaple/collab-runtime";
+import { normalizeDocumentId } from "./document-id";
+
+const ATTACHMENT_VERSION = 1 as const;
+const PEER_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export interface MessageQuota {
+  readonly count: number;
+  readonly windowStartedAt: number;
+}
+
+interface WebSocketAttachmentBase {
+  readonly documentId: string;
+  readonly peerId: string;
+  readonly quota: MessageQuota;
+  readonly version: typeof ATTACHMENT_VERSION;
+}
+
+export interface AwaitingAuthWebSocketAttachment
+  extends WebSocketAttachmentBase {
+  readonly phase: "awaiting-auth";
+}
+
+export interface AuthenticatedWebSocketAttachment
+  extends WebSocketAttachmentBase {
+  readonly auth: AuthMessage | LegacyAuthMessage;
+  readonly phase: "authenticated";
+  readonly ready: ReadyMessage | LegacyReadyMessage;
+  readonly validatedAt: number;
+}
+
+export type DocumentWebSocketAttachment =
+  | AwaitingAuthWebSocketAttachment
+  | AuthenticatedWebSocketAttachment;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+
+const parseQuota = (value: unknown): MessageQuota | null => {
+  if (
+    !isRecord(value) ||
+    !isNonNegativeInteger(value.count) ||
+    !isNonNegativeInteger(value.windowStartedAt)
+  ) {
+    return null;
+  }
+  return { count: value.count, windowStartedAt: value.windowStartedAt };
+};
+
+const parseAuth = (value: unknown): AuthMessage | LegacyAuthMessage | null => {
+  try {
+    const message = parseClientCollabMessage(value);
+    return message.type === COLLAB_MESSAGE_TYPE.Auth ? message : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseReady = (
+  value: unknown,
+): LegacyReadyMessage | ReadyMessage | null => {
+  try {
+    const message = parseServerCollabMessage(value);
+    return message.type === COLLAB_MESSAGE_TYPE.Ready ? message : null;
+  } catch {
+    return null;
+  }
+};
+
+const hasConsistentIdentity = (
+  documentId: string,
+  auth: AuthMessage | LegacyAuthMessage,
+  ready: LegacyReadyMessage | ReadyMessage,
+): boolean => {
+  if (
+    auth.documentId !== documentId ||
+    ready.documentId !== documentId ||
+    auth.protocolVersion !== ready.protocolVersion
+  ) {
+    return false;
+  }
+  if (auth.protocolVersion === LEGACY_COLLAB_PROTOCOL_VERSION) {
+    return ready.protocolVersion === LEGACY_COLLAB_PROTOCOL_VERSION;
+  }
+  if (ready.protocolVersion !== COLLAB_PROTOCOL_VERSION) return false;
+  if (
+    ready.accessMode === COLLAB_ACCESS_MODE.Authenticated &&
+    (ready.userId === null || ready.role === null)
+  ) {
+    return false;
+  }
+  return auth.credential.kind === "public"
+    ? ready.accessMode === COLLAB_ACCESS_MODE.Public
+    : ready.accessMode === COLLAB_ACCESS_MODE.Authenticated;
+};
+
+export const createAwaitingAuthAttachment = (
+  documentId: string,
+  now = Date.now(),
+): AwaitingAuthWebSocketAttachment => ({
+  documentId,
+  peerId: crypto.randomUUID(),
+  phase: "awaiting-auth",
+  quota: { count: 0, windowStartedAt: now },
+  version: ATTACHMENT_VERSION,
+});
+
+export const parseDocumentWebSocketAttachment = (
+  value: unknown,
+): DocumentWebSocketAttachment | null => {
+  if (
+    !isRecord(value) ||
+    value.version !== ATTACHMENT_VERSION ||
+    typeof value.documentId !== "string" ||
+    normalizeDocumentId(value.documentId) !== value.documentId ||
+    typeof value.peerId !== "string" ||
+    !PEER_ID_PATTERN.test(value.peerId)
+  ) {
+    return null;
+  }
+  const quota = parseQuota(value.quota);
+  if (quota === null) return null;
+  const base = {
+    documentId: value.documentId,
+    peerId: value.peerId,
+    quota,
+    version: ATTACHMENT_VERSION,
+  } as const;
+  if (value.phase === "awaiting-auth") {
+    return { ...base, phase: "awaiting-auth" };
+  }
+  if (
+    value.phase !== "authenticated" ||
+    !isNonNegativeInteger(value.validatedAt)
+  ) {
+    return null;
+  }
+  const auth = parseAuth(value.auth);
+  const ready = parseReady(value.ready);
+  if (
+    auth === null ||
+    ready === null ||
+    !hasConsistentIdentity(value.documentId, auth, ready)
+  ) {
+    return null;
+  }
+  return {
+    ...base,
+    auth,
+    phase: "authenticated",
+    ready,
+    validatedAt: value.validatedAt,
+  };
+};
+
+const credentialFromAuth = (
+  auth: AuthMessage | LegacyAuthMessage,
+): CollabCredential =>
+  auth.protocolVersion === LEGACY_COLLAB_PROTOCOL_VERSION
+    ? { kind: "access-token", token: auth.accessToken }
+    : auth.credential;
+
+const sessionFromMessages = (
+  auth: AuthMessage | LegacyAuthMessage,
+  ready: LegacyReadyMessage | ReadyMessage,
+): DocumentSession | null => {
+  if (!hasConsistentIdentity(auth.documentId, auth, ready)) return null;
+  if (
+    auth.protocolVersion === LEGACY_COLLAB_PROTOCOL_VERSION &&
+    ready.protocolVersion === LEGACY_COLLAB_PROTOCOL_VERSION
+  ) {
+    return {
+      accessMode: COLLAB_ACCESS_MODE.Authenticated,
+      actorId: ready.userId,
+      canWrite: ready.canWrite,
+      documentId: auth.documentId,
+      protocolVersion: LEGACY_COLLAB_PROTOCOL_VERSION,
+      role: ready.role,
+      sessionId: auth.sessionId,
+    };
+  }
+  if (
+    auth.protocolVersion !== COLLAB_PROTOCOL_VERSION ||
+    ready.protocolVersion !== COLLAB_PROTOCOL_VERSION
+  ) {
+    return null;
+  }
+  if (ready.accessMode === COLLAB_ACCESS_MODE.Public) {
+    return {
+      accessMode: COLLAB_ACCESS_MODE.Public,
+      actorId: null,
+      canWrite: false,
+      documentId: auth.documentId,
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      role: null,
+      sessionId: auth.sessionId,
+    };
+  }
+  if (ready.userId === null || ready.role === null) return null;
+  return {
+    accessMode: COLLAB_ACCESS_MODE.Authenticated,
+    actorId: ready.userId,
+    canWrite: ready.canWrite,
+    documentId: auth.documentId,
+    protocolVersion: COLLAB_PROTOCOL_VERSION,
+    role: ready.role,
+    sessionId: auth.sessionId,
+  };
+};
+
+export const resumeStateFromAttachment = (
+  attachment: AuthenticatedWebSocketAttachment,
+): DocumentRoomResumeState | null => {
+  const session = sessionFromMessages(attachment.auth, attachment.ready);
+  return session === null
+    ? null
+    : { credential: credentialFromAuth(attachment.auth), session };
+};
+
+const readyFromSession = (
+  session: DocumentSession,
+): LegacyReadyMessage | ReadyMessage => {
+  if (session.protocolVersion === LEGACY_COLLAB_PROTOCOL_VERSION) {
+    return {
+      protocolVersion: LEGACY_COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.Ready,
+      canWrite: session.canWrite,
+      documentId: session.documentId,
+      role: session.role,
+      userId: session.actorId,
+    };
+  }
+  return {
+    protocolVersion: COLLAB_PROTOCOL_VERSION,
+    type: COLLAB_MESSAGE_TYPE.Ready,
+    accessMode: session.accessMode,
+    canWrite: session.canWrite,
+    documentId: session.documentId,
+    role: session.role,
+    userId: session.actorId,
+  };
+};
+
+export const attachmentAfterReady = (
+  attachment: DocumentWebSocketAttachment,
+  auth: AuthMessage | LegacyAuthMessage,
+  ready: LegacyReadyMessage | ReadyMessage,
+  validatedAt: number,
+): AuthenticatedWebSocketAttachment | null => {
+  if (!hasConsistentIdentity(attachment.documentId, auth, ready)) return null;
+  return {
+    ...attachment,
+    auth,
+    phase: "authenticated",
+    ready,
+    validatedAt,
+  };
+};
+
+export const attachmentAfterResume = (
+  attachment: AuthenticatedWebSocketAttachment,
+  session: DocumentSession,
+  validatedAt: number,
+): AuthenticatedWebSocketAttachment | null => {
+  const ready = readyFromSession(session);
+  return hasConsistentIdentity(attachment.documentId, attachment.auth, ready)
+    ? { ...attachment, ready, validatedAt }
+    : null;
+};
+
+export const attachmentWithQuota = (
+  attachment: DocumentWebSocketAttachment,
+  quota: MessageQuota,
+): DocumentWebSocketAttachment => ({ ...attachment, quota });
+
+export const protocolVersionFromAttachment = (
+  attachment: DocumentWebSocketAttachment,
+): SupportedCollabProtocolVersion =>
+  attachment.phase === "authenticated"
+    ? attachment.ready.protocolVersion
+    : COLLAB_PROTOCOL_VERSION;

--- a/apps/collab-cloudflare/test/document-room-do.test.ts
+++ b/apps/collab-cloudflare/test/document-room-do.test.ts
@@ -506,8 +506,12 @@ describe("Cloudflare DocumentRoomDO", () => {
         sessionId: "hibernate-reader",
       }),
     ]);
-    expect(after[0]!.quota.count).toBeGreaterThan(before[0]!.quota.count);
-    expect(after[1]!.quota.count).toBeGreaterThan(before[1]!.quota.count);
+    expect(after[0]!.quota.windowStartedAt).toBe(
+      before[0]!.quota.windowStartedAt,
+    );
+    expect(after[1]!.quota.windowStartedAt).toBe(
+      before[1]!.quota.windowStartedAt,
+    );
     const audit = await sessionAudit(stub);
     expect(
       audit.refreshes

--- a/apps/collab-cloudflare/test/document-room-do.test.ts
+++ b/apps/collab-cloudflare/test/document-room-do.test.ts
@@ -15,9 +15,25 @@ import {
   type ClientCollabMessage,
   type ServerCollabMessage,
 } from "@softmaple/collab-protocol";
+import { DOCUMENT_SESSION_END_REASON } from "@softmaple/collab-runtime";
+import {
+  evictAllDurableObjects,
+  evictDurableObject,
+  runInDurableObject,
+} from "cloudflare:test";
 import { env, exports } from "cloudflare:workers";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_PERSISTED_AUTH_BYTES } from "../src/constants";
 import { normalizeDocumentId } from "../src/document-id";
+import type { DocumentRoomDO } from "../src/document-room-do";
+import {
+  parseDocumentWebSocketAttachment,
+  resumeStateFromAttachment,
+} from "../src/websocket-attachment";
+import {
+  readMemorySessionAudit,
+  setMemoryAuthenticatedAccessRevoked,
+} from "./memory-backend";
 
 const ORIGIN = "https://app.example";
 const TEST_BATCH = {
@@ -48,7 +64,35 @@ const TEST_BATCH = {
   ],
 } as const;
 
+const POST_WAKE_BATCH = {
+  schemaVersion: BLOCK_MODEL_SCHEMA_VERSION,
+  batchId: "test:post-wake:event",
+  parentVersion: [BOOTSTRAP_EVENT_ID],
+  events: [
+    {
+      schemaVersion: BLOCK_MODEL_SCHEMA_VERSION,
+      id: "test:post-wake:event",
+      parentVersion: [BOOTSTRAP_EVENT_ID],
+      timestamp: 1,
+      operation: { type: "insert" as const, index: 1, text: "awake" },
+      effect: {
+        type: "text-insert" as const,
+        blockId: BOOTSTRAP_BLOCK_ID,
+        text: "awake",
+      },
+    },
+  ],
+} as const;
+
+interface TestSocketClose {
+  readonly code: number;
+  readonly reason: string;
+  readonly wasClean: boolean;
+}
+
 class TestSocket {
+  private readonly closes: TestSocketClose[] = [];
+  private readonly closeWaiters: Array<(event: TestSocketClose) => void> = [];
   private readonly messages: ServerCollabMessage[] = [];
   private readonly waiters: Array<(message: ServerCollabMessage) => void> = [];
 
@@ -64,6 +108,16 @@ class TestSocket {
       if (waiter === undefined) this.messages.push(message);
       else waiter(message);
     });
+    socket.addEventListener("close", (event) => {
+      const close = {
+        code: event.code,
+        reason: event.reason,
+        wasClean: event.wasClean,
+      };
+      const waiter = this.closeWaiters.shift();
+      if (waiter === undefined) this.closes.push(close);
+      else waiter(close);
+    });
   }
 
   send(message: ClientCollabMessage): void {
@@ -74,6 +128,12 @@ class TestSocket {
     const queued = this.messages.shift();
     if (queued !== undefined) return Promise.resolve(queued);
     return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  closed(): Promise<TestSocketClose> {
+    const queued = this.closes.shift();
+    if (queued !== undefined) return Promise.resolve(queued);
+    return new Promise((resolve) => this.closeWaiters.push(resolve));
   }
 
   close(): void {
@@ -96,6 +156,45 @@ const connect = async (): Promise<TestSocket> => {
   return client;
 };
 
+type DocumentRoomStub = DurableObjectStub<DocumentRoomDO>;
+
+const attachmentSnapshots = async (stub: DocumentRoomStub) =>
+  runInDurableObject(stub, (_instance, state) =>
+    state
+      .getWebSockets()
+      .map((socket) => {
+        const attachment = parseDocumentWebSocketAttachment(
+          socket.deserializeAttachment(),
+        );
+        if (attachment === null || attachment.phase !== "authenticated") {
+          throw new Error("Expected an authenticated WebSocket attachment");
+        }
+        const resumed = resumeStateFromAttachment(attachment);
+        if (resumed === null) {
+          throw new Error("Expected resumable WebSocket attachment metadata");
+        }
+        return {
+          accessMode: resumed.session.accessMode,
+          actorId: resumed.session.actorId,
+          canWrite: resumed.session.canWrite,
+          credential: resumed.credential,
+          documentId: attachment.documentId,
+          peerId: attachment.peerId,
+          protocolVersion: resumed.session.protocolVersion,
+          quota: attachment.quota,
+          role: resumed.session.role,
+          sessionId: resumed.session.sessionId,
+          validatedAt: attachment.validatedAt,
+        };
+      })
+      .sort((left, right) => left.sessionId.localeCompare(right.sessionId)),
+  );
+
+const sessionAudit = (stub: DocumentRoomStub) =>
+  runInDurableObject(stub, (_instance, state) =>
+    readMemorySessionAudit(state.storage),
+  );
+
 const authenticate = async (
   socket: TestSocket,
   documentId: string,
@@ -111,8 +210,15 @@ const authenticate = async (
   return socket.next();
 };
 
-afterEach(() => {
-  for (const socket of sockets.splice(0)) socket.close();
+afterEach(async () => {
+  const closing = sockets.splice(0).flatMap((socket) => {
+    if (socket.socket.readyState >= WebSocket.CLOSING) return [];
+    const closed = socket.closed();
+    socket.close();
+    return [closed];
+  });
+  await Promise.all(closing);
+  await evictAllDurableObjects({ webSockets: "close" });
 });
 
 describe("Cloudflare DocumentRoomDO", () => {
@@ -224,6 +330,347 @@ describe("Cloudflare DocumentRoomDO", () => {
       type: COLLAB_MESSAGE_TYPE.Error,
       code: COLLAB_ERROR_CODE.Forbidden,
       retryable: false,
+    });
+  });
+
+  it("rejects authentication metadata that cannot fit in an attachment", async () => {
+    const documentId = "00000000-0000-4000-8000-000000000032";
+    const client = await connect();
+    const closed = client.closed();
+    client.send({
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.Auth,
+      credential: { kind: "public" },
+      documentId,
+      sessionId: "x".repeat(MAX_PERSISTED_AUTH_BYTES),
+    });
+
+    await expect(closed).resolves.toMatchObject({
+      code: 1009,
+      reason: "Authentication metadata is too large",
+    });
+    const audit = await sessionAudit(env.DOCUMENT_ROOMS.getByName(documentId));
+    expect(audit.authorizations).toEqual([]);
+  });
+
+  it("restores every attached peer and durable history after hibernation", async () => {
+    const documentId = "00000000-0000-4000-8000-000000000041";
+    const author = await connect();
+    const reader = await connect();
+
+    await expect(
+      authenticate(author, documentId, "hibernate-author"),
+    ).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.Ready,
+      accessMode: COLLAB_ACCESS_MODE.Authenticated,
+      documentId,
+      canWrite: true,
+    });
+    reader.send({
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.Auth,
+      credential: { kind: "public" },
+      documentId,
+      sessionId: "hibernate-reader",
+    });
+    await expect(reader.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.Ready,
+      accessMode: COLLAB_ACCESS_MODE.Public,
+      documentId,
+      canWrite: false,
+    });
+
+    author.send({
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.Event,
+      batches: [TEST_BATCH],
+    });
+    await expect(author.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.DurableAck,
+      batchIds: [BOOTSTRAP_BATCH_ID],
+    });
+    await expect(author.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.Event,
+      batches: [TEST_BATCH],
+    });
+    await expect(reader.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.Event,
+      batches: [TEST_BATCH],
+    });
+
+    const stub = env.DOCUMENT_ROOMS.getByName(documentId);
+    const before = await attachmentSnapshots(stub);
+    expect(before).toEqual([
+      expect.objectContaining({
+        accessMode: COLLAB_ACCESS_MODE.Authenticated,
+        canWrite: true,
+        credential: { kind: "access-token", token: "test-token" },
+        documentId,
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        role: "EDITOR",
+        sessionId: "hibernate-author",
+      }),
+      expect.objectContaining({
+        accessMode: COLLAB_ACCESS_MODE.Public,
+        actorId: null,
+        canWrite: false,
+        credential: { kind: "public" },
+        documentId,
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        role: null,
+        sessionId: "hibernate-reader",
+      }),
+    ]);
+
+    await evictDurableObject(stub, { webSockets: "hibernate" });
+    expect(author.socket.readyState).toBe(WebSocket.OPEN);
+    expect(reader.socket.readyState).toBe(WebSocket.OPEN);
+
+    reader.send({
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.RepairRequest,
+      requestId: "wake-repair",
+      afterCursor: "0",
+    });
+    await expect(reader.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.RepairResponse,
+      requestId: "wake-repair",
+      batches: [TEST_BATCH],
+      complete: true,
+      nextCursor: "1",
+    });
+
+    author.send({
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.Event,
+      batches: [POST_WAKE_BATCH],
+    });
+    await expect(author.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.DurableAck,
+      batchIds: [POST_WAKE_BATCH.batchId],
+    });
+    await expect(author.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.Event,
+      batches: [POST_WAKE_BATCH],
+    });
+    await expect(reader.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.Event,
+      batches: [POST_WAKE_BATCH],
+    });
+
+    reader.send({
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.RepairRequest,
+      requestId: "post-wake-repair",
+      afterCursor: "1",
+    });
+    await expect(reader.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.RepairResponse,
+      requestId: "post-wake-repair",
+      batches: [POST_WAKE_BATCH],
+      complete: true,
+      nextCursor: "2",
+    });
+
+    reader.send({
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.Event,
+      batches: [POST_WAKE_BATCH],
+    });
+    await expect(reader.next()).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.Error,
+      code: COLLAB_ERROR_CODE.Forbidden,
+      retryable: false,
+    });
+
+    const after = await attachmentSnapshots(stub);
+    expect(
+      after.map(({ peerId, sessionId }) => ({ peerId, sessionId })),
+    ).toEqual(before.map(({ peerId, sessionId }) => ({ peerId, sessionId })));
+    expect(after).toEqual([
+      expect.objectContaining({
+        accessMode: COLLAB_ACCESS_MODE.Authenticated,
+        canWrite: true,
+        credential: { kind: "access-token", token: "test-token" },
+        documentId,
+        role: "EDITOR",
+        sessionId: "hibernate-author",
+      }),
+      expect.objectContaining({
+        accessMode: COLLAB_ACCESS_MODE.Public,
+        actorId: null,
+        canWrite: false,
+        credential: { kind: "public" },
+        documentId,
+        role: null,
+        sessionId: "hibernate-reader",
+      }),
+    ]);
+    expect(after[0]!.quota.count).toBeGreaterThan(before[0]!.quota.count);
+    expect(after[1]!.quota.count).toBeGreaterThan(before[1]!.quota.count);
+    const audit = await sessionAudit(stub);
+    expect(
+      audit.refreshes
+        .map(({ peerId, session }) => ({
+          peerId,
+          sessionId: session.sessionId,
+        }))
+        .sort((left, right) => left.sessionId.localeCompare(right.sessionId)),
+    ).toEqual(before.map(({ peerId, sessionId }) => ({ peerId, sessionId })));
+  });
+
+  it("revalidates and revokes an attached session when hibernation ends", async () => {
+    const documentId = "00000000-0000-4000-8000-000000000051";
+    const author = await connect();
+    await expect(
+      authenticate(author, documentId, "revoked-session"),
+    ).resolves.toMatchObject({
+      type: COLLAB_MESSAGE_TYPE.Ready,
+      documentId,
+      canWrite: true,
+    });
+
+    const stub = env.DOCUMENT_ROOMS.getByName(documentId);
+    await runInDurableObject(stub, (_instance, state) =>
+      setMemoryAuthenticatedAccessRevoked(state.storage, true),
+    );
+    const closed = author.closed();
+    await evictDurableObject(stub, { webSockets: "hibernate" });
+    author.send({
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      type: COLLAB_MESSAGE_TYPE.RepairRequest,
+      requestId: "revoked-wake",
+      afterCursor: "0",
+    });
+
+    await expect(closed).resolves.toMatchObject({
+      code: 1008,
+      reason: "Collaboration access was revoked",
+    });
+    const audit = await sessionAudit(stub);
+    expect(audit.refreshes).toEqual([
+      expect.objectContaining({
+        credential: { kind: "access-token", token: "test-token" },
+        session: expect.objectContaining({ sessionId: "revoked-session" }),
+      }),
+    ]);
+    expect(audit.ends).toEqual([
+      expect.objectContaining({
+        reason: DOCUMENT_SESSION_END_REASON.AccessRevoked,
+        session: expect.objectContaining({ sessionId: "revoked-session" }),
+      }),
+    ]);
+  });
+
+  it("releases runtime resources after WebSocket close and error events", async () => {
+    const closeDocumentId = "00000000-0000-4000-8000-000000000061";
+    const closing = await connect();
+    await expect(
+      authenticate(closing, closeDocumentId, "closing-session"),
+    ).resolves.toMatchObject({ type: COLLAB_MESSAGE_TYPE.Ready });
+    const closeStub = env.DOCUMENT_ROOMS.getByName(closeDocumentId);
+    const closedNormally = closing.closed();
+    closing.close();
+    await expect(closedNormally).resolves.toMatchObject({ code: 1000 });
+    await vi.waitFor(async () => {
+      await expect(sessionAudit(closeStub)).resolves.toMatchObject({
+        ends: [
+          expect.objectContaining({
+            reason: DOCUMENT_SESSION_END_REASON.PeerLeft,
+            session: expect.objectContaining({ sessionId: "closing-session" }),
+          }),
+        ],
+      });
+    });
+
+    const errorDocumentId = "00000000-0000-4000-8000-000000000062";
+    const failing = await connect();
+    await expect(
+      authenticate(failing, errorDocumentId, "error-session"),
+    ).resolves.toMatchObject({ type: COLLAB_MESSAGE_TYPE.Ready });
+    const errorStub = env.DOCUMENT_ROOMS.getByName(errorDocumentId);
+    const closedWithError = failing.closed();
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await runInDurableObject(errorStub, async (instance, state) => {
+        const socket = state.getWebSockets()[0];
+        if (socket === undefined) throw new Error("Expected a server socket");
+        await instance.webSocketError(
+          socket,
+          new Error("test transport error"),
+        );
+      });
+    } finally {
+      errorLog.mockRestore();
+    }
+    await expect(closedWithError).resolves.toMatchObject({
+      code: 1011,
+      reason: "Collaboration transport failure",
+    });
+    await vi.waitFor(async () => {
+      await expect(sessionAudit(errorStub)).resolves.toMatchObject({
+        ends: [
+          expect.objectContaining({
+            reason: DOCUMENT_SESSION_END_REASON.PeerLeft,
+            session: expect.objectContaining({ sessionId: "error-session" }),
+          }),
+        ],
+      });
+    });
+  });
+
+  it("removes sockets closed or failed while their room is hibernating", async () => {
+    const closeDocumentId = "00000000-0000-4000-8000-000000000071";
+    const closing = await connect();
+    await expect(
+      authenticate(closing, closeDocumentId, "hibernating-close"),
+    ).resolves.toMatchObject({ type: COLLAB_MESSAGE_TYPE.Ready });
+    const closeStub = env.DOCUMENT_ROOMS.getByName(closeDocumentId);
+    await evictDurableObject(closeStub, { webSockets: "hibernate" });
+    const closedNormally = closing.closed();
+    closing.close();
+    await expect(closedNormally).resolves.toMatchObject({ code: 1000 });
+    await vi.waitFor(async () => {
+      await expect(
+        runInDurableObject(
+          closeStub,
+          (_instance, state) => state.getWebSockets().length,
+        ),
+      ).resolves.toBe(0);
+    });
+
+    const errorDocumentId = "00000000-0000-4000-8000-000000000072";
+    const failing = await connect();
+    await expect(
+      authenticate(failing, errorDocumentId, "hibernating-error"),
+    ).resolves.toMatchObject({ type: COLLAB_MESSAGE_TYPE.Ready });
+    const errorStub = env.DOCUMENT_ROOMS.getByName(errorDocumentId);
+    await evictDurableObject(errorStub, { webSockets: "hibernate" });
+    const closedWithError = failing.closed();
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await runInDurableObject(errorStub, async (instance, state) => {
+        const socket = state.getWebSockets()[0];
+        if (socket === undefined) throw new Error("Expected a server socket");
+        await instance.webSocketError(
+          socket,
+          new Error("test transport error"),
+        );
+      });
+    } finally {
+      errorLog.mockRestore();
+    }
+    await expect(closedWithError).resolves.toMatchObject({
+      code: 1011,
+      reason: "Collaboration transport failure",
+    });
+    await vi.waitFor(async () => {
+      await expect(
+        runInDurableObject(
+          errorStub,
+          (_instance, state) => state.getWebSockets().length,
+        ),
+      ).resolves.toBe(0);
     });
   });
 

--- a/apps/collab-cloudflare/test/memory-backend.ts
+++ b/apps/collab-cloudflare/test/memory-backend.ts
@@ -3,6 +3,7 @@ import { BOOTSTRAP_EVENT_ID } from "@softmaple/block-model";
 import {
   COLLAB_ACCESS_MODE,
   type CollabCredential,
+  type SupportedCollabProtocolVersion,
 } from "@softmaple/collab-protocol";
 import {
   DOCUMENT_EVENT_CONFLICT_TYPE,
@@ -10,17 +11,66 @@ import {
   DocumentEventConflictError,
   type DocumentAccess,
   type DocumentEventStore,
+  type DocumentSession,
+  type DocumentSessionEndReason,
   type DocumentSessionHooks,
 } from "@softmaple/collab-runtime";
 
 const TEST_ACTOR_ID = "00000000-0000-4000-8000-000000000002";
 const TEST_ACCESS_TOKEN = "test-token";
 
+const STORAGE_KEY = {
+  authorization: "test-backend:authorization",
+  events: "test-backend:events",
+  sessionAudit: "test-backend:session-audit",
+} as const;
+
 interface StoredBatch {
   readonly cursor: bigint;
   readonly payload: Parameters<DocumentEventStore["append"]>[2][number];
   readonly serialized: string;
 }
+
+interface StoredAuthorizationState {
+  readonly authenticatedAccessRevoked: boolean;
+  readonly publicAccessEnabled: boolean;
+}
+
+export interface MemoryAuthorizeAuditEntry {
+  readonly credential: CollabCredential;
+  readonly documentId: string;
+  readonly peerId: string;
+  readonly protocolVersion: SupportedCollabProtocolVersion;
+  readonly sessionId: string;
+}
+
+export interface MemoryRefreshAuditEntry {
+  readonly credential: CollabCredential;
+  readonly peerId: string;
+  readonly session: DocumentSession;
+}
+
+export interface MemoryEndAuditEntry {
+  readonly reason: DocumentSessionEndReason;
+  readonly session: DocumentSession;
+}
+
+export interface MemorySessionAudit {
+  readonly authorizations: ReadonlyArray<MemoryAuthorizeAuditEntry>;
+  readonly refreshes: ReadonlyArray<MemoryRefreshAuditEntry>;
+  readonly ends: ReadonlyArray<MemoryEndAuditEntry>;
+}
+
+const defaultAuthorizationState = (): StoredAuthorizationState => ({
+  authenticatedAccessRevoked: false,
+  publicAccessEnabled: true,
+});
+
+const emptySessionAudit = (): MemorySessionAudit => ({
+  authorizations: [],
+  refreshes: [],
+  ends: [],
+});
 
 const canonicalJson = (value: unknown): string => {
   if (
@@ -46,16 +96,24 @@ const canonicalJson = (value: unknown): string => {
 
 const accessForCredential = (
   credential: CollabCredential,
+  state: StoredAuthorizationState,
 ): DocumentAccess | null => {
   if (credential.kind === "public") {
-    return {
-      accessMode: COLLAB_ACCESS_MODE.Public,
-      actorId: null,
-      canWrite: false,
-      role: null,
-    };
+    return state.publicAccessEnabled
+      ? {
+          accessMode: COLLAB_ACCESS_MODE.Public,
+          actorId: null,
+          canWrite: false,
+          role: null,
+        }
+      : null;
   }
-  if (credential.token !== TEST_ACCESS_TOKEN) return null;
+  if (
+    credential.token !== TEST_ACCESS_TOKEN ||
+    state.authenticatedAccessRevoked
+  ) {
+    return null;
+  }
   return {
     accessMode: COLLAB_ACCESS_MODE.Authenticated,
     actorId: TEST_ACTOR_ID,
@@ -64,6 +122,97 @@ const accessForCredential = (
   };
 };
 
+const authorizationState = async (
+  transaction: DurableObjectTransaction,
+): Promise<StoredAuthorizationState> => {
+  const stored = await transaction.get<StoredAuthorizationState>(
+    STORAGE_KEY.authorization,
+  );
+  if (stored !== undefined) return stored;
+  const initial = defaultAuthorizationState();
+  await transaction.put(STORAGE_KEY.authorization, initial);
+  return initial;
+};
+
+const appendAuthorizationAudit = async (
+  storage: DurableObjectStorage,
+  entry: MemoryAuthorizeAuditEntry,
+): Promise<StoredAuthorizationState> =>
+  storage.transaction(async (transaction) => {
+    const state = await authorizationState(transaction);
+    const audit =
+      (await transaction.get<MemorySessionAudit>(STORAGE_KEY.sessionAudit)) ??
+      emptySessionAudit();
+    await transaction.put(STORAGE_KEY.sessionAudit, {
+      ...audit,
+      authorizations: [...audit.authorizations, entry],
+    });
+    return state;
+  });
+
+const appendRefreshAudit = async (
+  storage: DurableObjectStorage,
+  entry: MemoryRefreshAuditEntry,
+): Promise<StoredAuthorizationState> =>
+  storage.transaction(async (transaction) => {
+    const state = await authorizationState(transaction);
+    const audit =
+      (await transaction.get<MemorySessionAudit>(STORAGE_KEY.sessionAudit)) ??
+      emptySessionAudit();
+    await transaction.put(STORAGE_KEY.sessionAudit, {
+      ...audit,
+      refreshes: [...audit.refreshes, entry],
+    });
+    return state;
+  });
+
+const appendEndAudit = async (
+  storage: DurableObjectStorage,
+  entry: MemoryEndAuditEntry,
+): Promise<void> => {
+  await storage.transaction(async (transaction) => {
+    const audit =
+      (await transaction.get<MemorySessionAudit>(STORAGE_KEY.sessionAudit)) ??
+      emptySessionAudit();
+    await transaction.put(STORAGE_KEY.sessionAudit, {
+      ...audit,
+      ends: [...audit.ends, entry],
+    });
+  });
+};
+
+export const setMemoryAuthenticatedAccessRevoked = async (
+  storage: DurableObjectStorage,
+  revoked: boolean,
+): Promise<void> => {
+  await storage.transaction(async (transaction) => {
+    const current = await authorizationState(transaction);
+    await transaction.put(STORAGE_KEY.authorization, {
+      ...current,
+      authenticatedAccessRevoked: revoked,
+    });
+  });
+};
+
+export const setMemoryPublicAccessEnabled = async (
+  storage: DurableObjectStorage,
+  enabled: boolean,
+): Promise<void> => {
+  await storage.transaction(async (transaction) => {
+    const current = await authorizationState(transaction);
+    await transaction.put(STORAGE_KEY.authorization, {
+      ...current,
+      publicAccessEnabled: enabled,
+    });
+  });
+};
+
+export const readMemorySessionAudit = async (
+  storage: DurableObjectStorage,
+): Promise<MemorySessionAudit> =>
+  (await storage.get<MemorySessionAudit>(STORAGE_KEY.sessionAudit)) ??
+  emptySessionAudit();
+
 export interface MemoryDocumentBackend {
   readonly events: DocumentEventStore;
   readonly sessions: DocumentSessionHooks;
@@ -71,11 +220,8 @@ export interface MemoryDocumentBackend {
 
 export const createMemoryDocumentBackend = (
   documentId: string,
+  storage: DurableObjectStorage,
 ): MemoryDocumentBackend => {
-  const stored: StoredBatch[] = [];
-  const batchesById = new Map<string, StoredBatch>();
-  const eventIds = new Set<string>();
-
   const events: DocumentEventStore = {
     async append(requestDocumentId, actorId, batches) {
       if (requestDocumentId !== documentId || actorId !== TEST_ACTOR_ID) {
@@ -84,112 +230,136 @@ export const createMemoryDocumentBackend = (
         );
       }
 
-      const incomingEventIds = batches.flatMap((batch) =>
-        batch.events.map((event) => event.id),
-      );
-      if (new Set(incomingEventIds).size !== incomingEventIds.length) {
-        throw new DocumentEventConflictError(
-          "duplicate event IDs in incoming batches",
-          {
-            conflictType: DOCUMENT_EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
-            documentId,
-            eventIds: incomingEventIds,
-          },
+      return storage.transaction(async (transaction) => {
+        const stored =
+          (await transaction.get<ReadonlyArray<StoredBatch>>(
+            STORAGE_KEY.events,
+          )) ?? [];
+        const batchesById = new Map(
+          stored.map((entry) => [entry.payload.batchId, entry]),
         );
-      }
-
-      const availableEventIds = new Set<string>();
-      for (const batch of batches) {
-        const serialized = canonicalJson(batch);
-        const existing = batchesById.get(batch.batchId);
-        if (existing !== undefined) {
-          if (existing.serialized !== serialized) {
-            throw new DocumentEventConflictError(
-              `conflicting payload for batch ${batch.batchId}`,
-              {
-                batchIds: [batch.batchId],
-                conflictType: DOCUMENT_EVENT_CONFLICT_TYPE.BatchPayloadConflict,
-                documentId,
-              },
-            );
-          }
-          for (const event of batch.events) availableEventIds.add(event.id);
-          continue;
+        const eventIds = new Set(
+          stored.flatMap((entry) =>
+            entry.payload.events.map((event) => event.id),
+          ),
+        );
+        const incomingEventIds = batches.flatMap((batch) =>
+          batch.events.map((event) => event.id),
+        );
+        if (new Set(incomingEventIds).size !== incomingEventIds.length) {
+          throw new DocumentEventConflictError(
+            "duplicate event IDs in incoming batches",
+            {
+              conflictType:
+                DOCUMENT_EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
+              documentId,
+              eventIds: incomingEventIds,
+            },
+          );
         }
 
-        const seenInBatch = new Set<string>();
-        const requiredParents = new Set<string>();
-        for (const parentId of batch.parentVersion) {
-          if (
-            parentId !== BOOTSTRAP_EVENT_ID &&
-            !availableEventIds.has(parentId)
-          ) {
-            requiredParents.add(parentId);
+        const availableEventIds = new Set<string>();
+        const appended: StoredBatch[] = [];
+        for (const batch of batches) {
+          const serialized = canonicalJson(batch);
+          const existing = batchesById.get(batch.batchId);
+          if (existing !== undefined) {
+            if (existing.serialized !== serialized) {
+              throw new DocumentEventConflictError(
+                `conflicting payload for batch ${batch.batchId}`,
+                {
+                  batchIds: [batch.batchId],
+                  conflictType:
+                    DOCUMENT_EVENT_CONFLICT_TYPE.BatchPayloadConflict,
+                  documentId,
+                },
+              );
+            }
+            for (const event of batch.events) availableEventIds.add(event.id);
+            continue;
           }
-        }
-        for (const event of batch.events) {
-          for (const parentId of event.parentVersion) {
+
+          const seenInBatch = new Set<string>();
+          const requiredParents = new Set<string>();
+          for (const parentId of batch.parentVersion) {
             if (
               parentId !== BOOTSTRAP_EVENT_ID &&
-              !availableEventIds.has(parentId) &&
-              !seenInBatch.has(parentId)
+              !availableEventIds.has(parentId)
             ) {
               requiredParents.add(parentId);
             }
           }
-          seenInBatch.add(event.id);
+          for (const event of batch.events) {
+            for (const parentId of event.parentVersion) {
+              if (
+                parentId !== BOOTSTRAP_EVENT_ID &&
+                !availableEventIds.has(parentId) &&
+                !seenInBatch.has(parentId)
+              ) {
+                requiredParents.add(parentId);
+              }
+            }
+            seenInBatch.add(event.id);
+          }
+
+          const missingParentIds = [...requiredParents]
+            .filter((eventId) => !eventIds.has(eventId))
+            .sort();
+          if (missingParentIds.length > 0) {
+            throw new DocumentEventConflictError(
+              "event batch references document history that has not been stored",
+              {
+                batchIds: [batch.batchId],
+                conflictType: DOCUMENT_EVENT_CONFLICT_TYPE.MissingParentHistory,
+                documentId,
+                missingParentIds,
+              },
+            );
+          }
+
+          const conflictingEventIds = batch.events
+            .map((event) => event.id)
+            .filter((eventId) => eventIds.has(eventId));
+          if (conflictingEventIds.length > 0) {
+            throw new DocumentEventConflictError(
+              "event IDs conflict with stored document history",
+              {
+                batchIds: [batch.batchId],
+                conflictType:
+                  DOCUMENT_EVENT_CONFLICT_TYPE.StoredEventIdConflict,
+                documentId,
+                eventIds: conflictingEventIds,
+              },
+            );
+          }
+
+          const entry: StoredBatch = {
+            cursor: BigInt(stored.length + appended.length + 1),
+            payload: batch,
+            serialized,
+          };
+          appended.push(entry);
+          batchesById.set(batch.batchId, entry);
+          for (const event of batch.events) {
+            eventIds.add(event.id);
+            availableEventIds.add(event.id);
+          }
         }
 
-        const missingParentIds = [...requiredParents]
-          .filter((eventId) => !eventIds.has(eventId))
-          .sort();
-        if (missingParentIds.length > 0) {
-          throw new DocumentEventConflictError(
-            "event batch references document history that has not been stored",
-            {
-              batchIds: [batch.batchId],
-              conflictType: DOCUMENT_EVENT_CONFLICT_TYPE.MissingParentHistory,
-              documentId,
-              missingParentIds,
-            },
-          );
+        if (appended.length > 0) {
+          await transaction.put(STORAGE_KEY.events, [...stored, ...appended]);
         }
-
-        const conflictingEventIds = batch.events
-          .map((event) => event.id)
-          .filter((eventId) => eventIds.has(eventId));
-        if (conflictingEventIds.length > 0) {
-          throw new DocumentEventConflictError(
-            "event IDs conflict with stored document history",
-            {
-              batchIds: [batch.batchId],
-              conflictType: DOCUMENT_EVENT_CONFLICT_TYPE.StoredEventIdConflict,
-              documentId,
-              eventIds: conflictingEventIds,
-            },
-          );
-        }
-
-        const entry: StoredBatch = {
-          cursor: BigInt(stored.length + 1),
-          payload: batch,
-          serialized,
-        };
-        stored.push(entry);
-        batchesById.set(batch.batchId, entry);
-        for (const event of batch.events) {
-          eventIds.add(event.id);
-          availableEventIds.add(event.id);
-        }
-      }
-
-      return batches.map((batch) => batch.batchId);
+        return batches.map((batch) => batch.batchId);
+      });
     },
 
     async read(requestDocumentId, afterCursor) {
       if (requestDocumentId !== documentId) {
         return { batches: [], complete: true, nextCursor: afterCursor };
       }
+      const stored =
+        (await storage.get<ReadonlyArray<StoredBatch>>(STORAGE_KEY.events)) ??
+        [];
       const cursor = BigInt(afterCursor);
       const remaining = stored.filter((entry) => entry.cursor > cursor);
       const page = remaining.slice(0, 100);
@@ -203,14 +373,19 @@ export const createMemoryDocumentBackend = (
 
   const sessions: DocumentSessionHooks = {
     async authorize(request) {
+      const state = await appendAuthorizationAudit(storage, request);
       return request.documentId === documentId
-        ? accessForCredential(request.credential)
+        ? accessForCredential(request.credential, state)
         : null;
     },
     async refresh(request) {
+      const state = await appendRefreshAudit(storage, request);
       return request.session.documentId === documentId
-        ? accessForCredential(request.credential)
+        ? accessForCredential(request.credential, state)
         : null;
+    },
+    async end(session, reason) {
+      await appendEndAudit(storage, { reason, session });
     },
   };
 

--- a/apps/collab-cloudflare/test/memory-backend.ts
+++ b/apps/collab-cloudflare/test/memory-backend.ts
@@ -22,7 +22,10 @@ const TEST_ACCESS_TOKEN = "test-token";
 const STORAGE_KEY = {
   authorization: "test-backend:authorization",
   events: "test-backend:events",
-  sessionAudit: "test-backend:session-audit",
+  sessionAuditAuthorization: "test-backend:session-audit:authorization:",
+  sessionAuditEnd: "test-backend:session-audit:end:",
+  sessionAuditRefresh: "test-backend:session-audit:refresh:",
+  sessionAuditSequence: "test-backend:session-audit:sequence",
 } as const;
 
 interface StoredBatch {
@@ -64,12 +67,6 @@ export interface MemorySessionAudit {
 const defaultAuthorizationState = (): StoredAuthorizationState => ({
   authenticatedAccessRevoked: false,
   publicAccessEnabled: true,
-});
-
-const emptySessionAudit = (): MemorySessionAudit => ({
-  authorizations: [],
-  refreshes: [],
-  ends: [],
 });
 
 const canonicalJson = (value: unknown): string => {
@@ -134,19 +131,27 @@ const authorizationState = async (
   return initial;
 };
 
+const nextAuditSequence = async (
+  transaction: DurableObjectTransaction,
+): Promise<number> => {
+  const sequence =
+    ((await transaction.get<number>(STORAGE_KEY.sessionAuditSequence)) ?? 0) +
+    1;
+  await transaction.put(STORAGE_KEY.sessionAuditSequence, sequence);
+  return sequence;
+};
+
 const appendAuthorizationAudit = async (
   storage: DurableObjectStorage,
   entry: MemoryAuthorizeAuditEntry,
 ): Promise<StoredAuthorizationState> =>
   storage.transaction(async (transaction) => {
     const state = await authorizationState(transaction);
-    const audit =
-      (await transaction.get<MemorySessionAudit>(STORAGE_KEY.sessionAudit)) ??
-      emptySessionAudit();
-    await transaction.put(STORAGE_KEY.sessionAudit, {
-      ...audit,
-      authorizations: [...audit.authorizations, entry],
-    });
+    const sequence = await nextAuditSequence(transaction);
+    await transaction.put(
+      `${STORAGE_KEY.sessionAuditAuthorization}${sequence}`,
+      entry,
+    );
     return state;
   });
 
@@ -156,13 +161,11 @@ const appendRefreshAudit = async (
 ): Promise<StoredAuthorizationState> =>
   storage.transaction(async (transaction) => {
     const state = await authorizationState(transaction);
-    const audit =
-      (await transaction.get<MemorySessionAudit>(STORAGE_KEY.sessionAudit)) ??
-      emptySessionAudit();
-    await transaction.put(STORAGE_KEY.sessionAudit, {
-      ...audit,
-      refreshes: [...audit.refreshes, entry],
-    });
+    const sequence = await nextAuditSequence(transaction);
+    await transaction.put(
+      `${STORAGE_KEY.sessionAuditRefresh}${sequence}`,
+      entry,
+    );
     return state;
   });
 
@@ -171,13 +174,8 @@ const appendEndAudit = async (
   entry: MemoryEndAuditEntry,
 ): Promise<void> => {
   await storage.transaction(async (transaction) => {
-    const audit =
-      (await transaction.get<MemorySessionAudit>(STORAGE_KEY.sessionAudit)) ??
-      emptySessionAudit();
-    await transaction.put(STORAGE_KEY.sessionAudit, {
-      ...audit,
-      ends: [...audit.ends, entry],
-    });
+    const sequence = await nextAuditSequence(transaction);
+    await transaction.put(`${STORAGE_KEY.sessionAuditEnd}${sequence}`, entry);
   });
 };
 
@@ -207,11 +205,32 @@ export const setMemoryPublicAccessEnabled = async (
   });
 };
 
+const listedAuditEntries = async <T>(
+  storage: DurableObjectStorage,
+  prefix: string,
+): Promise<ReadonlyArray<T>> => {
+  const entries = await storage.list<T>({ prefix });
+  return [...entries.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([, value]) => value);
+};
+
 export const readMemorySessionAudit = async (
   storage: DurableObjectStorage,
-): Promise<MemorySessionAudit> =>
-  (await storage.get<MemorySessionAudit>(STORAGE_KEY.sessionAudit)) ??
-  emptySessionAudit();
+): Promise<MemorySessionAudit> => ({
+  authorizations: await listedAuditEntries<MemoryAuthorizeAuditEntry>(
+    storage,
+    STORAGE_KEY.sessionAuditAuthorization,
+  ),
+  refreshes: await listedAuditEntries<MemoryRefreshAuditEntry>(
+    storage,
+    STORAGE_KEY.sessionAuditRefresh,
+  ),
+  ends: await listedAuditEntries<MemoryEndAuditEntry>(
+    storage,
+    STORAGE_KEY.sessionAuditEnd,
+  ),
+});
 
 export interface MemoryDocumentBackend {
   readonly events: DocumentEventStore;

--- a/apps/collab-cloudflare/test/worker.ts
+++ b/apps/collab-cloudflare/test/worker.ts
@@ -8,7 +8,7 @@ export class TestDocumentRoomDO extends DocumentRoomDO {
   protected override createServices(documentId: string): DocumentRoomServices {
     return createRoomServicesForBackend(
       documentId,
-      createMemoryDocumentBackend(documentId),
+      createMemoryDocumentBackend(documentId, this.ctx.storage),
     );
   }
 }

--- a/packages/collab-runtime/src/document-room-implementation.ts
+++ b/packages/collab-runtime/src/document-room-implementation.ts
@@ -21,11 +21,17 @@ import {
 } from "./document-session";
 import type {
   DocumentRoom,
+  DocumentRoomOptions,
+  DocumentRoomResumeState,
   DocumentRoomServices,
   RoomLeaveReason,
   RoomPeer,
 } from "./document-room";
-import { ROOM_LEAVE_REASON } from "./document-room";
+import {
+  DOCUMENT_ROOM_REFRESH_MODE,
+  ROOM_LEAVE_REASON,
+  type DocumentRoomRefreshMode,
+} from "./document-room";
 import {
   DocumentEventAuthorizationError,
   DocumentEventConflictError,
@@ -185,15 +191,23 @@ class RuntimeDocumentRoom implements DocumentRoom {
   private fanoutQueue: Promise<void> = Promise.resolve();
   private fanoutRetainers = 0;
   private fanoutSubscription: RoomFanoutSubscription | null = null;
+  private messageMaintenanceQueue: Promise<void> = Promise.resolve();
   private readonly peers = new Map<RoomPeer, PeerState>();
+  private readonly refreshMode: DocumentRoomRefreshMode;
   private readonly services: DocumentRoomServices;
 
-  constructor(documentId: string, services: DocumentRoomServices) {
+  constructor(
+    documentId: string,
+    services: DocumentRoomServices,
+    options: DocumentRoomOptions = {},
+  ) {
     if (documentId.length === 0) {
       throw new Error("DocumentRoom requires a non-empty document id");
     }
     this.assertPolicy(services);
     this.documentId = documentId;
+    this.refreshMode =
+      options.refreshMode ?? DOCUMENT_ROOM_REFRESH_MODE.Background;
     this.services = services;
   }
 
@@ -207,6 +221,31 @@ class RuntimeDocumentRoom implements DocumentRoom {
       return;
     }
     if (!this.peers.has(peer)) this.peers.set(peer, createPeerState(peer));
+  }
+
+  async resume(
+    peer: RoomPeer,
+    resumed: DocumentRoomResumeState,
+  ): Promise<DocumentSession | null> {
+    await this.join(peer);
+    const state = this.peers.get(peer);
+    if (state === undefined || this.closed) return null;
+
+    if (state.phase !== PEER_PHASE.Joined) {
+      state.leaveRequested = true;
+      await this.closePeer(peer, 1008, "Already authenticated");
+      await this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          DOCUMENT_SESSION_END_REASON.PeerLeft,
+        );
+      });
+      return null;
+    }
+
+    state.phase = PEER_PHASE.Authenticating;
+    return this.enqueue(state, async () => this.resumeSession(state, resumed));
   }
 
   async receive(peer: RoomPeer, message: ClientCollabMessage): Promise<void> {
@@ -243,6 +282,23 @@ class RuntimeDocumentRoom implements DocumentRoom {
         ),
         message.type,
       );
+      return;
+    }
+
+    if (this.refreshMode === DOCUMENT_ROOM_REFRESH_MODE.OnMessage) {
+      await this.withMessageMaintenanceLock(async () => {
+        await this.maintainPeersForMessage(message.type);
+      });
+      await this.enqueue(state, async () => {
+        if (state.phase !== PEER_PHASE.Authenticated || state.leaveRequested) {
+          return;
+        }
+        if (message.type === COLLAB_MESSAGE_TYPE.RepairRequest) {
+          await this.receiveRepair(state, message);
+          return;
+        }
+        await this.receiveEvent(state, message);
+      });
       return;
     }
 
@@ -513,6 +569,134 @@ class RuntimeDocumentRoom implements DocumentRoom {
     }
   }
 
+  private async resumeSession(
+    state: PeerState,
+    resumed: DocumentRoomResumeState,
+  ): Promise<DocumentSession | null> {
+    if (resumed.session.documentId !== this.documentId) {
+      state.leaveRequested = true;
+      await this.closePeer(state.peer, 1008, "Unauthorized");
+      await this.resetState(
+        state,
+        true,
+        DOCUMENT_SESSION_END_REASON.AccessRevoked,
+      );
+      return null;
+    }
+
+    state.credential = resumed.credential;
+    state.session = resumed.session;
+
+    let access: DocumentAccess | null;
+    try {
+      access = await this.services.sessions.refresh({
+        credential: resumed.credential,
+        peerId: state.peer.id,
+        session: resumed.session,
+      });
+    } catch (error) {
+      this.report(error, state, "authorization-recheck");
+      state.leaveRequested = true;
+      await this.closePeer(state.peer, 1011, "Authorization recheck failed");
+      await this.resetState(state, true, DOCUMENT_SESSION_END_REASON.PeerLeft);
+      return null;
+    }
+
+    if (state.leaveRequested || this.closed) {
+      await this.resetState(
+        state,
+        true,
+        this.closed
+          ? DOCUMENT_SESSION_END_REASON.RoomClosed
+          : DOCUMENT_SESSION_END_REASON.PeerLeft,
+      );
+      return null;
+    }
+    if (
+      access === null ||
+      !accessMatchesSessionIdentity(access, resumed.session)
+    ) {
+      state.leaveRequested = true;
+      await this.closePeer(
+        state.peer,
+        1008,
+        "Collaboration access was revoked",
+      );
+      await this.resetState(
+        state,
+        true,
+        DOCUMENT_SESSION_END_REASON.AccessRevoked,
+      );
+      return null;
+    }
+
+    const session = sessionWithRefreshedAccess(resumed.session, access);
+    state.session = session;
+    try {
+      const admission = await this.services.connections.acquire({
+        documentId: this.documentId,
+        peerId: state.peer.id,
+        policy: this.services.policy.connection,
+        sessionId: session.sessionId,
+      });
+      if (!admission.accepted) {
+        state.leaveRequested = true;
+        await this.closePeer(
+          state.peer,
+          1013,
+          "Collaboration connection lease was lost",
+        );
+        await this.resetState(
+          state,
+          true,
+          DOCUMENT_SESSION_END_REASON.PeerLeft,
+        );
+        return null;
+      }
+      state.lease = admission.lease;
+      if (state.leaveRequested || this.closed) {
+        await this.resetState(
+          state,
+          true,
+          this.closed
+            ? DOCUMENT_SESSION_END_REASON.RoomClosed
+            : DOCUMENT_SESSION_END_REASON.PeerLeft,
+        );
+        return null;
+      }
+
+      await this.retainFanout(state);
+      if (state.leaveRequested || this.closed) {
+        await this.resetState(
+          state,
+          true,
+          this.closed
+            ? DOCUMENT_SESSION_END_REASON.RoomClosed
+            : DOCUMENT_SESSION_END_REASON.PeerLeft,
+        );
+        return null;
+      }
+
+      state.authorizationExpiresAt =
+        Date.now() + this.services.policy.authorizationRefreshIntervalMs;
+      state.leaseRefreshAt =
+        Date.now() + this.services.policy.connection.leaseRefreshIntervalMs;
+      state.phase = PEER_PHASE.Authenticated;
+      this.startRefreshTimers(state);
+      return session;
+    } catch (error) {
+      this.report(error, state, "session-resume");
+      state.leaveRequested = true;
+      await this.closePeer(
+        state.peer,
+        1011,
+        "Collaboration runtime unavailable",
+      );
+      await this.resetState(state, true, DOCUMENT_SESSION_END_REASON.PeerLeft);
+      return null;
+    }
+  }
+
   private async failTemporaryAuthentication(
     state: PeerState,
     message: AuthMessage | LegacyAuthMessage,
@@ -609,7 +793,74 @@ class RuntimeDocumentRoom implements DocumentRoom {
     state.session = sessionWithRefreshedAccess(session, access);
     state.authorizationExpiresAt =
       Date.now() + this.services.policy.authorizationRefreshIntervalMs;
-    this.scheduleAuthorizationRefresh(state);
+    if (this.refreshMode === DOCUMENT_ROOM_REFRESH_MODE.Background) {
+      this.scheduleAuthorizationRefresh(state);
+    }
+    return true;
+  }
+
+  private async maintainPeersForMessage(messageType: string): Promise<void> {
+    const now = Date.now();
+    const candidates = [...this.peers.values()].filter(
+      (state) =>
+        state.phase === PEER_PHASE.Authenticated &&
+        !state.leaveRequested &&
+        (state.authorizationExpiresAt <= now || state.leaseRefreshAt <= now),
+    );
+    await Promise.all(
+      candidates.map(async (state) => {
+        await this.enqueue(state, async () => {
+          await this.maintainPeerForMessage(state, messageType);
+        });
+      }),
+    );
+  }
+
+  private async maintainPeerForMessage(
+    state: PeerState,
+    messageType: string,
+  ): Promise<boolean> {
+    if (state.phase !== PEER_PHASE.Authenticated || state.leaveRequested) {
+      return false;
+    }
+    if (!(await this.refreshAuthorizationForMessage(state, messageType))) {
+      return false;
+    }
+    return this.refreshLeaseForMessage(state);
+  }
+
+  private async refreshLeaseForMessage(state: PeerState): Promise<boolean> {
+    if (state.leaseRefreshAt > Date.now()) return true;
+    const session = state.session;
+    const lease = state.lease;
+    if (session === null || lease === null) return false;
+
+    let leaseAlive: boolean;
+    try {
+      leaseAlive = await lease.refresh();
+    } catch (error) {
+      if (!this.isCurrentAuthenticatedSession(state, session)) return false;
+      this.report(error, state, "lease-refresh");
+      state.leaveRequested = true;
+      await this.closePeer(state.peer, 1011, "Connection lease refresh failed");
+      await this.resetState(state, true, DOCUMENT_SESSION_END_REASON.PeerLeft);
+      return false;
+    }
+
+    if (!this.isCurrentAuthenticatedSession(state, session)) return false;
+    if (!leaseAlive) {
+      state.leaveRequested = true;
+      await this.closePeer(
+        state.peer,
+        1013,
+        "Collaboration connection lease was lost",
+      );
+      await this.resetState(state, true, DOCUMENT_SESSION_END_REASON.PeerLeft);
+      return false;
+    }
+
+    state.leaseRefreshAt =
+      Date.now() + this.services.policy.connection.leaseRefreshIntervalMs;
     return true;
   }
 
@@ -627,6 +878,12 @@ class RuntimeDocumentRoom implements DocumentRoom {
         this.documentId,
         message.afterCursor,
       );
+      if (
+        this.refreshMode === DOCUMENT_ROOM_REFRESH_MODE.OnMessage &&
+        !(await this.maintainPeerForMessage(state, message.type))
+      ) {
+        return;
+      }
       if (!this.isCurrentAuthenticatedSession(state, session)) {
         return;
       }
@@ -711,15 +968,26 @@ class RuntimeDocumentRoom implements DocumentRoom {
 
     // A durable append must fan out even if the origin disconnects while the
     // write is in flight. A failed acknowledgement send is therefore isolated.
-    await this.sendIgnoringFailure(
-      state.peer,
-      {
-        protocolVersion: session.protocolVersion,
-        type: COLLAB_MESSAGE_TYPE.DurableAck,
-        batchIds,
-      },
-      message.type,
-    );
+    let senderActive =
+      this.refreshMode !== DOCUMENT_ROOM_REFRESH_MODE.OnMessage;
+    if (!senderActive) {
+      try {
+        senderActive = await this.maintainPeerForMessage(state, message.type);
+      } catch (error) {
+        this.report(error, state, "post-append-maintenance");
+      }
+    }
+    if (senderActive) {
+      await this.sendIgnoringFailure(
+        state.peer,
+        {
+          protocolVersion: session.protocolVersion,
+          type: COLLAB_MESSAGE_TYPE.DurableAck,
+          batchIds,
+        },
+        message.type,
+      );
+    }
     try {
       await this.services.fanout.publish({
         documentId: this.documentId,
@@ -731,6 +999,7 @@ class RuntimeDocumentRoom implements DocumentRoom {
   }
 
   private startRefreshTimers(state: PeerState): void {
+    if (this.refreshMode !== DOCUMENT_ROOM_REFRESH_MODE.Background) return;
     this.scheduleAuthorizationRefresh(state);
     this.scheduleLeaseRefresh(state);
   }
@@ -921,11 +1190,27 @@ class RuntimeDocumentRoom implements DocumentRoom {
           this.documentId,
           async (event) => {
             if (event.documentId !== this.documentId) return;
-            const recipients = [...this.peers.values()].filter(
+            const now = Date.now();
+            const active = [...this.peers.values()].filter(
               (candidate) =>
                 candidate.phase === PEER_PHASE.Authenticated &&
                 !candidate.leaveRequested &&
                 candidate.session !== null,
+            );
+            if (this.refreshMode === DOCUMENT_ROOM_REFRESH_MODE.OnMessage) {
+              const expired = active.filter(
+                (candidate) =>
+                  candidate.authorizationExpiresAt <= now ||
+                  candidate.leaseRefreshAt <= now,
+              );
+              await Promise.all(
+                expired.map(async (candidate) => {
+                  await this.closeExpiredFanoutPeer(candidate);
+                }),
+              );
+            }
+            const recipients = active.filter(
+              (candidate) => !candidate.leaveRequested,
             );
             await Promise.all(
               recipients.map(async (recipient) => {
@@ -947,6 +1232,23 @@ class RuntimeDocumentRoom implements DocumentRoom {
       }
       this.fanoutRetainers += 1;
       state.fanoutRetained = true;
+    });
+  }
+
+  private async closeExpiredFanoutPeer(state: PeerState): Promise<void> {
+    if (state.phase !== PEER_PHASE.Authenticated || state.leaveRequested) {
+      return;
+    }
+    state.leaveRequested = true;
+    await this.closePeer(
+      state.peer,
+      1012,
+      "Collaboration session requires revalidation",
+    );
+    void this.enqueue(state, async () => {
+      await this.resetState(state, true, DOCUMENT_SESSION_END_REASON.PeerLeft);
+    }).catch((error: unknown) => {
+      this.report(error, state, "expired-fanout-cleanup");
     });
   }
 
@@ -1033,9 +1335,18 @@ class RuntimeDocumentRoom implements DocumentRoom {
     }
   }
 
-  private enqueue(state: PeerState, work: () => Promise<void>): Promise<void> {
+  private enqueue<T>(state: PeerState, work: () => Promise<T>): Promise<T> {
     const operation = state.queue.then(work, work);
-    state.queue = operation.catch(() => undefined);
+    state.queue = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
+  private withMessageMaintenanceLock(work: () => Promise<void>): Promise<void> {
+    const operation = this.messageMaintenanceQueue.then(work, work);
+    this.messageMaintenanceQueue = operation.catch(() => undefined);
     return operation;
   }
 
@@ -1107,4 +1418,5 @@ class RuntimeDocumentRoom implements DocumentRoom {
 export const createDocumentRoom = (
   documentId: string,
   services: DocumentRoomServices,
-): DocumentRoom => new RuntimeDocumentRoom(documentId, services);
+  options?: DocumentRoomOptions,
+): DocumentRoom => new RuntimeDocumentRoom(documentId, services, options);

--- a/packages/collab-runtime/src/document-room-implementation.ts
+++ b/packages/collab-runtime/src/document-room-implementation.ts
@@ -61,6 +61,7 @@ interface PeerState {
   phase: PeerPhase;
   readonly peer: RoomPeer;
   queue: Promise<void>;
+  queuePending: number;
   session: DocumentSession | null;
 }
 
@@ -78,6 +79,7 @@ const createPeerState = (peer: RoomPeer): PeerState => ({
   phase: PEER_PHASE.Joined,
   peer,
   queue: Promise.resolve(),
+  queuePending: 0,
   session: null,
 });
 
@@ -805,6 +807,7 @@ class RuntimeDocumentRoom implements DocumentRoom {
       (state) =>
         state.phase === PEER_PHASE.Authenticated &&
         !state.leaveRequested &&
+        state.queuePending === 0 &&
         (state.authorizationExpiresAt <= now || state.leaseRefreshAt <= now),
     );
     await Promise.all(
@@ -1336,7 +1339,10 @@ class RuntimeDocumentRoom implements DocumentRoom {
   }
 
   private enqueue<T>(state: PeerState, work: () => Promise<T>): Promise<T> {
-    const operation = state.queue.then(work, work);
+    state.queuePending += 1;
+    const operation = state.queue.then(work, work).finally(() => {
+      state.queuePending -= 1;
+    });
     state.queue = operation.then(
       () => undefined,
       () => undefined,

--- a/packages/collab-runtime/src/document-room.ts
+++ b/packages/collab-runtime/src/document-room.ts
@@ -1,9 +1,10 @@
 import type {
   ClientCollabMessage,
+  CollabCredential,
   ServerCollabMessage,
 } from "@softmaple/collab-protocol";
 import type { ConnectionLimiter, ConnectionPolicy } from "./connection-limiter";
-import type { DocumentSessionHooks } from "./document-session";
+import type { DocumentSession, DocumentSessionHooks } from "./document-session";
 import type { DocumentEventStore } from "./event-store";
 import type { RoomFanout } from "./room-fanout";
 
@@ -22,6 +23,25 @@ export const ROOM_LEAVE_REASON = {
 
 export type RoomLeaveReason =
   (typeof ROOM_LEAVE_REASON)[keyof typeof ROOM_LEAVE_REASON];
+
+export const DOCUMENT_ROOM_REFRESH_MODE = {
+  Background: "background",
+  OnMessage: "on-message",
+} as const;
+
+export type DocumentRoomRefreshMode =
+  (typeof DOCUMENT_ROOM_REFRESH_MODE)[keyof typeof DOCUMENT_ROOM_REFRESH_MODE];
+
+export interface DocumentRoomOptions {
+  /** Background timers are the default; hibernating hosts refresh on messages. */
+  readonly refreshMode?: DocumentRoomRefreshMode;
+}
+
+/** Server-owned session metadata restored by a hibernating transport host. */
+export interface DocumentRoomResumeState {
+  readonly credential: CollabCredential;
+  readonly session: DocumentSession;
+}
 
 export interface DocumentRoomPolicy {
   /** Positive cadence for revalidating cached document access. */
@@ -81,6 +101,15 @@ export type DocumentRoomErrorReporter = (
 export interface DocumentRoom {
   readonly documentId: string;
   join(peer: RoomPeer): Promise<void>;
+  /**
+   * Restores an already-established transport session without another wire Auth
+   * or Ready exchange. Access is always revalidated before resources are
+   * reacquired. A null result means the peer was closed and cleaned up.
+   */
+  resume(
+    peer: RoomPeer,
+    state: DocumentRoomResumeState,
+  ): Promise<DocumentSession | null>;
   receive(peer: RoomPeer, message: ClientCollabMessage): Promise<void>;
   leave(peer: RoomPeer, reason?: RoomLeaveReason): Promise<void>;
   close(): Promise<void>;

--- a/packages/collab-runtime/src/index.ts
+++ b/packages/collab-runtime/src/index.ts
@@ -9,10 +9,14 @@ export {
 } from "./connection-limiter";
 export {
   DEFAULT_DOCUMENT_ROOM_POLICY,
+  DOCUMENT_ROOM_REFRESH_MODE,
   type DocumentRoom,
   type DocumentRoomErrorContext,
   type DocumentRoomErrorReporter,
+  type DocumentRoomOptions,
   type DocumentRoomPolicy,
+  type DocumentRoomRefreshMode,
+  type DocumentRoomResumeState,
   type DocumentRoomServices,
   ROOM_LEAVE_REASON,
   type RoomLeaveReason,

--- a/packages/collab-runtime/test/document-room.test.ts
+++ b/packages/collab-runtime/test/document-room.test.ts
@@ -795,13 +795,25 @@ describe("createDocumentRoom refresh semantics", () => {
   });
 
   it("does not hold the room maintenance lock across peer persistence I/O", async () => {
-    const fixture = createFixture();
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const fixture = createFixture({
+      authorizationRefreshIntervalMs: 10,
+      connection: {
+        leaseRefreshIntervalMs: 60_000,
+        leaseTtlMs: 120_000,
+        maxConnectionsPerDocument: 100,
+      },
+    });
     const slowRead =
       deferred<Awaited<ReturnType<DocumentEventStore["read"]>>>();
-    fixture.controls.readImpl = async (_documentId, afterCursor) =>
-      afterCursor === "0"
-        ? slowRead.promise
-        : { batches: BATCHES, complete: true, nextCursor: afterCursor };
+    fixture.controls.readImpl = async (_documentId, afterCursor) => {
+      if (afterCursor === "0") {
+        vi.setSystemTime(1_030);
+        return slowRead.promise;
+      }
+      return { batches: BATCHES, complete: true, nextCursor: afterCursor };
+    };
     const room = createRoom(fixture, {
       refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage,
     });
@@ -814,6 +826,7 @@ describe("createDocumentRoom refresh semantics", () => {
       authMessage({ sessionId: "fast-session" }),
     );
 
+    vi.setSystemTime(1_011);
     const slowRequest = room.receive(slowPeer, repairMessage());
     await vi.waitFor(() => expect(fixture.read).toHaveBeenCalledOnce());
     let fastFinished = false;

--- a/packages/collab-runtime/test/document-room.test.ts
+++ b/packages/collab-runtime/test/document-room.test.ts
@@ -14,12 +14,14 @@ import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
   CONNECTION_REJECTION_REASON,
   DOCUMENT_EVENT_CONFLICT_TYPE,
+  DOCUMENT_ROOM_REFRESH_MODE,
   DOCUMENT_SESSION_END_REASON,
   DocumentEventAuthorizationError,
   DocumentEventConflictError,
   DocumentEventStoreUnavailableError,
   ROOM_LEAVE_REASON,
   createDocumentRoom,
+  type AuthenticatedDocumentSession,
   type CommittedDocumentEvent,
   type ConnectionAdmission,
   type ConnectionAdmissionRequest,
@@ -27,7 +29,9 @@ import {
   type DocumentAccess,
   type DocumentEventStore,
   type DocumentRoom,
+  type DocumentRoomOptions,
   type DocumentRoomPolicy,
+  type DocumentRoomResumeState,
   type DocumentRoomServices,
   type DocumentSessionAuthorizationRequest,
   type DocumentSessionHooks,
@@ -71,6 +75,19 @@ const PUBLIC_ACCESS: DocumentAccess = {
   canWrite: false,
   role: null,
 };
+
+const resumeState = (
+  overrides: Partial<AuthenticatedDocumentSession> = {},
+): DocumentRoomResumeState => ({
+  credential: { kind: "access-token", token: "token" },
+  session: {
+    ...AUTHENTICATED_ACCESS,
+    documentId: DOCUMENT_ID,
+    protocolVersion: COLLAB_PROTOCOL_VERSION,
+    sessionId: "session-1",
+    ...overrides,
+  },
+});
 
 const authMessage = (overrides: Partial<AuthMessage> = {}): AuthMessage => ({
   protocolVersion: COLLAB_PROTOCOL_VERSION,
@@ -314,8 +331,11 @@ const createFixture = (policy = DEFAULT_TEST_POLICY): Fixture => {
 
 const openRooms: DocumentRoom[] = [];
 
-const createRoom = (fixture: Fixture): DocumentRoom => {
-  const room = createDocumentRoom(DOCUMENT_ID, fixture.services);
+const createRoom = (
+  fixture: Fixture,
+  options?: DocumentRoomOptions,
+): DocumentRoom => {
+  const room = createDocumentRoom(DOCUMENT_ID, fixture.services, options);
   openRooms.push(room);
   return room;
 };
@@ -604,7 +624,356 @@ describe("createDocumentRoom authentication", () => {
   });
 });
 
+describe("createDocumentRoom session resume", () => {
+  it("revalidates and reacquires a session without another Ready exchange", async () => {
+    const fixture = createFixture();
+    fixture.controls.refreshAccess = {
+      ...AUTHENTICATED_ACCESS,
+      role: "OWNER",
+    };
+    const room = createRoom(fixture, {
+      refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage,
+    });
+    const peer = new FakePeer("peer-resume");
+    const restored = resumeState();
+
+    const session = await room.resume(peer, restored);
+
+    expect(fixture.authorize).not.toHaveBeenCalled();
+    expect(fixture.refresh).toHaveBeenCalledWith({
+      credential: restored.credential,
+      peerId: peer.id,
+      session: restored.session,
+    });
+    expect(fixture.acquire).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: DOCUMENT_ID,
+        peerId: peer.id,
+        sessionId: restored.session.sessionId,
+      }),
+    );
+    expect(session).toMatchObject({
+      documentId: DOCUMENT_ID,
+      role: "OWNER",
+      sessionId: restored.session.sessionId,
+    });
+    expect(peer.messages).toHaveLength(0);
+
+    await room.receive(peer, eventMessage());
+    expect(peer.messages).toContainEqual(
+      expect.objectContaining({
+        type: COLLAB_MESSAGE_TYPE.DurableAck,
+        batchIds: ["batch-1"],
+      }),
+    );
+    expect(peer.messages).toContainEqual(
+      expect.objectContaining({
+        type: COLLAB_MESSAGE_TYPE.Event,
+        batches: BATCHES,
+      }),
+    );
+  });
+
+  it("closes a resumed session when its access identity changed", async () => {
+    const fixture = createFixture();
+    fixture.controls.refreshAccess = {
+      ...AUTHENTICATED_ACCESS,
+      actorId: "00000000-0000-4000-8000-000000000099",
+    };
+    const room = createRoom(fixture);
+    const peer = new FakePeer("peer-resume-revoked");
+    const restored = resumeState();
+
+    await expect(room.resume(peer, restored)).resolves.toBeNull();
+
+    expect(fixture.acquire).not.toHaveBeenCalled();
+    expect(fixture.fanout.subscribeCalls).toBe(0);
+    expect(peer.closes).toContainEqual({
+      code: 1008,
+      reason: "Collaboration access was revoked",
+    });
+    expect(fixture.end).toHaveBeenCalledWith(
+      restored.session,
+      DOCUMENT_SESSION_END_REASON.AccessRevoked,
+    );
+  });
+
+  it("releases partial resumed setup when fan-out cannot be restored", async () => {
+    const fixture = createFixture();
+    fixture.fanout.subscribeError = new Error("fanout unavailable");
+    const room = createRoom(fixture);
+    const peer = new FakePeer("peer-resume-partial");
+
+    await expect(room.resume(peer, resumeState())).resolves.toBeNull();
+
+    expect(fixture.leases[0]?.releaseCalls).toBe(1);
+    expect(peer.closes).toContainEqual({
+      code: 1011,
+      reason: "Collaboration runtime unavailable",
+    });
+    expect(fixture.end).toHaveBeenCalledWith(
+      expect.anything(),
+      DOCUMENT_SESSION_END_REASON.PeerLeft,
+    );
+  });
+});
+
 describe("createDocumentRoom refresh semantics", () => {
+  it("refreshes access and leases lazily without background timers", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const fixture = createFixture({
+      authorizationRefreshIntervalMs: 10,
+      connection: {
+        leaseRefreshIntervalMs: 10,
+        leaseTtlMs: 100,
+        maxConnectionsPerDocument: 100,
+      },
+    });
+    const room = createRoom(fixture, {
+      refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage,
+    });
+    const peer = new FakePeer("peer-on-message-refresh");
+    await authenticate(room, peer);
+
+    expect(vi.getTimerCount()).toBe(0);
+    vi.setSystemTime(1_011);
+    expect(fixture.refresh).not.toHaveBeenCalled();
+    expect(fixture.leases[0]?.refreshCalls).toBe(0);
+
+    await room.receive(peer, repairMessage());
+
+    expect(fixture.refresh).toHaveBeenCalledOnce();
+    expect(fixture.leases[0]?.refreshCalls).toBe(1);
+    expect(fixture.read).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await room.receive(peer, repairMessage({ requestId: "repair-2" }));
+    expect(fixture.refresh).toHaveBeenCalledOnce();
+    expect(fixture.leases[0]?.refreshCalls).toBe(1);
+    expect(fixture.read).toHaveBeenCalledTimes(2);
+  });
+
+  it("revalidates again before returning a repair that crossed its deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const fixture = createFixture({
+      authorizationRefreshIntervalMs: 10,
+      connection: {
+        leaseRefreshIntervalMs: 20,
+        leaseTtlMs: 100,
+        maxConnectionsPerDocument: 100,
+      },
+    });
+    fixture.controls.readImpl = async (_documentId, afterCursor) => {
+      vi.setSystemTime(1_011);
+      fixture.controls.refreshAccess = null;
+      return { batches: BATCHES, complete: true, nextCursor: afterCursor };
+    };
+    const room = createRoom(fixture, {
+      refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage,
+    });
+    const peer = new FakePeer("peer-repair-deadline");
+    await authenticate(room, peer);
+    peer.messages.length = 0;
+
+    await room.receive(peer, repairMessage());
+
+    expect(fixture.refresh).toHaveBeenCalledOnce();
+    expect(peer.closes).toContainEqual({ code: 1008, reason: "Unauthorized" });
+    expect(peer.messages).toContainEqual(
+      expect.objectContaining({
+        type: COLLAB_MESSAGE_TYPE.Error,
+        code: COLLAB_ERROR_CODE.AuthenticationFailed,
+      }),
+    );
+    expect(
+      peer.messages.some(
+        (message) => message.type === COLLAB_MESSAGE_TYPE.RepairResponse,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not hold the room maintenance lock across peer persistence I/O", async () => {
+    const fixture = createFixture();
+    const slowRead =
+      deferred<Awaited<ReturnType<DocumentEventStore["read"]>>>();
+    fixture.controls.readImpl = async (_documentId, afterCursor) =>
+      afterCursor === "0"
+        ? slowRead.promise
+        : { batches: BATCHES, complete: true, nextCursor: afterCursor };
+    const room = createRoom(fixture, {
+      refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage,
+    });
+    const slowPeer = new FakePeer("peer-slow-repair");
+    const fastPeer = new FakePeer("peer-fast-repair");
+    await authenticate(room, slowPeer);
+    await authenticate(
+      room,
+      fastPeer,
+      authMessage({ sessionId: "fast-session" }),
+    );
+
+    const slowRequest = room.receive(slowPeer, repairMessage());
+    await vi.waitFor(() => expect(fixture.read).toHaveBeenCalledOnce());
+    let fastFinished = false;
+    const fastRequest = room
+      .receive(
+        fastPeer,
+        repairMessage({ afterCursor: "1", requestId: "fast-repair" }),
+      )
+      .then(() => {
+        fastFinished = true;
+      });
+    try {
+      await vi.waitFor(() => expect(fastFinished).toBe(true));
+    } finally {
+      slowRead.resolve({ batches: BATCHES, complete: true, nextCursor: "0" });
+      await Promise.all([slowRequest, fastRequest]);
+    }
+    expect(fastPeer.messages).toContainEqual(
+      expect.objectContaining({
+        type: COLLAB_MESSAGE_TYPE.RepairResponse,
+        requestId: "fast-repair",
+      }),
+    );
+  });
+
+  it("closes a peer whose validation expired during append before fan-out", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const fixture = createFixture({
+      authorizationRefreshIntervalMs: 10,
+      connection: {
+        leaseRefreshIntervalMs: 20,
+        leaseTtlMs: 100,
+        maxConnectionsPerDocument: 100,
+      },
+    });
+    fixture.controls.appendImpl = async (_documentId, _actorId, batches) => {
+      vi.setSystemTime(1_011);
+      return batches.map((batch) => batch.batchId);
+    };
+    const room = createRoom(fixture, {
+      refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage,
+    });
+    const sender = new FakePeer("peer-deadline-sender");
+    const expired = new FakePeer("peer-expired-recipient");
+    await authenticate(room, sender);
+    await authenticate(
+      room,
+      expired,
+      authMessage({ sessionId: "expired-session" }),
+    );
+    sender.messages.length = 0;
+    expired.messages.length = 0;
+
+    await room.receive(sender, eventMessage());
+
+    expect(sender.messages).toContainEqual(
+      expect.objectContaining({ type: COLLAB_MESSAGE_TYPE.Event }),
+    );
+    expect(
+      expired.messages.some(
+        (message) => message.type === COLLAB_MESSAGE_TYPE.Event,
+      ),
+    ).toBe(false);
+
+    expect(expired.closes).toContainEqual({
+      code: 1012,
+      reason: "Collaboration session requires revalidation",
+    });
+    await vi.waitFor(() => {
+      expect(fixture.end).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: "expired-session" }),
+        DOCUMENT_SESSION_END_REASON.PeerLeft,
+      );
+    });
+    expect(fixture.leases[1]?.releaseCalls).toBe(1);
+  });
+
+  it("removes every expired revoked peer before another peer publishes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const fixture = createFixture({
+      authorizationRefreshIntervalMs: 10,
+      connection: {
+        leaseRefreshIntervalMs: 20,
+        leaseTtlMs: 100,
+        maxConnectionsPerDocument: 100,
+      },
+    });
+    fixture.controls.refreshImpl = async (request) =>
+      request.peerId === "peer-idle-revoked" ? null : AUTHENTICATED_ACCESS;
+    const room = createRoom(fixture, {
+      refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage,
+    });
+    const sender = new FakePeer("peer-sender");
+    const revoked = new FakePeer("peer-idle-revoked");
+    await authenticate(room, sender);
+    await authenticate(
+      room,
+      revoked,
+      authMessage({ sessionId: "idle-session" }),
+    );
+    sender.messages.length = 0;
+    revoked.messages.length = 0;
+    vi.setSystemTime(1_011);
+
+    await room.receive(sender, eventMessage());
+
+    expect(fixture.refresh).toHaveBeenCalledTimes(2);
+    expect(revoked.closes).toContainEqual({
+      code: 1008,
+      reason: "Unauthorized",
+    });
+    expect(
+      revoked.messages.some(
+        (message) => message.type === COLLAB_MESSAGE_TYPE.Event,
+      ),
+    ).toBe(false);
+    expect(sender.messages).toContainEqual(
+      expect.objectContaining({
+        type: COLLAB_MESSAGE_TYPE.Event,
+        batches: BATCHES,
+      }),
+    );
+    expect(fixture.fanout.published).toHaveLength(1);
+    expect(fixture.leases[1]?.releaseCalls).toBe(1);
+  });
+
+  it("blocks a message when lazy connection lease maintenance fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const fixture = createFixture({
+      authorizationRefreshIntervalMs: 100,
+      connection: {
+        leaseRefreshIntervalMs: 10,
+        leaseTtlMs: 100,
+        maxConnectionsPerDocument: 100,
+      },
+    });
+    const room = createRoom(fixture, {
+      refreshMode: DOCUMENT_ROOM_REFRESH_MODE.OnMessage,
+    });
+    const peer = new FakePeer("peer-lazy-lease-loss");
+    await authenticate(room, peer);
+    fixture.leases[0]!.refreshResult = false;
+    vi.setSystemTime(1_011);
+
+    await room.receive(peer, repairMessage());
+
+    expect(peer.closes).toContainEqual({
+      code: 1013,
+      reason: "Collaboration connection lease was lost",
+    });
+    expect(fixture.read).not.toHaveBeenCalled();
+    expect(fixture.end).toHaveBeenCalledWith(
+      expect.anything(),
+      DOCUMENT_SESSION_END_REASON.PeerLeft,
+    );
+  });
+
   it("lazily revalidates expired access and closes a revoked session", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);


### PR DESCRIPTION
## Summary

- Upgrade `DocumentRoomDO` to Cloudflare's hibernatable WebSocket model: each socket carries versioned attachment metadata (peer/session identity, protocol/access fields, reauthorization credential, message quota) so rooms survive Durable Object eviction and constructor re-entry.
- Extend `@softmaple/collab-runtime` `DocumentRoom` with resume/refresh semantics so authenticated peers reconnect without a second protocol `Ready`, revalidate auth on wake, and keep repair/fan-out correct after hibernation.
- Add workerd conformance tests covering multi-client hibernation/wake, session revocation after wake, close/error cleanup, and sockets that fail while the room is hibernating.

Closes #872

## Test plan

- [x] `pnpm --filter @softmaple/collab-runtime test`
- [x] `pnpm --filter @softmaple/collab-cloudflare test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for restoring collaborative document sessions after connection hibernation or recovery.
  * Added configurable refresh behavior, including message-driven access checks.
  * Improved session revalidation, authorization, quota tracking, and lease maintenance.
  * Added safeguards for invalid, duplicate, expired, or oversized connection metadata.

* **Bug Fixes**
  * Improved cleanup when connections close, fail, or lose authorization.

* **Documentation**
  * Updated deployment, lifecycle, persistence, and verification guidance for Cloudflare collaboration rooms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->