### PR TITLE
chore: enable Cloudflare plugin in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "cloudflare@cloudflare": true
+  }
+}


### PR DESCRIPTION
<!-- ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Changes proposed in this pull request:

- Add `.claude/settings.json` to enable the `cloudflare@cloudflare` plugin for Claude Code
- Complements the Cloudflare agent skills plugin added in #882


Made with [Cursor](https://cursor.com)