### PR TITLE
Add PresenceRoom implementation and conformance tests

### DIFF
--- a/docs/design/collaboration-layers.md
+++ b/docs/design/collaboration-layers.md
@@ -231,6 +231,11 @@ choosing a deployment runtime or persistence implementation.
   lifecycle contracts.
 - Define capabilities for durable event append/history reads, committed-event
   fan-out, connection admission/leases, and authorization refresh.
+- Define ephemeral presence-room capabilities (`PresenceStore`,
+  `PresenceFanout`, `PresenceSessionHooks`) and a payload-opaque
+  `PresenceCodec` seam, plus the `PresenceRoom` state machine built on them.
+  Presence shares no capability instance with `DocumentRoom` — a presence
+  failure cannot block durable document convergence.
 - Reuse `@softmaple/collab-protocol` messages and validated batch shapes rather
   than creating a second browser protocol.
 - Specify durable append, `DurableAck`, fan-out, and repair/resync ordering.
@@ -247,6 +252,10 @@ The complete behavioral contract is in
   infrastructure.
 - Import EG-walker directly, awareness, a surface binding, an editor
   framework, React, UI packages, or app routing.
+- Import `@softmaple/awareness` or any subpath (including
+  `@softmaple/awareness/protocol` and `@softmaple/awareness/types/presence`)
+  — presence payload shapes are opaque here; the host injects a
+  `PresenceCodec`.
 - Implement convergence, block integration, or another CRDT. EG-walker and
   block-model retain those responsibilities.
 - Own a browser transport or alter the wire protocol.

--- a/docs/design/collaboration-runtime.md
+++ b/docs/design/collaboration-runtime.md
@@ -11,10 +11,12 @@ the same room behavior be implemented on the current Nitro/Redis/Postgres
 stack and on a future runtime without importing either environment into the
 runtime package.
 
-The package supplies the shared `DocumentRoom` implementation as well as its
-contracts. The production Nitro host in `apps/collab` owns only transport and
-infrastructure adapters: raw WebSocket ingress, Supabase authorization,
-Prisma/Postgres history, and Redis-backed fan-out and connection leases.
+The package supplies the shared `DocumentRoom` and `PresenceRoom`
+implementations as well as their contracts. The production Nitro host in
+`apps/collab` owns only transport and infrastructure adapters: raw WebSocket
+ingress, Supabase authorization, Prisma/Postgres history, and Redis-backed
+fan-out and connection leases. `PresenceRoom` is documented separately below
+— it shares no capability instance with `DocumentRoom`.
 
 ## Capability boundary
 
@@ -26,6 +28,18 @@ Prisma/Postgres history, and Redis-backed fan-out and connection leases.
 | `DocumentEventStore` | Atomic durable append and ordered repair pages | Prisma/Postgres implementation details |
 | `RoomFanout` | Committed document-event delivery across room instances | Presence or durable acknowledgement |
 | `ConnectionLimiter` | Per-document admission and renewable leases | Redis or Durable Object implementation details |
+| `PresenceRoom` | Peer join/receive/leave/close state machine for one presence room | WebSocket upgrade, raw JSON parsing, or document convergence |
+| `PresencePeer` | Sending codec-encoded frames and closing a transport peer | Wire frame shape or identity state |
+| `PresenceStore` | TTL-backed member storage with purge-on-read expiry | Redis or Durable Object storage implementation details |
+| `PresenceFanout` | Presence broadcast delivery across room instances, including loopback | Document event delivery or durable acknowledgement |
+| `PresenceSessionHooks` | Resolving and refreshing a server-authoritative presence identity | Supabase/JWT implementation details |
+| `PresenceCodec` | Wire type classification, payload validation, and frame encoding | Room dispatch, TTL, or connection-admission policy |
+
+`PresenceRoom` shares no capability instance with `DocumentRoom`: separate
+`PresenceStore`/`PresenceFanout` from `RoomFanout`, and its own
+`PresenceSessionHooks`. Only `ConnectionLimiter` is reused as-is, scoped by a
+different room id, so a presence failure structurally cannot block durable
+document convergence.
 
 The room consumes parsed `ClientCollabMessage` values and sends existing
 `ServerCollabMessage` values. `DocumentEventPage` is derived from
@@ -174,6 +188,68 @@ every conflict.
 On reconnect, the browser repairs to completion before it exact-resends its
 pending write. That one-in-flight queue is a client invariant that the room
 must remain compatible with; it is not server-owned session state.
+
+## Presence room
+
+`PresenceRoom` is a separate, payload-opaque state machine beside
+`DocumentRoom`. It shares **no** capability instance with the document room —
+`PresenceStore`/`PresenceFanout`/`PresenceSessionHooks` are distinct from
+`DocumentEventStore`/`RoomFanout`/`DocumentSessionHooks` — so a presence
+failure structurally cannot block durable document convergence, and a
+document-store outage cannot block presence. Presence is authenticated-only;
+there is no public-access path.
+
+The room never reads a presence payload directly. A `PresenceCodec` owns
+every wire type string, envelope/patch/auth/heartbeat shape, and the
+published `updates` object; the room only reads the three identity fields it
+owns on a stored member (`clock`, `connectionId`, `userId`) and dispatches on
+the codec's classification of an inbound frame. This is what lets the same
+`PresenceRoom` run behind `@softmaple/awareness/protocol` in production and
+behind a dependency-free test codec in this package's own tests.
+
+### Room-owned behavior
+
+| Rule | Behavior |
+| --- | --- |
+| Room match | A frame whose room id does not match `PresenceRoom.roomId` closes 1008 |
+| Sender binding | Pre-auth: `senderId` must equal the Auth payload's `connectionId`. Post-auth: `senderId` must equal the authenticated `connectionId`. A mismatch closes 1008 |
+| Identity match | A patch whose `connectionId`/`userId` does not match the authenticated peer closes 1008 |
+| Monotonic clock | `clock <= current.clock` is a **silent drop** (no publish, no store write, no close); `clock > current.clock + 1000` closes 1008 |
+| TTL refresh | Join, Heartbeat, and Update each refresh the stored member's TTL and the connection lease |
+| Rate limit | `PresenceCodec.consumeQuota` runs **before** parsing, so a malformed frame still consumes quota |
+| Expiry → Leave | Every `PresenceStore.listMembers()` read's `expired[]` produces one Leave broadcast, with `senderId` set to the expired member's `connectionId` |
+| Heartbeat expiry | Rearmed on every valid post-auth frame; lapsing closes 1001 |
+| Auth cadence | Cached for `PresenceRoomPolicy.authorizationRefreshIntervalMs`; `PresenceSessionHooks.refresh` returning null or a different `userId` closes 1008 |
+| Cleanup order | Release fan-out retain → release the connection lease → `PresenceStore.removeMember` → publish Leave if the member had joined |
+| "Had joined" | True if the peer's local Joined state was true, **or** `removeMember` returned a prior record (a peer can be discovered joined even after eviction wiped local state) |
+| Close codes | 1000 leave · 1001 heartbeat expired · 1008 protocol/auth/identity/clock/revocation · 1011 store/fan-out failure · 1012 shutdown · 1013 full/duplicate/rate-limited |
+
+Origin validation, `?roomId=` parsing, and the frame byte-size limit remain
+host adapter responsibilities, exactly as they do for `DocumentRoom`. Byte
+measurement is transport-specific.
+
+### Refresh modes
+
+`PresenceRoomOptions.refreshMode` mirrors `DocumentRoomRefreshMode`:
+
+- **`background`** — one per-peer heartbeat-expiry timer, unref'd so it never
+  blocks process exit. Used by hosts that do not hibernate (Nitro).
+- **`on-message`** — no timers. Every inbound frame first runs
+  `PresenceRoom.sweep(now)` under a room-level maintenance lock, which closes
+  peers past their heartbeat deadline and drains lapsed store members into
+  Leave broadcasts. Used by hosts that hibernate (a Durable Object), where a
+  `sweep()` call can also be driven by an alarm instead of an inbound frame.
+
+`sweep(now?)` is public on `PresenceRoom` precisely so a host's alarm or
+timer can drive liveness without reimplementing expiry rules, and so the
+shared conformance suite in `@softmaple/collab-runtime/testing` exercises it
+identically on both hosts. It is idempotent: a member already purged by an
+earlier `sweep()` or read is not reported expired again.
+
+`PresenceRoom.resume(peer, state)` restores an already-authenticated session
+after a hibernating host wakes a peer, without a new wire Auth or a second
+`auth-ok` — it revalidates through `PresenceSessionHooks.refresh` first, the
+same way `DocumentRoom.resume` does.
 
 ## Not a convergence layer
 

--- a/packages/collab-runtime/README.md
+++ b/packages/collab-runtime/README.md
@@ -12,6 +12,17 @@ The public capabilities cover:
 - committed-event fan-out across room instances
 - per-document connection admission and renewable leases
 - runtime-neutral authorization, conflict, and store-unavailable failures
+- `PresenceRoom` and transport-neutral `PresencePeer` lifecycle, built on a
+  payload-opaque `PresenceCodec` seam so this package never imports
+  `@softmaple/awareness`
+- TTL-backed presence membership (`PresenceStore`) and presence broadcast
+  fan-out (`PresenceFanout`), sharing no capability instance with
+  `DocumentRoom`
+
+A `./testing` subpath ships a dependency-free conformance kit (assertion
+library free, so it stays inside the same host-infrastructure-free import
+allowlist) that both the Redis-backed and Durable-Object-backed adapters run
+against to prove equivalent behavior.
 
 `createDocumentRoom` preserves the collaboration consistency baseline: append
 before `DurableAck`, acknowledge before fan-out, never fan out a failed append,

--- a/packages/collab-runtime/package.json
+++ b/packages/collab-runtime/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
     }
   },
   "files": [

--- a/packages/collab-runtime/src/connection-limiter.ts
+++ b/packages/collab-runtime/src/connection-limiter.ts
@@ -7,6 +7,7 @@ export type ConnectionRejectionReason =
   (typeof CONNECTION_REJECTION_REASON)[keyof typeof CONNECTION_REJECTION_REASON];
 
 export interface ConnectionAdmissionRequest {
+  /** The room-scope id; a document id for `DocumentRoom`, a presence room id for `PresenceRoom`. */
   readonly documentId: string;
   /** Stable server-side identity for this physical connection. */
   readonly peerId: string;

--- a/packages/collab-runtime/src/index.ts
+++ b/packages/collab-runtime/src/index.ts
@@ -58,3 +58,52 @@ export {
   type RoomFanoutHandler,
   type RoomFanoutSubscription,
 } from "./room-fanout";
+export {
+  PRESENCE_FRAME,
+  PRESENCE_MESSAGE,
+  type PresenceAuthPayload,
+  type PresenceCodec,
+  type PresenceEnvelope,
+  type PresenceFrameKind,
+  type PresenceMessageKind,
+  type PresencePatch,
+  type PresencePatchApplication,
+  type PresenceQuotaResult,
+  type PresenceRateLimitState,
+} from "./presence-codec";
+export {
+  type PresenceBroadcast,
+  type PresenceFanout,
+  type PresenceFanoutHandler,
+  type PresenceFanoutSubscription,
+} from "./presence-fanout";
+export {
+  DEFAULT_PRESENCE_ROOM_POLICY,
+  PRESENCE_ROOM_REFRESH_MODE,
+  type PresencePeer,
+  type PresencePeerSnapshot,
+  type PresenceRoom,
+  type PresenceRoomErrorContext,
+  type PresenceRoomErrorReporter,
+  type PresenceRoomOptions,
+  type PresenceRoomPolicy,
+  type PresenceRoomRefreshMode,
+  type PresenceRoomResumeState,
+  type PresenceRoomServices,
+} from "./presence-room";
+export { createPresenceRoom } from "./presence-room-implementation";
+export {
+  PRESENCE_SESSION_END_REASON,
+  type PresenceIdentity,
+  type PresenceSession,
+  type PresenceSessionAuthorizationRequest,
+  type PresenceSessionEndReason,
+  type PresenceSessionHooks,
+  type PresenceSessionRefreshRequest,
+} from "./presence-session";
+export {
+  type ExpiredPresenceMember,
+  type PresenceMemberPage,
+  type PresenceMemberRecord,
+  type PresenceStore,
+} from "./presence-store";

--- a/packages/collab-runtime/src/presence-codec.ts
+++ b/packages/collab-runtime/src/presence-codec.ts
@@ -1,0 +1,115 @@
+import type { CollabCredential } from "@softmaple/collab-protocol";
+import type { PresenceIdentity } from "./presence-session";
+import type { PresenceMemberRecord } from "./presence-store";
+
+/**
+ * Room-level classification of an inbound envelope. `classify` maps a
+ * codec-owned wire type string (e.g. awareness's `WS_MESSAGE.*`) onto this
+ * closed set; the room dispatches on it without ever reading the wire type.
+ */
+export const PRESENCE_MESSAGE = {
+  Auth: "auth",
+  Heartbeat: "heartbeat",
+  Join: "join",
+  Leave: "leave",
+  Sync: "sync",
+  Update: "update",
+} as const;
+
+export type PresenceMessageKind =
+  (typeof PRESENCE_MESSAGE)[keyof typeof PRESENCE_MESSAGE];
+
+/** Outbound frame kinds the room asks the codec to encode. */
+export const PRESENCE_FRAME = {
+  AuthError: "auth-error",
+  AuthOk: "auth-ok",
+  Error: "error",
+  HeartbeatAck: "heartbeat-ack",
+  Join: "join",
+  Leave: "leave",
+  SyncResponse: "sync-response",
+  Update: "update",
+} as const;
+
+export type PresenceFrameKind =
+  (typeof PRESENCE_FRAME)[keyof typeof PRESENCE_FRAME];
+
+/** The generic wire envelope shell every presence frame shares. */
+export interface PresenceEnvelope {
+  readonly payload?: unknown;
+  readonly roomId: string;
+  readonly senderId: string;
+  readonly type: string;
+}
+
+export interface PresenceAuthPayload {
+  readonly connectionId: string;
+  readonly credential: CollabCredential;
+  /** Client-claimed userId, verified against the resolved identity by `PresenceSessionHooks`. */
+  readonly userId: string;
+}
+
+/**
+ * Room-visible identity fields of an inbound update. Cursor, selection,
+ * `meta`, and any other patch payload remain codec-owned and opaque; the
+ * room passes the parsed value straight through to `applyPatch`.
+ */
+export interface PresencePatch {
+  readonly clock: number;
+  readonly connectionId: string;
+  readonly userId: string;
+}
+
+export interface PresencePatchApplication {
+  /** The codec-owned partial object published on the wire Update frame. */
+  readonly broadcastPayload: unknown;
+  readonly member: PresenceMemberRecord;
+}
+
+/** Opaque rate-limit bookkeeping the room stores and replays but never reads. */
+export type PresenceRateLimitState = unknown;
+
+export interface PresenceQuotaResult {
+  readonly allowed: boolean;
+  readonly state: PresenceRateLimitState;
+}
+
+/**
+ * The seam that keeps `PresenceRoom` payload-opaque. Wire type strings,
+ * capability negotiation, and every presence payload shape (cursor,
+ * selection, name, color, activity/liveness timestamps) live behind this
+ * interface; `collab-runtime` never imports awareness.
+ *
+ * Every parse/classify method throws on invalid input; there is no null
+ * sentinel to check.
+ */
+export interface PresenceCodec {
+  applyPatch(
+    current: PresenceMemberRecord,
+    patch: PresencePatch,
+    now: number,
+  ): PresencePatchApplication;
+  /** Throws for a wire type the room does not understand. */
+  classify(envelope: PresenceEnvelope): PresenceMessageKind;
+  consumeQuota(
+    current: PresenceRateLimitState | null,
+    now: number,
+  ): PresenceQuotaResult;
+  createMember(
+    identity: PresenceIdentity,
+    connectionId: string,
+    now: number,
+  ): PresenceMemberRecord;
+  encode(
+    kind: PresenceFrameKind,
+    roomId: string,
+    senderId: string,
+    payload: unknown,
+  ): unknown;
+  isMember(value: unknown): value is PresenceMemberRecord;
+  parseAuth(payload: unknown): PresenceAuthPayload;
+  parseEnvelope(value: unknown): PresenceEnvelope;
+  /** Returns the validated pingId. */
+  parseHeartbeat(payload: unknown): string;
+  parsePatch(payload: unknown): PresencePatch;
+}

--- a/packages/collab-runtime/src/presence-codec.ts
+++ b/packages/collab-runtime/src/presence-codec.ts
@@ -80,8 +80,12 @@ export interface PresenceQuotaResult {
  * selection, name, color, activity/liveness timestamps) live behind this
  * interface; `collab-runtime` never imports awareness.
  *
- * Every parse/classify method throws on invalid input; there is no null
- * sentinel to check.
+ * Throwing behavior:
+ * - Parse methods (`parseEnvelope`, `parseAuth`, `parseHeartbeat`, `parsePatch`)
+ *   and `classify` throw on invalid input; there is no null sentinel to check.
+ * - `consumeQuota`, `createMember`, `applyPatch`, `encode`, and `isMember` are
+ *   guaranteed not to throw under normal operation. The room guards `encode`
+ *   calls on error-path flows where host failures are possible.
  */
 export interface PresenceCodec {
   applyPatch(

--- a/packages/collab-runtime/src/presence-fanout.ts
+++ b/packages/collab-runtime/src/presence-fanout.ts
@@ -1,0 +1,30 @@
+/** A codec-encoded frame ready for cross-instance delivery. Opaque to the runtime. */
+export interface PresenceBroadcast {
+  readonly frame: unknown;
+  readonly roomId: string;
+}
+
+export type PresenceFanoutHandler = (
+  broadcast: PresenceBroadcast,
+) => void | Promise<void>;
+
+export interface PresenceFanoutSubscription {
+  /** Releases this subscription; repeated calls must be safe. */
+  unsubscribe(): Promise<void>;
+}
+
+/**
+ * Cross-room-instance presence broadcast delivery. Distinct from
+ * `RoomFanout`: presence never shares a capability instance with the
+ * document room. Publish must make the broadcast observable to every
+ * matching subscription, including the publisher's own — browser clients
+ * rely on that loopback to self-suppress by `senderId`. A subscriber must
+ * discard a broadcast whose roomId does not match its subscription.
+ */
+export interface PresenceFanout {
+  publish(broadcast: PresenceBroadcast): Promise<void>;
+  subscribe(
+    roomId: string,
+    handler: PresenceFanoutHandler,
+  ): Promise<PresenceFanoutSubscription>;
+}

--- a/packages/collab-runtime/src/presence-room-implementation.ts
+++ b/packages/collab-runtime/src/presence-room-implementation.ts
@@ -1,0 +1,1243 @@
+import type { CollabCredential } from "@softmaple/collab-protocol";
+import type { ConnectionLease } from "./connection-limiter";
+import { ROOM_LEAVE_REASON, type RoomLeaveReason } from "./document-room";
+import {
+  PRESENCE_FRAME,
+  PRESENCE_MESSAGE,
+  type PresenceEnvelope,
+  type PresenceMessageKind,
+  type PresencePatch,
+} from "./presence-codec";
+import type { PresenceFanoutSubscription } from "./presence-fanout";
+import {
+  PRESENCE_ROOM_REFRESH_MODE,
+  type PresencePeer,
+  type PresenceRoom,
+  type PresenceRoomOptions,
+  type PresenceRoomRefreshMode,
+  type PresenceRoomResumeState,
+  type PresenceRoomServices,
+} from "./presence-room";
+import {
+  PRESENCE_SESSION_END_REASON,
+  type PresenceIdentity,
+  type PresenceSession,
+  type PresenceSessionEndReason,
+} from "./presence-session";
+import type { PresenceMemberRecord } from "./presence-store";
+
+const PEER_PHASE = {
+  Authenticated: "authenticated",
+  Authenticating: "authenticating",
+  Connected: "connected",
+  Joined: "joined",
+  Left: "left",
+} as const;
+
+type PeerPhase = (typeof PEER_PHASE)[keyof typeof PEER_PHASE];
+
+interface PeerState {
+  authorizationExpiresAt: number;
+  connectionId: string | null;
+  credential: CollabCredential | null;
+  fanoutRetained: boolean;
+  heartbeatExpiresAt: number;
+  heartbeatTimer: ReturnType<typeof setTimeout> | null;
+  identity: PresenceIdentity | null;
+  joined: boolean;
+  lease: ConnectionLease | null;
+  leaveRequested: boolean;
+  phase: PeerPhase;
+  readonly peer: PresencePeer;
+  queue: Promise<void>;
+  queuePending: number;
+  rateLimit: unknown;
+}
+
+const createPeerState = (peer: PresencePeer): PeerState => ({
+  authorizationExpiresAt: 0,
+  connectionId: null,
+  credential: null,
+  fanoutRetained: false,
+  heartbeatExpiresAt: 0,
+  heartbeatTimer: null,
+  identity: null,
+  joined: false,
+  lease: null,
+  leaveRequested: false,
+  phase: PEER_PHASE.Connected,
+  peer,
+  queue: Promise.resolve(),
+  queuePending: 0,
+  rateLimit: null,
+});
+
+const unrefTimer = (timer: ReturnType<typeof setTimeout>): void => {
+  const candidate = timer as unknown as { unref?: () => void };
+  candidate.unref?.();
+};
+
+const endReasonFromLeave = (
+  reason: RoomLeaveReason,
+): PresenceSessionEndReason => {
+  switch (reason) {
+    case ROOM_LEAVE_REASON.AccessRevoked:
+      return PRESENCE_SESSION_END_REASON.AccessRevoked;
+    case ROOM_LEAVE_REASON.RuntimeShutdown:
+      return PRESENCE_SESSION_END_REASON.RoomClosed;
+    case ROOM_LEAVE_REASON.ConnectionClosed:
+      return PRESENCE_SESSION_END_REASON.PeerLeft;
+  }
+};
+
+class RuntimePresenceRoom implements PresenceRoom {
+  readonly roomId: string;
+
+  private closed = false;
+  private closePromise: Promise<void> | null = null;
+  private fanoutQueue: Promise<void> = Promise.resolve();
+  private fanoutRetainers = 0;
+  private fanoutSubscription: PresenceFanoutSubscription | null = null;
+  private messageMaintenanceQueue: Promise<void> = Promise.resolve();
+  private readonly peers = new Map<PresencePeer, PeerState>();
+  private readonly refreshMode: PresenceRoomRefreshMode;
+  private readonly services: PresenceRoomServices;
+
+  constructor(
+    roomId: string,
+    services: PresenceRoomServices,
+    options: PresenceRoomOptions = {},
+  ) {
+    if (roomId.length === 0) {
+      throw new Error("PresenceRoom requires a non-empty room id");
+    }
+    this.assertPolicy(services);
+    this.roomId = roomId;
+    this.refreshMode =
+      options.refreshMode ?? PRESENCE_ROOM_REFRESH_MODE.Background;
+    this.services = services;
+  }
+
+  async join(peer: PresencePeer): Promise<void> {
+    if (this.closed) {
+      await this.closePeer(
+        peer,
+        1012,
+        "Collaboration runtime is shutting down",
+      );
+      return;
+    }
+    if (!this.peers.has(peer)) this.peers.set(peer, createPeerState(peer));
+  }
+
+  async resume(
+    peer: PresencePeer,
+    resumed: PresenceRoomResumeState,
+  ): Promise<PresenceSession | null> {
+    await this.join(peer);
+    const state = this.peers.get(peer);
+    if (state === undefined || this.closed) return null;
+
+    if (state.phase !== PEER_PHASE.Connected) {
+      state.leaveRequested = true;
+      await this.closePeer(peer, 1008, "Already authenticated");
+      await this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+      });
+      return null;
+    }
+
+    state.phase = PEER_PHASE.Authenticating;
+    return this.enqueue(state, async () => this.resumeSession(state, resumed));
+  }
+
+  async receive(peer: PresencePeer, rawMessage: string): Promise<void> {
+    if (this.closed) return;
+    const state = this.peers.get(peer);
+    if (
+      state === undefined ||
+      state.leaveRequested ||
+      state.phase === PEER_PHASE.Left
+    ) {
+      return;
+    }
+
+    const quota = this.services.codec.consumeQuota(state.rateLimit, Date.now());
+    state.rateLimit = quota.state;
+    await this.persistSnapshot(state);
+    if (!quota.allowed) {
+      state.leaveRequested = true;
+      await this.closePeer(peer, 1013, "Presence rate limit exceeded");
+      await this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+      });
+      return;
+    }
+
+    let envelope: PresenceEnvelope;
+    try {
+      envelope = this.services.codec.parseEnvelope(JSON.parse(rawMessage));
+    } catch {
+      await this.sendIgnoringFailure(
+        peer,
+        this.services.codec.encode(PRESENCE_FRAME.Error, "unknown", "server", {
+          code: "invalid-message",
+          message: "The presence message is invalid",
+        }),
+        "invalid-message",
+      );
+      return;
+    }
+
+    if (envelope.roomId !== this.roomId) {
+      state.leaveRequested = true;
+      await this.closePeer(peer, 1008, "Presence room mismatch");
+      await this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+      });
+      return;
+    }
+
+    let kind: PresenceMessageKind;
+    try {
+      kind = this.services.codec.classify(envelope);
+    } catch {
+      state.leaveRequested = true;
+      await this.closePeer(peer, 1008, "Unsupported presence message");
+      await this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+      });
+      return;
+    }
+
+    if (kind === PRESENCE_MESSAGE.Auth) {
+      await this.receiveAuth(state, envelope);
+      return;
+    }
+
+    if (
+      state.phase !== PEER_PHASE.Authenticated &&
+      state.phase !== PEER_PHASE.Joined
+    ) {
+      state.leaveRequested = true;
+      await this.closePeer(peer, 1008, "Authenticate presence first");
+      await this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+      });
+      return;
+    }
+    if (
+      state.connectionId === null ||
+      envelope.senderId !== state.connectionId
+    ) {
+      state.leaveRequested = true;
+      await this.closePeer(peer, 1008, "Presence sender mismatch");
+      await this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+      });
+      return;
+    }
+
+    await this.enqueue(state, async () => {
+      if (!this.isPeerLive(state)) return;
+      if (!(await this.refreshAuthorizationForMessage(state))) return;
+      if (!this.isPeerLive(state)) return;
+
+      await this.rearmHeartbeat(state);
+
+      if (this.refreshMode === PRESENCE_ROOM_REFRESH_MODE.OnMessage) {
+        await this.withMessageMaintenanceLock(async () => {
+          await this.sweepLocked(Date.now());
+        });
+        if (!this.isPeerLive(state)) return;
+      }
+
+      switch (kind) {
+        case PRESENCE_MESSAGE.Join:
+          await this.receiveJoin(state);
+          return;
+        case PRESENCE_MESSAGE.Sync:
+          await this.receiveSync(state);
+          return;
+        case PRESENCE_MESSAGE.Heartbeat:
+          await this.receiveHeartbeat(state, envelope);
+          return;
+        case PRESENCE_MESSAGE.Update:
+          await this.receiveUpdate(state, envelope);
+          return;
+        case PRESENCE_MESSAGE.Leave:
+          await this.receiveLeave(state);
+          return;
+      }
+    });
+  }
+
+  async leave(
+    peer: PresencePeer,
+    reason: RoomLeaveReason = ROOM_LEAVE_REASON.ConnectionClosed,
+  ): Promise<void> {
+    const state = this.peers.get(peer);
+    if (state === undefined) return;
+    state.leaveRequested = true;
+    this.clearHeartbeatTimer(state);
+    await this.enqueue(state, async () => {
+      await this.resetState(state, true, endReasonFromLeave(reason));
+    });
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise !== null) return this.closePromise;
+    this.closed = true;
+    this.closePromise = this.closeRoom();
+    return this.closePromise;
+  }
+
+  async sweep(now: number = Date.now()): Promise<void> {
+    await this.withMessageMaintenanceLock(async () => {
+      await this.sweepLocked(now);
+    });
+  }
+
+  private async closeRoom(): Promise<void> {
+    const states = [...this.peers.values()];
+    for (const state of states) state.leaveRequested = true;
+    await Promise.all(
+      states.map(async (state) => {
+        this.clearHeartbeatTimer(state);
+        await this.closePeer(
+          state.peer,
+          1012,
+          "Collaboration runtime is shutting down",
+        );
+        await this.enqueue(state, async () => {
+          await this.resetState(
+            state,
+            true,
+            PRESENCE_SESSION_END_REASON.RoomClosed,
+          );
+        });
+      }),
+    );
+    await this.withFanoutLock(async () => {
+      const subscription = this.fanoutSubscription;
+      this.fanoutRetainers = 0;
+      if (
+        subscription !== null &&
+        (await this.unsubscribeFanout(subscription))
+      ) {
+        this.fanoutSubscription = null;
+      }
+    });
+  }
+
+  private async receiveAuth(
+    state: PeerState,
+    envelope: PresenceEnvelope,
+  ): Promise<void> {
+    if (state.phase !== PEER_PHASE.Connected) {
+      state.leaveRequested = true;
+      await this.closePeer(
+        state.peer,
+        1008,
+        "Presence is already authenticated",
+      );
+      void this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+      }).catch((error: unknown) => {
+        this.report(error, state, "auth-cleanup");
+      });
+      return;
+    }
+
+    // Set synchronously so a concurrent second Auth observes the pending state.
+    state.phase = PEER_PHASE.Authenticating;
+    await this.enqueue(state, async () => {
+      await this.authenticate(state, envelope);
+    });
+  }
+
+  private async authenticate(
+    state: PeerState,
+    envelope: PresenceEnvelope,
+  ): Promise<void> {
+    try {
+      const auth = this.services.codec.parseAuth(envelope.payload);
+      if (envelope.senderId !== auth.connectionId) {
+        throw new Error("presence sender mismatch");
+      }
+
+      const identity = await this.services.sessions.authorize({
+        connectionId: auth.connectionId,
+        credential: auth.credential,
+        roomId: this.roomId,
+        userId: auth.userId,
+      });
+      if (identity === null) {
+        throw new Error("presence membership denied");
+      }
+
+      if (state.leaveRequested || this.closed) {
+        await this.resetState(
+          state,
+          true,
+          this.closed
+            ? PRESENCE_SESSION_END_REASON.RoomClosed
+            : PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        return;
+      }
+
+      // Set before admission so a concurrent cleanup can identify the peer.
+      state.connectionId = auth.connectionId;
+      const admission = await this.services.connections.acquire({
+        documentId: this.roomId,
+        peerId: auth.connectionId,
+        policy: this.services.policy.connection,
+        sessionId: auth.connectionId,
+      });
+      if (!admission.accepted) {
+        state.leaveRequested = true;
+        await this.closePeer(
+          state.peer,
+          1013,
+          "Presence room is full or duplicated",
+        );
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        return;
+      }
+      state.lease = admission.lease;
+      if (state.leaveRequested || this.closed) {
+        await this.resetState(
+          state,
+          true,
+          this.closed
+            ? PRESENCE_SESSION_END_REASON.RoomClosed
+            : PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        return;
+      }
+
+      await this.retainFanout(state);
+      if (state.leaveRequested || this.closed) {
+        await this.resetState(
+          state,
+          true,
+          this.closed
+            ? PRESENCE_SESSION_END_REASON.RoomClosed
+            : PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        return;
+      }
+
+      state.credential = auth.credential;
+      state.identity = identity;
+      state.authorizationExpiresAt =
+        Date.now() + this.services.policy.authorizationRefreshIntervalMs;
+      state.phase = PEER_PHASE.Authenticated;
+      await this.persistSnapshot(state);
+      await this.sendIgnoringFailure(
+        state.peer,
+        this.services.codec.encode(
+          PRESENCE_FRAME.AuthOk,
+          this.roomId,
+          "server",
+          {},
+        ),
+        "auth-ok",
+      );
+    } catch (error) {
+      this.report(error, state, "auth");
+      state.leaveRequested = true;
+      await this.resetState(
+        state,
+        true,
+        PRESENCE_SESSION_END_REASON.AccessRevoked,
+      );
+      await this.sendIgnoringFailure(
+        state.peer,
+        this.services.codec.encode(
+          PRESENCE_FRAME.AuthError,
+          this.roomId,
+          "server",
+          { message: "Authentication or document membership failed" },
+        ),
+        "auth-error",
+      );
+      await this.closePeer(state.peer, 1008, "Unauthorized");
+    }
+  }
+
+  private async resumeSession(
+    state: PeerState,
+    resumed: PresenceRoomResumeState,
+  ): Promise<PresenceSession | null> {
+    let refreshed: PresenceIdentity | null;
+    try {
+      refreshed = await this.services.sessions.refresh({
+        connectionId: resumed.connectionId,
+        credential: resumed.credential,
+        session: {
+          connectionId: resumed.connectionId,
+          identity: resumed.identity,
+          roomId: this.roomId,
+        },
+      });
+    } catch (error) {
+      this.report(error, state, "session-resume");
+      state.leaveRequested = true;
+      await this.closePeer(state.peer, 1011, "Presence runtime unavailable");
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      return null;
+    }
+
+    if (state.leaveRequested || this.closed) {
+      await this.resetState(
+        state,
+        true,
+        this.closed
+          ? PRESENCE_SESSION_END_REASON.RoomClosed
+          : PRESENCE_SESSION_END_REASON.PeerLeft,
+      );
+      return null;
+    }
+    if (refreshed === null || refreshed.userId !== resumed.identity.userId) {
+      state.leaveRequested = true;
+      await this.closePeer(state.peer, 1008, "Presence access was revoked");
+      await this.resetState(
+        state,
+        true,
+        PRESENCE_SESSION_END_REASON.AccessRevoked,
+      );
+      return null;
+    }
+
+    state.connectionId = resumed.connectionId;
+    state.credential = resumed.credential;
+    state.identity = refreshed;
+    state.joined = resumed.joined;
+    state.rateLimit = resumed.rateLimit;
+    state.heartbeatExpiresAt = resumed.heartbeatExpiresAt;
+
+    try {
+      const admission = await this.services.connections.acquire({
+        documentId: this.roomId,
+        peerId: resumed.connectionId,
+        policy: this.services.policy.connection,
+        sessionId: resumed.connectionId,
+      });
+      if (!admission.accepted) {
+        state.leaveRequested = true;
+        await this.closePeer(
+          state.peer,
+          1013,
+          "Presence connection lease was lost",
+        );
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        return null;
+      }
+      state.lease = admission.lease;
+      if (state.leaveRequested || this.closed) {
+        await this.resetState(
+          state,
+          true,
+          this.closed
+            ? PRESENCE_SESSION_END_REASON.RoomClosed
+            : PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        return null;
+      }
+
+      await this.retainFanout(state);
+      if (state.leaveRequested || this.closed) {
+        await this.resetState(
+          state,
+          true,
+          this.closed
+            ? PRESENCE_SESSION_END_REASON.RoomClosed
+            : PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        return null;
+      }
+
+      state.authorizationExpiresAt =
+        Date.now() + this.services.policy.authorizationRefreshIntervalMs;
+      state.phase = state.joined ? PEER_PHASE.Joined : PEER_PHASE.Authenticated;
+      if (
+        this.refreshMode === PRESENCE_ROOM_REFRESH_MODE.Background &&
+        state.heartbeatExpiresAt > 0
+      ) {
+        this.rearmHeartbeatTimer(state);
+      }
+      return {
+        connectionId: state.connectionId,
+        identity: refreshed,
+        roomId: this.roomId,
+      };
+    } catch (error) {
+      this.report(error, state, "session-resume");
+      state.leaveRequested = true;
+      await this.closePeer(state.peer, 1011, "Presence runtime unavailable");
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      return null;
+    }
+  }
+
+  private async refreshAuthorizationForMessage(
+    state: PeerState,
+  ): Promise<boolean> {
+    if (state.authorizationExpiresAt > Date.now()) return true;
+    const credential = state.credential;
+    const identity = state.identity;
+    const connectionId = state.connectionId;
+    if (credential === null || identity === null || connectionId === null) {
+      return false;
+    }
+
+    let refreshed: PresenceIdentity | null;
+    try {
+      refreshed = await this.services.sessions.refresh({
+        connectionId,
+        credential,
+        session: { connectionId, identity, roomId: this.roomId },
+      });
+    } catch (error) {
+      this.report(error, state, "authorization-recheck");
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1011, "Authorization recheck failed");
+      return false;
+    }
+
+    if (state.leaveRequested || state.phase === PEER_PHASE.Left) return false;
+    if (refreshed === null || refreshed.userId !== identity.userId) {
+      state.leaveRequested = true;
+      await this.resetState(
+        state,
+        true,
+        PRESENCE_SESSION_END_REASON.AccessRevoked,
+      );
+      await this.closePeer(
+        state.peer,
+        1008,
+        "Workspace membership was revoked",
+      );
+      return false;
+    }
+
+    state.identity = refreshed;
+    state.authorizationExpiresAt =
+      Date.now() + this.services.policy.authorizationRefreshIntervalMs;
+    await this.persistSnapshot(state);
+    return true;
+  }
+
+  private async receiveJoin(state: PeerState): Promise<void> {
+    if (state.phase !== PEER_PHASE.Authenticated) {
+      state.leaveRequested = true;
+      await this.closePeer(state.peer, 1008, "Presence already joined");
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      return;
+    }
+    const identity = state.identity;
+    const connectionId = state.connectionId;
+    if (identity === null || connectionId === null) return;
+
+    const now = Date.now();
+    const member = this.services.codec.createMember(
+      identity,
+      connectionId,
+      now,
+    );
+    try {
+      await this.services.store.setMember(
+        this.roomId,
+        member,
+        this.services.policy.memberTtlMs,
+      );
+      if (state.lease !== null) await state.lease.refresh();
+      state.joined = true;
+      await this.persistSnapshot(state);
+      state.phase = PEER_PHASE.Joined;
+      await this.services.fanout.publish({
+        roomId: this.roomId,
+        frame: this.services.codec.encode(
+          PRESENCE_FRAME.Join,
+          this.roomId,
+          connectionId,
+          member,
+        ),
+      });
+    } catch (error) {
+      this.report(error, state, "join");
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1011, "Presence join failed");
+    }
+  }
+
+  private async receiveSync(state: PeerState): Promise<void> {
+    try {
+      const page = await this.services.store.listMembers(this.roomId);
+      for (const expired of page.expired) {
+        await this.publishLeave(expired.connectionId, expired.userId);
+      }
+      const members = page.members.filter((value) =>
+        this.services.codec.isMember(value),
+      );
+      await this.sendIgnoringFailure(
+        state.peer,
+        this.services.codec.encode(
+          PRESENCE_FRAME.SyncResponse,
+          this.roomId,
+          "server",
+          members,
+        ),
+        "sync",
+      );
+    } catch (error) {
+      this.report(error, state, "sync");
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1011, "Presence sync failed");
+    }
+  }
+
+  private async receiveHeartbeat(
+    state: PeerState,
+    envelope: PresenceEnvelope,
+  ): Promise<void> {
+    let pingId: string;
+    try {
+      pingId = this.services.codec.parseHeartbeat(envelope.payload);
+    } catch {
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1008, "Invalid presence heartbeat");
+      return;
+    }
+
+    const connectionId = state.connectionId;
+    if (connectionId === null) return;
+    try {
+      const leaseAlive =
+        state.lease !== null ? await state.lease.refresh() : false;
+      const presenceAlive = await this.services.store.refreshMember(
+        this.roomId,
+        connectionId,
+        this.services.policy.memberTtlMs,
+      );
+      if (!leaseAlive || (state.joined && !presenceAlive)) {
+        state.leaveRequested = true;
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        await this.closePeer(state.peer, 1008, "Presence lease expired");
+        return;
+      }
+      await this.sendIgnoringFailure(
+        state.peer,
+        this.services.codec.encode(
+          PRESENCE_FRAME.HeartbeatAck,
+          this.roomId,
+          connectionId,
+          { pingId },
+        ),
+        "heartbeat",
+      );
+    } catch (error) {
+      this.report(error, state, "heartbeat");
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1011, "Presence heartbeat failed");
+    }
+  }
+
+  private async receiveUpdate(
+    state: PeerState,
+    envelope: PresenceEnvelope,
+  ): Promise<void> {
+    const connectionId = state.connectionId;
+    const identity = state.identity;
+    if (connectionId === null || identity === null) return;
+
+    let current: PresenceMemberRecord;
+    try {
+      const currentRaw = await this.services.store.getMember(
+        this.roomId,
+        connectionId,
+      );
+      if (!this.services.codec.isMember(currentRaw)) {
+        state.leaveRequested = true;
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        await this.closePeer(state.peer, 1008, "Join presence before updating");
+        return;
+      }
+      current = currentRaw;
+    } catch (error) {
+      this.report(error, state, "update");
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1011, "Presence update failed");
+      return;
+    }
+
+    let patch: PresencePatch;
+    try {
+      patch = this.services.codec.parsePatch(envelope.payload);
+      if (
+        patch.connectionId !== connectionId ||
+        patch.userId !== identity.userId
+      ) {
+        throw new Error("presence identity mismatch");
+      }
+    } catch {
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1008, "Invalid presence update");
+      return;
+    }
+
+    if (patch.clock <= current.clock) return; // Stale write; silently dropped.
+    if (patch.clock > current.clock + 1_000) {
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1008, "Invalid presence update");
+      return;
+    }
+
+    try {
+      const now = Date.now();
+      const application = this.services.codec.applyPatch(current, patch, now);
+      await this.services.store.setMember(
+        this.roomId,
+        application.member,
+        this.services.policy.memberTtlMs,
+      );
+      if (state.lease !== null) await state.lease.refresh();
+      await this.services.fanout.publish({
+        roomId: this.roomId,
+        frame: this.services.codec.encode(
+          PRESENCE_FRAME.Update,
+          this.roomId,
+          connectionId,
+          {
+            clock: patch.clock,
+            connectionId,
+            updates: application.broadcastPayload,
+            userId: identity.userId,
+          },
+        ),
+      });
+    } catch (error) {
+      this.report(error, state, "update");
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1011, "Presence update failed");
+    }
+  }
+
+  private async receiveLeave(state: PeerState): Promise<void> {
+    state.leaveRequested = true;
+    await this.closePeer(state.peer, 1000, "Presence left");
+    await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+  }
+
+  private async publishLeave(
+    connectionId: string,
+    userId: string,
+  ): Promise<void> {
+    await this.services.fanout.publish({
+      roomId: this.roomId,
+      frame: this.services.codec.encode(
+        PRESENCE_FRAME.Leave,
+        this.roomId,
+        connectionId,
+        { connectionId, userId },
+      ),
+    });
+  }
+
+  private async sweepLocked(now: number): Promise<void> {
+    const expiredHeartbeats = [...this.peers.values()].filter(
+      (state) =>
+        (state.phase === PEER_PHASE.Authenticated ||
+          state.phase === PEER_PHASE.Joined) &&
+        !state.leaveRequested &&
+        state.heartbeatExpiresAt > 0 &&
+        state.heartbeatExpiresAt <= now,
+    );
+    await Promise.all(
+      expiredHeartbeats.map(async (state) => {
+        state.leaveRequested = true;
+        this.clearHeartbeatTimer(state);
+        await this.closePeer(state.peer, 1001, "Presence heartbeat expired");
+        await this.enqueue(state, async () => {
+          await this.resetState(
+            state,
+            true,
+            PRESENCE_SESSION_END_REASON.PeerLeft,
+          );
+        });
+      }),
+    );
+
+    try {
+      const page = await this.services.store.listMembers(this.roomId);
+      for (const expired of page.expired) {
+        await this.publishLeave(expired.connectionId, expired.userId);
+      }
+    } catch (error) {
+      this.report(error, null, "sweep");
+    }
+  }
+
+  private async rearmHeartbeat(state: PeerState): Promise<void> {
+    state.heartbeatExpiresAt =
+      Date.now() + this.services.policy.heartbeatExpiryMs;
+    await this.persistSnapshot(state);
+    if (this.refreshMode === PRESENCE_ROOM_REFRESH_MODE.Background) {
+      this.rearmHeartbeatTimer(state);
+    }
+  }
+
+  private rearmHeartbeatTimer(state: PeerState): void {
+    this.clearHeartbeatTimer(state);
+    const delay = Math.max(0, state.heartbeatExpiresAt - Date.now());
+    state.heartbeatTimer = setTimeout(() => {
+      state.heartbeatTimer = null;
+      void this.closeExpiredHeartbeatPeer(state).catch((error: unknown) => {
+        this.report(error, state, "heartbeat-expiry");
+      });
+    }, delay);
+    unrefTimer(state.heartbeatTimer);
+  }
+
+  /**
+   * Wrapped in a call so TypeScript does not (incorrectly) treat a prior
+   * identical check earlier in the same async function as still valid after
+   * an intervening `await` mutates `state.phase`.
+   */
+  private isPeerLive(state: PeerState): boolean {
+    return !state.leaveRequested && state.phase !== PEER_PHASE.Left;
+  }
+
+  private clearHeartbeatTimer(state: PeerState): void {
+    if (state.heartbeatTimer !== null) {
+      clearTimeout(state.heartbeatTimer);
+      state.heartbeatTimer = null;
+    }
+  }
+
+  private async closeExpiredHeartbeatPeer(state: PeerState): Promise<void> {
+    if (
+      (state.phase !== PEER_PHASE.Authenticated &&
+        state.phase !== PEER_PHASE.Joined) ||
+      state.leaveRequested
+    ) {
+      return;
+    }
+    state.leaveRequested = true;
+    await this.closePeer(state.peer, 1001, "Presence heartbeat expired");
+    await this.enqueue(state, async () => {
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+    });
+  }
+
+  private async persistSnapshot(state: PeerState): Promise<void> {
+    const persist = state.peer.persist;
+    if (persist === undefined) return;
+    if (
+      state.connectionId === null ||
+      state.credential === null ||
+      state.identity === null
+    ) {
+      return;
+    }
+    try {
+      await persist.call(state.peer, {
+        authorizationExpiresAt: state.authorizationExpiresAt,
+        connectionId: state.connectionId,
+        credential: state.credential,
+        heartbeatExpiresAt: state.heartbeatExpiresAt,
+        identity: state.identity,
+        joined: state.joined,
+        rateLimit: state.rateLimit,
+      });
+    } catch (error) {
+      this.report(error, state, "persist");
+    }
+  }
+
+  private async retainFanout(state: PeerState): Promise<void> {
+    await this.withFanoutLock(async () => {
+      if (this.fanoutRetainers === 0) {
+        if (this.fanoutSubscription !== null) {
+          const stale = this.fanoutSubscription;
+          if (!(await this.unsubscribeFanout(stale))) {
+            throw new Error(
+              "Previous presence fanout subscription is still active",
+            );
+          }
+          if (this.fanoutSubscription === stale) this.fanoutSubscription = null;
+        }
+        this.fanoutSubscription = await this.services.fanout.subscribe(
+          this.roomId,
+          async (broadcast) => {
+            if (broadcast.roomId !== this.roomId) return;
+            const recipients = [...this.peers.values()].filter(
+              (candidate) =>
+                candidate.phase === PEER_PHASE.Joined &&
+                !candidate.leaveRequested,
+            );
+            await Promise.all(
+              recipients.map(async (recipient) => {
+                await this.sendIgnoringFailure(
+                  recipient.peer,
+                  broadcast.frame,
+                  "presence-fanout",
+                );
+              }),
+            );
+          },
+        );
+      }
+      this.fanoutRetainers += 1;
+      state.fanoutRetained = true;
+    });
+  }
+
+  private async releaseFanout(state: PeerState): Promise<void> {
+    if (!state.fanoutRetained) return;
+    state.fanoutRetained = false;
+    await this.withFanoutLock(async () => {
+      this.fanoutRetainers = Math.max(0, this.fanoutRetainers - 1);
+      if (this.fanoutRetainers !== 0) return;
+      const subscription = this.fanoutSubscription;
+      if (
+        subscription !== null &&
+        (await this.unsubscribeFanout(subscription)) &&
+        this.fanoutSubscription === subscription
+      ) {
+        this.fanoutSubscription = null;
+      }
+    });
+  }
+
+  private async unsubscribeFanout(
+    subscription: PresenceFanoutSubscription,
+  ): Promise<boolean> {
+    try {
+      await subscription.unsubscribe();
+      return true;
+    } catch (error) {
+      this.report(error, null, "fanout-unsubscribe");
+      return false;
+    }
+  }
+
+  private async resetState(
+    state: PeerState,
+    remove: boolean,
+    endReason: PresenceSessionEndReason,
+  ): Promise<void> {
+    this.clearHeartbeatTimer(state);
+    await this.releaseFanout(state);
+
+    const lease = state.lease;
+    state.lease = null;
+    if (lease !== null) {
+      try {
+        await lease.release();
+      } catch (error) {
+        this.report(error, state, "lease-release");
+      }
+    }
+
+    const connectionId = state.connectionId;
+    let removedMember: unknown = null;
+    if (connectionId !== null) {
+      try {
+        removedMember = await this.services.store.removeMember(
+          this.roomId,
+          connectionId,
+        );
+      } catch (error) {
+        this.report(error, state, "member-remove");
+      }
+    }
+    const wasJoined = state.joined || removedMember !== null;
+
+    const identity = state.identity;
+    const session: PresenceSession | null =
+      identity === null || connectionId === null
+        ? null
+        : { connectionId, identity, roomId: this.roomId };
+
+    state.identity = null;
+    state.credential = null;
+    state.authorizationExpiresAt = 0;
+    state.heartbeatExpiresAt = 0;
+    state.rateLimit = null;
+    state.joined = false;
+
+    if (session !== null && this.services.sessions.end !== undefined) {
+      try {
+        await this.services.sessions.end(session, endReason);
+      } catch (error) {
+        this.report(error, state, "session-end");
+      }
+    }
+
+    if (wasJoined && connectionId !== null && identity !== null) {
+      try {
+        await this.publishLeave(connectionId, identity.userId);
+      } catch (error) {
+        this.report(error, state, "leave-publish");
+      }
+    }
+
+    state.connectionId = null;
+
+    if (remove) {
+      state.phase = PEER_PHASE.Left;
+      this.peers.delete(state.peer);
+    } else {
+      state.phase = PEER_PHASE.Connected;
+      state.leaveRequested = false;
+    }
+  }
+
+  private enqueue<T>(state: PeerState, work: () => Promise<T>): Promise<T> {
+    state.queuePending += 1;
+    const operation = state.queue.then(work, work).finally(() => {
+      state.queuePending -= 1;
+    });
+    state.queue = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
+  private withMessageMaintenanceLock(work: () => Promise<void>): Promise<void> {
+    const operation = this.messageMaintenanceQueue.then(work, work);
+    this.messageMaintenanceQueue = operation.catch(() => undefined);
+    return operation;
+  }
+
+  private withFanoutLock(work: () => Promise<void>): Promise<void> {
+    const operation = this.fanoutQueue.then(work, work);
+    this.fanoutQueue = operation.catch(() => undefined);
+    return operation;
+  }
+
+  private async sendIgnoringFailure(
+    peer: PresencePeer,
+    frame: unknown,
+    messageType: string,
+  ): Promise<void> {
+    try {
+      await peer.send(frame);
+    } catch (error) {
+      this.report(error, this.peers.get(peer) ?? null, messageType);
+    }
+  }
+
+  private async closePeer(
+    peer: PresencePeer,
+    code: number,
+    reason: string,
+  ): Promise<void> {
+    try {
+      await peer.close(code, reason);
+    } catch (error) {
+      this.report(error, this.peers.get(peer) ?? null, "peer-close");
+    }
+  }
+
+  private report(
+    error: unknown,
+    state: PeerState | null,
+    messageType: string,
+  ): void {
+    try {
+      this.services.reportError?.(error, {
+        messageType,
+        roomId: this.roomId,
+        ...(state === null ? {} : { peerId: state.peer.id }),
+      });
+    } catch {
+      // Observability must never change room behavior.
+    }
+  }
+
+  private assertPolicy(services: PresenceRoomServices): void {
+    const { policy } = services;
+    const values = [
+      policy.authorizationRefreshIntervalMs,
+      policy.heartbeatExpiryMs,
+      policy.memberTtlMs,
+      policy.connection.leaseRefreshIntervalMs,
+      policy.connection.leaseTtlMs,
+      policy.connection.maxConnectionsPerDocument,
+    ];
+    if (values.some((value) => !Number.isFinite(value) || value <= 0)) {
+      throw new Error("PresenceRoom policy values must be positive");
+    }
+    if (
+      policy.connection.leaseRefreshIntervalMs >= policy.connection.leaseTtlMs
+    ) {
+      throw new Error(
+        "Presence connection lease refresh must be shorter than its TTL",
+      );
+    }
+  }
+}
+
+export const createPresenceRoom = (
+  roomId: string,
+  services: PresenceRoomServices,
+  options?: PresenceRoomOptions,
+): PresenceRoom => new RuntimePresenceRoom(roomId, services, options);

--- a/packages/collab-runtime/src/presence-room-implementation.ts
+++ b/packages/collab-runtime/src/presence-room-implementation.ts
@@ -641,7 +641,7 @@ class RuntimePresenceRoom implements PresenceRoom {
       state.phase = state.joined ? PEER_PHASE.Joined : PEER_PHASE.Authenticated;
       if (
         this.refreshMode === PRESENCE_ROOM_REFRESH_MODE.Background &&
-        state.heartbeatExpiresAt > 0
+        state.heartbeatExpiresAt > Date.now()
       ) {
         this.rearmHeartbeatTimer(state);
       }

--- a/packages/collab-runtime/src/presence-room-implementation.ts
+++ b/packages/collab-runtime/src/presence-room-implementation.ts
@@ -166,7 +166,22 @@ class RuntimePresenceRoom implements PresenceRoom {
       return;
     }
 
-    const quota = this.services.codec.consumeQuota(state.rateLimit, Date.now());
+    let quota: { allowed: boolean; state: unknown };
+    try {
+      quota = this.services.codec.consumeQuota(state.rateLimit, Date.now());
+    } catch (error) {
+      this.report(error, state, "quota-check");
+      state.leaveRequested = true;
+      await this.closePeer(peer, 1011, "Presence rate limit check failed");
+      await this.enqueue(state, async () => {
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+      });
+      return;
+    }
     state.rateLimit = quota.state;
     await this.persistSnapshot(state);
     if (!quota.allowed) {
@@ -186,14 +201,18 @@ class RuntimePresenceRoom implements PresenceRoom {
     try {
       envelope = this.services.codec.parseEnvelope(JSON.parse(rawMessage));
     } catch {
-      await this.sendIgnoringFailure(
-        peer,
-        this.services.codec.encode(PRESENCE_FRAME.Error, "unknown", "server", {
-          code: "invalid-message",
-          message: "The presence message is invalid",
-        }),
-        "invalid-message",
-      );
+      try {
+        await this.sendIgnoringFailure(
+          peer,
+          this.services.codec.encode(PRESENCE_FRAME.Error, "unknown", "server", {
+            code: "invalid-message",
+            message: "The presence message is invalid",
+          }),
+          "invalid-message",
+        );
+      } catch (encodeError) {
+        this.report(encodeError, state, "error-frame-encode");
+      }
       return;
     }
 
@@ -267,11 +286,16 @@ class RuntimePresenceRoom implements PresenceRoom {
       if (!(await this.refreshAuthorizationForMessage(state))) return;
       if (!this.isPeerLive(state)) return;
 
+      // Rearm the heartbeat BEFORE acquiring the maintenance lock. If we swept
+      // before rearming, this peer might be found expired, and sweepLocked would
+      // enqueue work on the same peer that is already holding its queue lock,
+      // causing a deadlock. By rearming first, the calling peer is guaranteed
+      // never to appear in the expired-heartbeats list.
       await this.rearmHeartbeat(state);
 
       if (this.refreshMode === PRESENCE_ROOM_REFRESH_MODE.OnMessage) {
         await this.withMessageMaintenanceLock(async () => {
-          await this.sweepLocked(Date.now());
+          await this.sweepLocked(Date.now(), state);
         });
         if (!this.isPeerLive(state)) return;
       }
@@ -318,7 +342,7 @@ class RuntimePresenceRoom implements PresenceRoom {
 
   async sweep(now: number = Date.now()): Promise<void> {
     await this.withMessageMaintenanceLock(async () => {
-      await this.sweepLocked(now);
+      await this.sweepLocked(now, null);
     });
   }
 
@@ -449,7 +473,19 @@ class RuntimePresenceRoom implements PresenceRoom {
         return;
       }
 
-      await this.retainFanout(state);
+      try {
+        await this.retainFanout(state);
+      } catch (fanoutError) {
+        this.report(fanoutError, state, "auth-fanout");
+        state.leaveRequested = true;
+        await this.closePeer(state.peer, 1011, "Presence runtime unavailable");
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        return;
+      }
       if (state.leaveRequested || this.closed) {
         await this.resetState(
           state,
@@ -679,18 +715,34 @@ class RuntimePresenceRoom implements PresenceRoom {
     if (identity === null || connectionId === null) return;
 
     const now = Date.now();
-    const member = this.services.codec.createMember(
-      identity,
-      connectionId,
-      now,
-    );
+    let member: PresenceMemberRecord;
+    try {
+      member = this.services.codec.createMember(identity, connectionId, now);
+    } catch (error) {
+      this.report(error, state, "create-member");
+      state.leaveRequested = true;
+      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.closePeer(state.peer, 1011, "Presence join failed");
+      return;
+    }
     try {
       await this.services.store.setMember(
         this.roomId,
         member,
         this.services.policy.memberTtlMs,
       );
-      if (state.lease !== null) await state.lease.refresh();
+      const leaseAlive =
+        state.lease !== null ? await state.lease.refresh() : true;
+      if (!leaseAlive) {
+        state.leaveRequested = true;
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        await this.closePeer(state.peer, 1008, "Presence lease expired");
+        return;
+      }
       state.joined = true;
       await this.persistSnapshot(state);
       state.phase = PEER_PHASE.Joined;
@@ -855,7 +907,18 @@ class RuntimePresenceRoom implements PresenceRoom {
         application.member,
         this.services.policy.memberTtlMs,
       );
-      if (state.lease !== null) await state.lease.refresh();
+      const leaseAlive =
+        state.lease !== null ? await state.lease.refresh() : true;
+      if (!leaseAlive) {
+        state.leaveRequested = true;
+        await this.resetState(
+          state,
+          true,
+          PRESENCE_SESSION_END_REASON.PeerLeft,
+        );
+        await this.closePeer(state.peer, 1008, "Presence lease expired");
+        return;
+      }
       await this.services.fanout.publish({
         roomId: this.roomId,
         frame: this.services.codec.encode(
@@ -899,9 +962,13 @@ class RuntimePresenceRoom implements PresenceRoom {
     });
   }
 
-  private async sweepLocked(now: number): Promise<void> {
+  private async sweepLocked(
+    now: number,
+    callingPeer: PeerState | null,
+  ): Promise<void> {
     const expiredHeartbeats = [...this.peers.values()].filter(
       (state) =>
+        state !== callingPeer &&
         (state.phase === PEER_PHASE.Authenticated ||
           state.phase === PEER_PHASE.Joined) &&
         !state.leaveRequested &&

--- a/packages/collab-runtime/src/presence-room-implementation.ts
+++ b/packages/collab-runtime/src/presence-room-implementation.ts
@@ -204,10 +204,15 @@ class RuntimePresenceRoom implements PresenceRoom {
       try {
         await this.sendIgnoringFailure(
           peer,
-          this.services.codec.encode(PRESENCE_FRAME.Error, "unknown", "server", {
-            code: "invalid-message",
-            message: "The presence message is invalid",
-          }),
+          this.services.codec.encode(
+            PRESENCE_FRAME.Error,
+            "unknown",
+            "server",
+            {
+              code: "invalid-message",
+              message: "The presence message is invalid",
+            },
+          ),
           "invalid-message",
         );
       } catch (encodeError) {

--- a/packages/collab-runtime/src/presence-room.ts
+++ b/packages/collab-runtime/src/presence-room.ts
@@ -1,0 +1,149 @@
+import type { CollabCredential } from "@softmaple/collab-protocol";
+import type { ConnectionLimiter, ConnectionPolicy } from "./connection-limiter";
+import type { RoomLeaveReason } from "./document-room";
+import type { PresenceCodec, PresenceRateLimitState } from "./presence-codec";
+import type { PresenceFanout } from "./presence-fanout";
+import type {
+  PresenceIdentity,
+  PresenceSession,
+  PresenceSessionHooks,
+} from "./presence-session";
+import type { PresenceStore } from "./presence-store";
+
+/** Transport adapter presented to runtime-independent presence room semantics. */
+export interface PresencePeer {
+  readonly id: string;
+  close(code: number, reason: string): void | Promise<void>;
+  /** Sends a codec-encoded frame; the room never inspects it. */
+  send(frame: unknown): void | Promise<void>;
+  /**
+   * Called whenever persisted peer state changes (rate limit, joined,
+   * authorization/heartbeat expiry). Hosts that do not hibernate may omit
+   * this; a throwing implementation is reported but never changes room
+   * behavior.
+   */
+  persist?(snapshot: PresencePeerSnapshot): void | Promise<void>;
+}
+
+/** Everything a hibernating transport must persist to survive eviction. */
+export interface PresencePeerSnapshot {
+  readonly authorizationExpiresAt: number;
+  readonly connectionId: string;
+  readonly credential: CollabCredential;
+  readonly heartbeatExpiresAt: number;
+  readonly identity: PresenceIdentity;
+  readonly joined: boolean;
+  readonly rateLimit: PresenceRateLimitState | null;
+}
+
+/** Server-owned session metadata restored by a hibernating transport host. */
+export interface PresenceRoomResumeState {
+  readonly connectionId: string;
+  readonly credential: CollabCredential;
+  /** Preserved as-is; the room does not recompute it on resume. */
+  readonly heartbeatExpiresAt: number;
+  readonly identity: PresenceIdentity;
+  readonly joined: boolean;
+  readonly rateLimit: PresenceRateLimitState | null;
+}
+
+export const PRESENCE_ROOM_REFRESH_MODE = {
+  Background: "background",
+  OnMessage: "on-message",
+} as const;
+
+export type PresenceRoomRefreshMode =
+  (typeof PRESENCE_ROOM_REFRESH_MODE)[keyof typeof PRESENCE_ROOM_REFRESH_MODE];
+
+export interface PresenceRoomOptions {
+  /** Background timers are the default; hibernating hosts refresh on messages. */
+  readonly refreshMode?: PresenceRoomRefreshMode;
+}
+
+export interface PresenceRoomPolicy {
+  /** Positive cadence for revalidating cached presence authorization. */
+  readonly authorizationRefreshIntervalMs: number;
+  readonly connection: ConnectionPolicy;
+  /** Positive silence window before a peer is closed with 1001. */
+  readonly heartbeatExpiryMs: number;
+  /** Positive TTL applied to every stored member on Join/Heartbeat/Update. */
+  readonly memberTtlMs: number;
+}
+
+export const DEFAULT_PRESENCE_ROOM_POLICY: PresenceRoomPolicy = Object.freeze({
+  authorizationRefreshIntervalMs: 8_000,
+  connection: Object.freeze({
+    leaseRefreshIntervalMs: 15_000,
+    leaseTtlMs: 30_000,
+    maxConnectionsPerDocument: 100,
+  }),
+  heartbeatExpiryMs: 30_000,
+  memberTtlMs: 30_000,
+});
+
+/** Infrastructure capabilities consumed by presence room semantics. */
+export interface PresenceRoomServices {
+  readonly codec: PresenceCodec;
+  readonly connections: ConnectionLimiter;
+  readonly fanout: PresenceFanout;
+  readonly policy: PresenceRoomPolicy;
+  /** Optional host observability; reporter failures are ignored by the room. */
+  readonly reportError?: PresenceRoomErrorReporter;
+  readonly sessions: PresenceSessionHooks;
+  readonly store: PresenceStore;
+}
+
+export interface PresenceRoomErrorContext {
+  readonly messageType?: string;
+  readonly peerId?: string;
+  readonly roomId: string;
+}
+
+export type PresenceRoomErrorReporter = (
+  error: unknown,
+  context: PresenceRoomErrorContext,
+) => void;
+
+/**
+ * Runtime-independent presence state-machine boundary for one room.
+ * Structurally mirrors `DocumentRoom` but owns no document convergence
+ * state and shares no capability instance with it — a presence failure
+ * structurally cannot block durable document convergence.
+ *
+ * Implementations receive raw inbound frame text; rate-limit consumption
+ * runs before parsing, so a malformed frame still consumes quota. Leave and
+ * close must tolerate partial setup and release room subscriptions,
+ * sessions, and connection leases idempotently. Calls that affect the same
+ * peer may arrive concurrently; the room synchronizes their state
+ * transitions so receive/leave races cannot create duplicate sessions or
+ * leak resources.
+ *
+ * An Auth frame is rejected before authorization unless its room id exactly
+ * matches this room. Every session, store call, and fan-out delivery
+ * remains scoped to the same room id; cross-room fan-out is never
+ * delivered.
+ */
+export interface PresenceRoom {
+  readonly roomId: string;
+  join(peer: PresencePeer): Promise<void>;
+  /**
+   * Restores an already-established transport session without another wire
+   * Auth or Auth-ok exchange. Access is always revalidated before resources
+   * are reacquired. A null result means the peer was closed and cleaned up.
+   */
+  resume(
+    peer: PresencePeer,
+    state: PresenceRoomResumeState,
+  ): Promise<PresenceSession | null>;
+  receive(peer: PresencePeer, rawMessage: string): Promise<void>;
+  leave(peer: PresencePeer, reason?: RoomLeaveReason): Promise<void>;
+  close(): Promise<void>;
+  /**
+   * Closes peers past their heartbeat deadline and drains lapsed store
+   * members into Leave broadcasts. Safe to call redundantly (idempotent) —
+   * a `Background` host never needs to call it, an `OnMessage` host calls it
+   * on every inbound frame, and a Durable Object alarm may call it directly
+   * to drive liveness without a per-peer timer.
+   */
+  sweep(now?: number): Promise<void>;
+}

--- a/packages/collab-runtime/src/presence-session.ts
+++ b/packages/collab-runtime/src/presence-session.ts
@@ -1,0 +1,58 @@
+import type { CollabCredential } from "@softmaple/collab-protocol";
+
+/** Server-authoritative presence identity. Never re-derived from a client frame. */
+export interface PresenceIdentity {
+  readonly avatarUrl?: string;
+  readonly name: string;
+  readonly userId: string;
+}
+
+export interface PresenceSession {
+  readonly connectionId: string;
+  readonly identity: PresenceIdentity;
+  readonly roomId: string;
+}
+
+export interface PresenceSessionAuthorizationRequest {
+  readonly connectionId: string;
+  readonly credential: CollabCredential;
+  readonly roomId: string;
+  /** Client-claimed userId; the hook must reject a mismatch against the resolved identity. */
+  readonly userId: string;
+}
+
+export interface PresenceSessionRefreshRequest {
+  readonly connectionId: string;
+  readonly credential: CollabCredential;
+  readonly session: PresenceSession;
+}
+
+export const PRESENCE_SESSION_END_REASON = {
+  AccessRevoked: "access-revoked",
+  PeerLeft: "peer-left",
+  RoomClosed: "room-closed",
+} as const;
+
+export type PresenceSessionEndReason =
+  (typeof PRESENCE_SESSION_END_REASON)[keyof typeof PRESENCE_SESSION_END_REASON];
+
+/**
+ * Host-provided presence identity hooks. Presence is authenticated-only —
+ * there is no public-access path. Implementations may use any auth
+ * provider, but room semantics only consume the normalized identity
+ * returned here.
+ */
+export interface PresenceSessionHooks {
+  /** Returns null for denied access; throws when the provider is unavailable. */
+  authorize(
+    request: PresenceSessionAuthorizationRequest,
+  ): Promise<PresenceIdentity | null>;
+  /** Returns null for revoked access; throws when the provider is unavailable. */
+  refresh(
+    request: PresenceSessionRefreshRequest,
+  ): Promise<PresenceIdentity | null>;
+  end?(
+    session: PresenceSession,
+    reason: PresenceSessionEndReason,
+  ): Promise<void>;
+}

--- a/packages/collab-runtime/src/presence-store.ts
+++ b/packages/collab-runtime/src/presence-store.ts
@@ -1,0 +1,53 @@
+/** A member the room removed because its TTL lapsed on a read. */
+export interface ExpiredPresenceMember {
+  readonly connectionId: string;
+  readonly userId: string;
+}
+
+/**
+ * Room-owned identity fields on a stored presence member. Every other field
+ * (cursor, selection, name, color, activity/liveness timestamps, `meta`) is
+ * codec-owned payload the store never inspects; awareness's `PresenceUser`
+ * is structurally assignable to this.
+ */
+export interface PresenceMemberRecord {
+  readonly clock: number;
+  readonly connectionId: string;
+  readonly userId: string;
+}
+
+/**
+ * A store read purges lapsed members as a side effect. `expired` reports
+ * exactly the members removed by that read so the room can fan out one
+ * Leave per lapsed member; `members` are opaque records the room validates
+ * with `PresenceCodec.isMember`.
+ */
+export interface PresenceMemberPage {
+  readonly expired: ReadonlyArray<ExpiredPresenceMember>;
+  readonly members: ReadonlyArray<unknown>;
+}
+
+/**
+ * TTL-backed presence membership for one room. Implementations purge lapsed
+ * members lazily on read; there is no separate expiry callback. Same-room
+ * calls do not need to serialize with each other beyond what each method
+ * individually guarantees.
+ */
+export interface PresenceStore {
+  /** Returns null when absent or lapsed. */
+  getMember(roomId: string, connectionId: string): Promise<unknown | null>;
+  listMembers(roomId: string): Promise<PresenceMemberPage>;
+  /** False when the member is absent or already lapsed. */
+  refreshMember(
+    roomId: string,
+    connectionId: string,
+    ttlMs: number,
+  ): Promise<boolean>;
+  /** Returns the removed record, or null when nothing was stored. */
+  removeMember(roomId: string, connectionId: string): Promise<unknown>;
+  setMember(
+    roomId: string,
+    member: PresenceMemberRecord,
+    ttlMs: number,
+  ): Promise<void>;
+}

--- a/packages/collab-runtime/src/testing/capability-conformance.ts
+++ b/packages/collab-runtime/src/testing/capability-conformance.ts
@@ -1,0 +1,397 @@
+import type {
+  ConnectionLimiter,
+  ConnectionPolicy,
+} from "../connection-limiter";
+import type { PresenceFanout } from "../presence-fanout";
+import type { PresenceMemberRecord, PresenceStore } from "../presence-store";
+import { check, checkEqual, type ConformanceCase } from "./conformance-case";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const TEST_TTL_MS = 15;
+const TEST_TTL_MARGIN_MS = 60;
+
+const testMember = (
+  overrides: Partial<PresenceMemberRecord> = {},
+): PresenceMemberRecord => ({
+  clock: 0,
+  connectionId: "connection-1",
+  userId: "user-1",
+  ...overrides,
+});
+
+/**
+ * TTL purge-on-read, `expired[]` reported exactly once, absent-member reads,
+ * removal semantics, per-room isolation, and overwrite-on-set. Every
+ * `PresenceStore` adapter (memory, Redis, Durable Object storage) must pass
+ * this unmodified.
+ */
+export const presenceStoreConformance = (
+  createStore: () => PresenceStore,
+): ConformanceCase[] => [
+  {
+    name: "getMember returns null for an absent member",
+    async run() {
+      const store = createStore();
+      const member = await store.getMember("room-a", "missing");
+      check(member === null, "expected null for an absent member");
+    },
+  },
+  {
+    name: "setMember then getMember round-trips the record",
+    async run() {
+      const store = createStore();
+      const member = testMember();
+      await store.setMember("room-a", member, 60_000);
+      const stored = await store.getMember("room-a", member.connectionId);
+      checkEqual(stored, member, "expected the stored member to round-trip");
+    },
+  },
+  {
+    name: "setMember overwrites the prior record for the same connectionId",
+    async run() {
+      const store = createStore();
+      await store.setMember("room-a", testMember({ clock: 1 }), 60_000);
+      await store.setMember("room-a", testMember({ clock: 2 }), 60_000);
+      const page = await store.listMembers("room-a");
+      checkEqual(page.members.length, 1, "expected exactly one stored member");
+      checkEqual(
+        (page.members[0] as PresenceMemberRecord).clock,
+        2,
+        "expected the latest write to win",
+      );
+    },
+  },
+  {
+    name: "refreshMember returns false for an absent member",
+    async run() {
+      const store = createStore();
+      const refreshed = await store.refreshMember("room-a", "missing", 60_000);
+      check(
+        refreshed === false,
+        "expected refresh of an absent member to fail",
+      );
+    },
+  },
+  {
+    name: "refreshMember extends TTL for a live member",
+    async run() {
+      const store = createStore();
+      const member = testMember();
+      await store.setMember("room-a", member, TEST_TTL_MS);
+      const refreshed = await store.refreshMember(
+        "room-a",
+        member.connectionId,
+        60_000,
+      );
+      check(refreshed, "expected refresh of a live member to succeed");
+      await sleep(TEST_TTL_MS + TEST_TTL_MARGIN_MS);
+      const stored = await store.getMember("room-a", member.connectionId);
+      check(
+        stored !== null,
+        "expected the refreshed TTL to keep the member alive",
+      );
+    },
+  },
+  {
+    name: "removeMember returns the prior record and clears it",
+    async run() {
+      const store = createStore();
+      const member = testMember();
+      await store.setMember("room-a", member, 60_000);
+      const removed = await store.removeMember("room-a", member.connectionId);
+      checkEqual(removed, member, "expected the removed record to be returned");
+      const afterRemoval = await store.getMember("room-a", member.connectionId);
+      check(
+        afterRemoval === null,
+        "expected the member to be gone after removal",
+      );
+    },
+  },
+  {
+    name: "removeMember returns null when nothing was stored",
+    async run() {
+      const store = createStore();
+      const removed = await store.removeMember("room-a", "missing");
+      check(removed === null, "expected null when nothing was stored");
+    },
+  },
+  {
+    name: "members are isolated per room",
+    async run() {
+      const store = createStore();
+      await store.setMember("room-a", testMember(), 60_000);
+      const page = await store.listMembers("room-b");
+      checkEqual(
+        page.members.length,
+        0,
+        "expected an unrelated room to be empty",
+      );
+    },
+  },
+  {
+    name: "a lapsed member is purged on read and reported in expired[]",
+    async run() {
+      const store = createStore();
+      const member = testMember();
+      await store.setMember("room-a", member, TEST_TTL_MS);
+      await sleep(TEST_TTL_MS + TEST_TTL_MARGIN_MS);
+      const page = await store.listMembers("room-a");
+      checkEqual(
+        page.members.length,
+        0,
+        "expected the lapsed member to be purged",
+      );
+      checkEqual(page.expired.length, 1, "expected exactly one expired member");
+      checkEqual(
+        page.expired[0]?.connectionId,
+        member.connectionId,
+        "expected the expired entry to identify the lapsed connection",
+      );
+    },
+  },
+  {
+    name: "a purged member is not reported expired again",
+    async run() {
+      const store = createStore();
+      const member = testMember();
+      await store.setMember("room-a", member, TEST_TTL_MS);
+      await sleep(TEST_TTL_MS + TEST_TTL_MARGIN_MS);
+      await store.listMembers("room-a");
+      const second = await store.listMembers("room-a");
+      checkEqual(second.expired.length, 0, "expected no repeat expiry report");
+    },
+  },
+];
+
+/**
+ * Loopback delivery (required for browser self-suppression by senderId),
+ * cross-subscription fan-out, cross-room isolation, idempotent unsubscribe,
+ * and frame-identity preservation.
+ */
+export const presenceFanoutConformance = (
+  createFanout: () => PresenceFanout,
+): ConformanceCase[] => [
+  {
+    name: "publish delivers to the publisher's own subscription",
+    async run() {
+      const fanout = createFanout();
+      const received: unknown[] = [];
+      await fanout.subscribe("room-a", (broadcast) => {
+        received.push(broadcast.frame);
+      });
+      await fanout.publish({ frame: { hello: "world" }, roomId: "room-a" });
+      checkEqual(
+        received.length,
+        1,
+        "expected loopback delivery to the publisher",
+      );
+    },
+  },
+  {
+    name: "publish delivers to every subscription on the same room",
+    async run() {
+      const fanout = createFanout();
+      let first = 0;
+      let second = 0;
+      await fanout.subscribe("room-a", () => {
+        first += 1;
+      });
+      await fanout.subscribe("room-a", () => {
+        second += 1;
+      });
+      await fanout.publish({ frame: {}, roomId: "room-a" });
+      checkEqual(
+        first,
+        1,
+        "expected the first subscription to receive one delivery",
+      );
+      checkEqual(
+        second,
+        1,
+        "expected the second subscription to receive one delivery",
+      );
+    },
+  },
+  {
+    name: "publish does not cross rooms",
+    async run() {
+      const fanout = createFanout();
+      let deliveries = 0;
+      await fanout.subscribe("room-a", () => {
+        deliveries += 1;
+      });
+      await fanout.publish({ frame: {}, roomId: "room-b" });
+      checkEqual(deliveries, 0, "expected no cross-room delivery");
+    },
+  },
+  {
+    name: "unsubscribe stops delivery and is idempotent",
+    async run() {
+      const fanout = createFanout();
+      let deliveries = 0;
+      const subscription = await fanout.subscribe("room-a", () => {
+        deliveries += 1;
+      });
+      await subscription.unsubscribe();
+      await subscription.unsubscribe();
+      await fanout.publish({ frame: {}, roomId: "room-a" });
+      checkEqual(deliveries, 0, "expected no delivery after unsubscribe");
+    },
+  },
+  {
+    name: "the delivered frame is the exact published value",
+    async run() {
+      const fanout = createFanout();
+      const frame = { marker: "unique" };
+      let deliveredFrame: unknown;
+      await fanout.subscribe("room-a", (broadcast) => {
+        deliveredFrame = broadcast.frame;
+      });
+      await fanout.publish({ frame, roomId: "room-a" });
+      checkEqual(
+        deliveredFrame,
+        frame,
+        "expected the exact frame to be delivered",
+      );
+    },
+  },
+];
+
+const testPolicy = (
+  overrides: Partial<ConnectionPolicy> = {},
+): ConnectionPolicy => ({
+  leaseRefreshIntervalMs: 15_000,
+  leaseTtlMs: 60_000,
+  maxConnectionsPerDocument: 2,
+  ...overrides,
+});
+
+/**
+ * Capacity/duplicate admission, lease refresh-after-release, and idempotent
+ * release. Run against both the Redis-backed and Durable-Object-backed
+ * adapters as the direct evidence that connection limits do not require a
+ * distributed lease in the Durable Object runtime.
+ */
+export const connectionLimiterConformance = (
+  createLimiter: () => ConnectionLimiter,
+): ConformanceCase[] => [
+  {
+    name: "acquire succeeds up to capacity and rejects the next admission",
+    async run() {
+      const limiter = createLimiter();
+      const policy = testPolicy({ maxConnectionsPerDocument: 2 });
+      const first = await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-1",
+        policy,
+        sessionId: "session-1",
+      });
+      const second = await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-2",
+        policy,
+        sessionId: "session-2",
+      });
+      const third = await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-3",
+        policy,
+        sessionId: "session-3",
+      });
+      check(first.accepted, "expected the first admission to be accepted");
+      check(second.accepted, "expected the second admission to be accepted");
+      check(!third.accepted, "expected capacity to reject the third admission");
+      if (!third.accepted) {
+        checkEqual(third.reason, "capacity", "expected a capacity rejection");
+      }
+    },
+  },
+  {
+    name: "acquire rejects a duplicate peerId",
+    async run() {
+      const limiter = createLimiter();
+      const policy = testPolicy();
+      await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-1",
+        policy,
+        sessionId: "session-1",
+      });
+      const duplicate = await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-1",
+        policy,
+        sessionId: "session-2",
+      });
+      check(!duplicate.accepted, "expected a duplicate peerId to be rejected");
+      if (!duplicate.accepted) {
+        checkEqual(
+          duplicate.reason,
+          "duplicate",
+          "expected a duplicate rejection",
+        );
+      }
+    },
+  },
+  {
+    name: "refresh returns false once the lease is released",
+    async run() {
+      const limiter = createLimiter();
+      const admission = await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-1",
+        policy: testPolicy(),
+        sessionId: "session-1",
+      });
+      check(admission.accepted, "expected the admission to be accepted");
+      if (!admission.accepted) return;
+      await admission.lease.release();
+      const refreshed = await admission.lease.refresh();
+      check(!refreshed, "expected refresh to fail after release");
+    },
+  },
+  {
+    name: "release is idempotent",
+    async run() {
+      const limiter = createLimiter();
+      const admission = await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-1",
+        policy: testPolicy(),
+        sessionId: "session-1",
+      });
+      check(admission.accepted, "expected the admission to be accepted");
+      if (!admission.accepted) return;
+      await admission.lease.release();
+      await admission.lease.release();
+    },
+  },
+  {
+    name: "a released peerId can be re-acquired",
+    async run() {
+      const limiter = createLimiter();
+      const policy = testPolicy();
+      const admission = await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-1",
+        policy,
+        sessionId: "session-1",
+      });
+      check(admission.accepted, "expected the admission to be accepted");
+      if (!admission.accepted) return;
+      await admission.lease.release();
+      const reacquired = await limiter.acquire({
+        documentId: "room-a",
+        peerId: "peer-1",
+        policy,
+        sessionId: "session-2",
+      });
+      check(
+        reacquired.accepted,
+        "expected a released peerId to be re-acquirable",
+      );
+    },
+  },
+];

--- a/packages/collab-runtime/src/testing/conformance-case.ts
+++ b/packages/collab-runtime/src/testing/conformance-case.ts
@@ -1,0 +1,48 @@
+/**
+ * A single named conformance assertion. Kept assertion-library-free so this
+ * directory stays free of `vitest` (the collab-runtime lint allowlist
+ * rejects it like any other bare specifier); a host wraps each case with
+ * its own test runner, e.g. `for (const c of suite) it(c.name, c.run)`.
+ */
+export interface ConformanceCase {
+  readonly name: string;
+  run(): Promise<void>;
+}
+
+export const check = (condition: boolean, message: string): void => {
+  if (!condition) throw new Error(message);
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (Object.is(a, b)) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return (
+      a.length === b.length &&
+      a.every((item, index) => deepEqual(item, b[index]))
+    );
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (key) => Object.hasOwn(b, key) && deepEqual(a[key], b[key]),
+    );
+  }
+  return false;
+};
+
+export const checkEqual = <T>(
+  actual: T,
+  expected: T,
+  message: string,
+): void => {
+  if (!deepEqual(actual, expected)) {
+    throw new Error(
+      `${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+};

--- a/packages/collab-runtime/src/testing/fakes.ts
+++ b/packages/collab-runtime/src/testing/fakes.ts
@@ -1,0 +1,462 @@
+import type { CollabCredential } from "@softmaple/collab-protocol";
+import {
+  CONNECTION_REJECTION_REASON,
+  type ConnectionLimiter,
+} from "../connection-limiter";
+import {
+  PRESENCE_MESSAGE,
+  type PresenceCodec,
+  type PresenceEnvelope,
+  type PresencePatch,
+} from "../presence-codec";
+import type {
+  PresenceBroadcast,
+  PresenceFanout,
+  PresenceFanoutHandler,
+} from "../presence-fanout";
+import type { PresencePeer, PresencePeerSnapshot } from "../presence-room";
+import type {
+  PresenceIdentity,
+  PresenceSession,
+  PresenceSessionAuthorizationRequest,
+  PresenceSessionEndReason,
+  PresenceSessionHooks,
+  PresenceSessionRefreshRequest,
+} from "../presence-session";
+import type {
+  ExpiredPresenceMember,
+  PresenceMemberRecord,
+  PresenceStore,
+} from "../presence-store";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Same purge-on-read TTL semantics as the Redis/Durable Object stores under test. */
+export const createMemoryPresenceStore = (): PresenceStore => {
+  const rooms = new Map<
+    string,
+    Map<string, { readonly expiresAt: number; readonly member: unknown }>
+  >();
+
+  const purge = (
+    roomId: string,
+    now: number,
+  ): {
+    readonly entries: Map<string, { expiresAt: number; member: unknown }>;
+    readonly expired: ExpiredPresenceMember[];
+  } => {
+    const entries =
+      rooms.get(roomId) ??
+      new Map<string, { expiresAt: number; member: unknown }>();
+    const expired: ExpiredPresenceMember[] = [];
+    for (const [connectionId, entry] of entries) {
+      if (entry.expiresAt <= now) {
+        entries.delete(connectionId);
+        const userId =
+          isRecord(entry.member) && typeof entry.member.userId === "string"
+            ? entry.member.userId
+            : connectionId;
+        expired.push({ connectionId, userId });
+      }
+    }
+    if (entries.size === 0) rooms.delete(roomId);
+    else rooms.set(roomId, entries);
+    return { entries, expired };
+  };
+
+  return {
+    async getMember(roomId, connectionId) {
+      const { entries } = purge(roomId, Date.now());
+      return entries.get(connectionId)?.member ?? null;
+    },
+    async listMembers(roomId) {
+      const { entries, expired } = purge(roomId, Date.now());
+      return {
+        expired,
+        members: [...entries.values()].map((entry) => entry.member),
+      };
+    },
+    async refreshMember(roomId, connectionId, ttlMs) {
+      const { entries } = purge(roomId, Date.now());
+      const current = entries.get(connectionId);
+      if (current === undefined) return false;
+      entries.set(connectionId, {
+        member: current.member,
+        expiresAt: Date.now() + ttlMs,
+      });
+      rooms.set(roomId, entries);
+      return true;
+    },
+    async removeMember(roomId, connectionId) {
+      const entries = rooms.get(roomId);
+      if (entries === undefined) return null;
+      const current = entries.get(connectionId)?.member ?? null;
+      entries.delete(connectionId);
+      if (entries.size === 0) rooms.delete(roomId);
+      return current;
+    },
+    async setMember(roomId, member, ttlMs) {
+      const { entries } = purge(roomId, Date.now());
+      entries.set(member.connectionId, {
+        member,
+        expiresAt: Date.now() + ttlMs,
+      });
+      rooms.set(roomId, entries);
+    },
+  };
+};
+
+/** Loopback-preserving cross-instance broadcast fake, scoped per room id. */
+export const createMemoryPresenceFanout = (): PresenceFanout => {
+  const handlers = new Map<string, Set<PresenceFanoutHandler>>();
+
+  return {
+    async publish(broadcast: PresenceBroadcast) {
+      const subscribers = handlers.get(broadcast.roomId);
+      if (subscribers === undefined) return;
+      await Promise.all([...subscribers].map((handler) => handler(broadcast)));
+    },
+    async subscribe(roomId, handler) {
+      const subscribers =
+        handlers.get(roomId) ?? new Set<PresenceFanoutHandler>();
+      subscribers.add(handler);
+      handlers.set(roomId, subscribers);
+      let subscribed = true;
+      return {
+        async unsubscribe() {
+          if (!subscribed) return;
+          subscribed = false;
+          const current = handlers.get(roomId);
+          current?.delete(handler);
+          if (current?.size === 0) handlers.delete(roomId);
+        },
+      };
+    },
+  };
+};
+
+export interface MemoryConnectionLimiterOptions {
+  /** Overrides the per-request policy ceiling; pass Infinity for an unlimited fake. */
+  readonly maxConnectionsPerDocument?: number;
+}
+
+/** In-memory admission fake respecting capacity, duplicates, and lease TTL. */
+export const createMemoryConnectionLimiter = (
+  options: MemoryConnectionLimiterOptions = {},
+): ConnectionLimiter => {
+  const rooms = new Map<string, Map<string, { expiresAt: number }>>();
+
+  const purge = (
+    documentId: string,
+    now: number,
+  ): Map<string, { expiresAt: number }> => {
+    const entries =
+      rooms.get(documentId) ?? new Map<string, { expiresAt: number }>();
+    for (const [peerId, entry] of entries) {
+      if (entry.expiresAt <= now) entries.delete(peerId);
+    }
+    if (entries.size === 0) rooms.delete(documentId);
+    else rooms.set(documentId, entries);
+    return entries;
+  };
+
+  return {
+    async acquire(request) {
+      const now = Date.now();
+      const entries = purge(request.documentId, now);
+      if (entries.has(request.peerId)) {
+        return {
+          accepted: false,
+          reason: CONNECTION_REJECTION_REASON.Duplicate,
+        };
+      }
+      const capacity =
+        options.maxConnectionsPerDocument ??
+        request.policy.maxConnectionsPerDocument;
+      if (entries.size >= capacity) {
+        return {
+          accepted: false,
+          reason: CONNECTION_REJECTION_REASON.Capacity,
+        };
+      }
+      entries.set(request.peerId, {
+        expiresAt: now + request.policy.leaseTtlMs,
+      });
+      rooms.set(request.documentId, entries);
+      let released = false;
+      return {
+        accepted: true,
+        lease: {
+          async refresh() {
+            if (released) return false;
+            const live = purge(request.documentId, Date.now());
+            if (!live.has(request.peerId)) return false;
+            live.set(request.peerId, {
+              expiresAt: Date.now() + request.policy.leaseTtlMs,
+            });
+            rooms.set(request.documentId, live);
+            return true;
+          },
+          async release() {
+            if (released) return;
+            released = true;
+            const live = rooms.get(request.documentId);
+            live?.delete(request.peerId);
+            if (live !== undefined && live.size === 0) {
+              rooms.delete(request.documentId);
+            }
+          },
+        },
+      };
+    },
+  };
+};
+
+export interface RecordingPresencePeer extends PresencePeer {
+  readonly closes: Array<{ readonly code: number; readonly reason: string }>;
+  readonly persisted: Array<PresencePeerSnapshot>;
+  /** Mutable so a test can clear it (`peer.sent.length = 0`) between assertions. */
+  readonly sent: unknown[];
+  closeImpl: (code: number, reason: string) => Promise<void>;
+  sendImpl: (frame: unknown) => Promise<void>;
+}
+
+/** Records sends/closes/persisted snapshots; `closeImpl`/`sendImpl` inject faults. */
+export const createRecordingPresencePeer = (
+  id: string,
+): RecordingPresencePeer => {
+  const closes: Array<{ code: number; reason: string }> = [];
+  const persisted: PresencePeerSnapshot[] = [];
+  const sent: unknown[] = [];
+
+  const peer: RecordingPresencePeer = {
+    id,
+    closes,
+    persisted,
+    sent,
+    closeImpl: async () => undefined,
+    sendImpl: async () => undefined,
+    async close(code, reason) {
+      closes.push({ code, reason });
+      await peer.closeImpl(code, reason);
+    },
+    async send(frame) {
+      await peer.sendImpl(frame);
+      sent.push(frame);
+    },
+    async persist(snapshot) {
+      persisted.push(snapshot);
+    },
+  };
+  return peer;
+};
+
+export interface StubPresenceSessionHooks extends PresenceSessionHooks {
+  readonly ends: ReadonlyArray<{
+    readonly reason: PresenceSessionEndReason;
+    readonly session: PresenceSession;
+  }>;
+  authorizeImpl: (
+    request: PresenceSessionAuthorizationRequest,
+  ) => Promise<PresenceIdentity | null>;
+  refreshImpl: (
+    request: PresenceSessionRefreshRequest,
+  ) => Promise<PresenceIdentity | null>;
+}
+
+/** Authorizes any userId with a deterministic identity; override the *Impl hooks to test failure paths. */
+export const createStubPresenceSessionHooks = (): StubPresenceSessionHooks => {
+  const ends: Array<{
+    reason: PresenceSessionEndReason;
+    session: PresenceSession;
+  }> = [];
+
+  const hooks: StubPresenceSessionHooks = {
+    ends,
+    authorizeImpl: async (request) => ({
+      name: `User ${request.userId}`,
+      userId: request.userId,
+    }),
+    refreshImpl: async (request) => request.session.identity,
+    async authorize(request) {
+      return hooks.authorizeImpl(request);
+    },
+    async refresh(request) {
+      return hooks.refreshImpl(request);
+    },
+    async end(session, reason) {
+      ends.push({ reason, session });
+    },
+  };
+  return hooks;
+};
+
+/** The wire type strings `createOpaqueTestCodec` understands. */
+export const TEST_PRESENCE_WIRE_TYPE = {
+  Auth: "test:auth",
+  Heartbeat: "test:heartbeat",
+  Join: "test:join",
+  Leave: "test:leave",
+  Sync: "test:sync",
+  Update: "test:update",
+} as const;
+
+interface TestMemberRecord extends PresenceMemberRecord {
+  readonly extra?: unknown;
+  readonly name: string;
+}
+
+interface TestPatchPayload {
+  readonly extra?: unknown;
+}
+
+/**
+ * A self-contained `PresenceCodec` with its own dependency-free wire format
+ * (`TEST_PRESENCE_WIRE_TYPE`). This is what lets PR1's own tests run before
+ * `@softmaple/awareness/protocol` exists — the codec is a capability rather
+ * than a direct import.
+ */
+export const createOpaqueTestCodec = (): PresenceCodec => ({
+  applyPatch(current, patch) {
+    const extra = (patch as PresencePatch & TestPatchPayload).extra;
+    const currentAsTestMember = current as unknown as TestMemberRecord;
+    const currentName =
+      typeof currentAsTestMember.name === "string"
+        ? currentAsTestMember.name
+        : current.userId;
+    const member: TestMemberRecord = {
+      clock: patch.clock,
+      connectionId: current.connectionId,
+      name: currentName,
+      userId: current.userId,
+      ...(extra === undefined ? {} : { extra }),
+    };
+    return {
+      broadcastPayload: {
+        clock: patch.clock,
+        ...(extra === undefined ? {} : { extra }),
+      },
+      member,
+    };
+  },
+  classify(envelope: PresenceEnvelope) {
+    switch (envelope.type) {
+      case TEST_PRESENCE_WIRE_TYPE.Auth:
+        return PRESENCE_MESSAGE.Auth;
+      case TEST_PRESENCE_WIRE_TYPE.Join:
+        return PRESENCE_MESSAGE.Join;
+      case TEST_PRESENCE_WIRE_TYPE.Leave:
+        return PRESENCE_MESSAGE.Leave;
+      case TEST_PRESENCE_WIRE_TYPE.Sync:
+        return PRESENCE_MESSAGE.Sync;
+      case TEST_PRESENCE_WIRE_TYPE.Heartbeat:
+        return PRESENCE_MESSAGE.Heartbeat;
+      case TEST_PRESENCE_WIRE_TYPE.Update:
+        return PRESENCE_MESSAGE.Update;
+      default:
+        throw new Error(`unsupported presence wire type: ${envelope.type}`);
+    }
+  },
+  consumeQuota(current, now) {
+    const maximum = 80;
+    const windowMs = 10_000;
+    const state =
+      isRecord(current) &&
+      typeof current.count === "number" &&
+      typeof current.windowStartedAt === "number"
+        ? { count: current.count, windowStartedAt: current.windowStartedAt }
+        : null;
+    if (state === null || now - state.windowStartedAt >= windowMs) {
+      return { allowed: true, state: { count: 1, windowStartedAt: now } };
+    }
+    if (state.count >= maximum) return { allowed: false, state };
+    return {
+      allowed: true,
+      state: { count: state.count + 1, windowStartedAt: state.windowStartedAt },
+    };
+  },
+  createMember(identity, connectionId) {
+    return {
+      clock: 0,
+      connectionId,
+      name: identity.name,
+      userId: identity.userId,
+    };
+  },
+  encode(kind, roomId, senderId, payload) {
+    return { payload, roomId, senderId, type: kind };
+  },
+  isMember(value): value is PresenceMemberRecord {
+    return (
+      isRecord(value) &&
+      typeof value.connectionId === "string" &&
+      typeof value.userId === "string" &&
+      typeof value.clock === "number"
+    );
+  },
+  parseAuth(payload) {
+    if (
+      !isRecord(payload) ||
+      typeof payload.connectionId !== "string" ||
+      payload.connectionId.length === 0 ||
+      typeof payload.userId !== "string" ||
+      payload.userId.length === 0 ||
+      payload.credential === undefined
+    ) {
+      throw new Error("invalid test presence auth payload");
+    }
+    return {
+      connectionId: payload.connectionId,
+      credential: payload.credential as CollabCredential,
+      userId: payload.userId,
+    };
+  },
+  parseEnvelope(value) {
+    if (
+      !isRecord(value) ||
+      typeof value.type !== "string" ||
+      value.type.length === 0 ||
+      typeof value.roomId !== "string" ||
+      value.roomId.length === 0 ||
+      typeof value.senderId !== "string" ||
+      value.senderId.length === 0
+    ) {
+      throw new Error("invalid test presence envelope");
+    }
+    return {
+      roomId: value.roomId,
+      senderId: value.senderId,
+      type: value.type,
+      ...(value.payload === undefined ? {} : { payload: value.payload }),
+    };
+  },
+  parseHeartbeat(payload) {
+    if (
+      !isRecord(payload) ||
+      typeof payload.pingId !== "string" ||
+      payload.pingId.length === 0
+    ) {
+      throw new Error("invalid test presence heartbeat");
+    }
+    return payload.pingId;
+  },
+  parsePatch(payload) {
+    if (
+      !isRecord(payload) ||
+      typeof payload.connectionId !== "string" ||
+      typeof payload.userId !== "string" ||
+      typeof payload.clock !== "number" ||
+      !Number.isSafeInteger(payload.clock) ||
+      payload.clock < 1
+    ) {
+      throw new Error("invalid test presence patch");
+    }
+    return {
+      clock: payload.clock,
+      connectionId: payload.connectionId,
+      userId: payload.userId,
+      ...(payload.extra === undefined ? {} : { extra: payload.extra }),
+    } as PresencePatch & TestPatchPayload;
+  },
+});

--- a/packages/collab-runtime/src/testing/fakes.ts
+++ b/packages/collab-runtime/src/testing/fakes.ts
@@ -214,7 +214,11 @@ export const createMemoryConnectionLimiter = (
             released = true;
             const live = rooms.get(request.documentId);
             const entry = live?.get(request.peerId);
-            if (entry !== undefined && entry.token === token && live !== undefined) {
+            if (
+              entry !== undefined &&
+              entry.token === token &&
+              live !== undefined
+            ) {
               live.delete(request.peerId);
               if (live.size === 0) {
                 rooms.delete(request.documentId);

--- a/packages/collab-runtime/src/testing/fakes.ts
+++ b/packages/collab-runtime/src/testing/fakes.ts
@@ -89,12 +89,14 @@ export const createMemoryPresenceStore = (): PresenceStore => {
       return true;
     },
     async removeMember(roomId, connectionId) {
-      const entries = rooms.get(roomId);
-      if (entries === undefined) return null;
-      const current = entries.get(connectionId)?.member ?? null;
+      const { entries } = purge(roomId, Date.now());
+      const current = entries.get(connectionId);
+      if (current === undefined) return null;
+      if (current.expiresAt <= Date.now()) return null;
       entries.delete(connectionId);
       if (entries.size === 0) rooms.delete(roomId);
-      return current;
+      else rooms.set(roomId, entries);
+      return current.member;
     },
     async setMember(roomId, member, ttlMs) {
       const { entries } = purge(roomId, Date.now());
@@ -145,14 +147,19 @@ export interface MemoryConnectionLimiterOptions {
 export const createMemoryConnectionLimiter = (
   options: MemoryConnectionLimiterOptions = {},
 ): ConnectionLimiter => {
-  const rooms = new Map<string, Map<string, { expiresAt: number }>>();
+  const rooms = new Map<
+    string,
+    Map<string, { expiresAt: number; token: number }>
+  >();
+  let nextToken = 1;
 
   const purge = (
     documentId: string,
     now: number,
-  ): Map<string, { expiresAt: number }> => {
+  ): Map<string, { expiresAt: number; token: number }> => {
     const entries =
-      rooms.get(documentId) ?? new Map<string, { expiresAt: number }>();
+      rooms.get(documentId) ??
+      new Map<string, { expiresAt: number; token: number }>();
     for (const [peerId, entry] of entries) {
       if (entry.expiresAt <= now) entries.delete(peerId);
     }
@@ -180,8 +187,10 @@ export const createMemoryConnectionLimiter = (
           reason: CONNECTION_REJECTION_REASON.Capacity,
         };
       }
+      const token = nextToken++;
       entries.set(request.peerId, {
         expiresAt: now + request.policy.leaseTtlMs,
+        token,
       });
       rooms.set(request.documentId, entries);
       let released = false;
@@ -191,9 +200,11 @@ export const createMemoryConnectionLimiter = (
           async refresh() {
             if (released) return false;
             const live = purge(request.documentId, Date.now());
-            if (!live.has(request.peerId)) return false;
+            const entry = live.get(request.peerId);
+            if (entry === undefined || entry.token !== token) return false;
             live.set(request.peerId, {
               expiresAt: Date.now() + request.policy.leaseTtlMs,
+              token,
             });
             rooms.set(request.documentId, live);
             return true;
@@ -202,9 +213,12 @@ export const createMemoryConnectionLimiter = (
             if (released) return;
             released = true;
             const live = rooms.get(request.documentId);
-            live?.delete(request.peerId);
-            if (live !== undefined && live.size === 0) {
-              rooms.delete(request.documentId);
+            const entry = live?.get(request.peerId);
+            if (entry !== undefined && entry.token === token && live !== undefined) {
+              live.delete(request.peerId);
+              if (live.size === 0) {
+                rooms.delete(request.documentId);
+              }
             }
           },
         },

--- a/packages/collab-runtime/src/testing/index.ts
+++ b/packages/collab-runtime/src/testing/index.ts
@@ -1,0 +1,27 @@
+export {
+  check,
+  checkEqual,
+  type ConformanceCase,
+} from "./conformance-case";
+export {
+  connectionLimiterConformance,
+  presenceFanoutConformance,
+  presenceStoreConformance,
+} from "./capability-conformance";
+export {
+  TEST_PRESENCE_WIRE_TYPE,
+  createMemoryConnectionLimiter,
+  createMemoryPresenceFanout,
+  createMemoryPresenceStore,
+  createOpaqueTestCodec,
+  createRecordingPresencePeer,
+  createStubPresenceSessionHooks,
+  type MemoryConnectionLimiterOptions,
+  type RecordingPresencePeer,
+  type StubPresenceSessionHooks,
+} from "./fakes";
+export {
+  presenceRoomConformance,
+  type PresenceRoomFactory,
+  type PresenceRoomHarness,
+} from "./presence-room-conformance";

--- a/packages/collab-runtime/src/testing/presence-room-conformance.ts
+++ b/packages/collab-runtime/src/testing/presence-room-conformance.ts
@@ -582,7 +582,6 @@ export const presenceRoomConformance = (
         {
           clock: 0,
           connectionId: "connection-1",
-          name: identity.name,
           userId: identity.userId,
         },
         60_000,

--- a/packages/collab-runtime/src/testing/presence-room-conformance.ts
+++ b/packages/collab-runtime/src/testing/presence-room-conformance.ts
@@ -277,10 +277,7 @@ export const presenceRoomConformance = (
       const peer = createRecordingPresencePeer("connection-1");
       await room.join(peer);
       await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
-      await room.receive(
-        peer,
-        updateWire(ROOM_ID, "connection-1", "user-connection-1", 1),
-      );
+      await room.receive(peer, updateWire(ROOM_ID, "connection-1", "user-1", 1));
       checkEqual(
         peer.closes[0]?.code,
         1008,
@@ -556,6 +553,71 @@ export const presenceRoomConformance = (
           `expected exactly one Leave in ${refreshMode} mode`,
         );
       }
+    },
+  },
+  {
+    name: "a post-deadline frame in background mode still refreshes the heartbeat",
+    async run() {
+      const { room } = factory({ refreshMode: "background" });
+      const peer = await authenticateAndJoin(room, "connection-1");
+      const expiredTime = Date.now() + 10 * 60_000;
+      await room.sweep(expiredTime);
+      checkEqual(
+        peer.closes[0]?.code,
+        1001,
+        "expected heartbeat-expiry close in background mode",
+      );
+    },
+  },
+  {
+    name: "a post-deadline frame in on-message mode rearms before sweep",
+    async run() {
+      const { room, sessions } = factory({ refreshMode: "on-message" });
+      const identity1 = { name: "User 1", userId: "user-1" };
+      const identity2 = { name: "User 2", userId: "user-2" };
+      sessions.authorizeImpl = async (req) => {
+        if (req.userId === "user-1") return identity1;
+        if (req.userId === "user-2") return identity2;
+        return null;
+      };
+      sessions.refreshImpl = async (req) => {
+        if (req.session.identity.userId === "user-1") return identity1;
+        if (req.session.identity.userId === "user-2") return identity2;
+        return null;
+      };
+
+      // Create first peer with an already-expired heartbeat using resume
+      const first = createRecordingPresencePeer("connection-1");
+      const pastTime = Date.now() - 1000; // 1 second in the past
+      await room.resume(first, {
+        connectionId: "connection-1",
+        credential: { kind: "access-token", token: "t1" },
+        heartbeatExpiresAt: pastTime, // Already expired!
+        identity: identity1,
+        joined: true,
+        rateLimit: null,
+      });
+
+      // Create second peer normally
+      const second = await authenticateAndJoin(room, "connection-2", "user-2");
+
+      // When second peer sends a message, it will sweep and should close first peer
+      await room.receive(
+        second,
+        heartbeatWire(ROOM_ID, "connection-2", "ping-after-deadline"),
+      );
+
+      // The sweep triggered by second's message should have closed first
+      checkEqual(
+        first.closes[0]?.code,
+        1001,
+        "expected first peer to be closed by sweep",
+      );
+      checkEqual(
+        second.closes.length,
+        0,
+        "expected calling peer to remain open after triggering sweep",
+      );
     },
   },
 ];

--- a/packages/collab-runtime/src/testing/presence-room-conformance.ts
+++ b/packages/collab-runtime/src/testing/presence-room-conformance.ts
@@ -277,7 +277,10 @@ export const presenceRoomConformance = (
       const peer = createRecordingPresencePeer("connection-1");
       await room.join(peer);
       await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
-      await room.receive(peer, updateWire(ROOM_ID, "connection-1", "user-1", 1));
+      await room.receive(
+        peer,
+        updateWire(ROOM_ID, "connection-1", "user-1", 1),
+      );
       checkEqual(
         peer.closes[0]?.code,
         1008,

--- a/packages/collab-runtime/src/testing/presence-room-conformance.ts
+++ b/packages/collab-runtime/src/testing/presence-room-conformance.ts
@@ -561,14 +561,47 @@ export const presenceRoomConformance = (
   {
     name: "a post-deadline frame in background mode still refreshes the heartbeat",
     async run() {
-      const { room } = factory({ refreshMode: "background" });
-      const peer = await authenticateAndJoin(room, "connection-1");
-      const expiredTime = Date.now() + 10 * 60_000;
-      await room.sweep(expiredTime);
+      const { room, sessions } = factory({ refreshMode: "background" });
+      const identity = { name: "User 1", userId: "user-1" };
+      sessions.authorizeImpl = async () => identity;
+      sessions.refreshImpl = async () => identity;
+
+      // Resume a peer with an already-expired heartbeat
+      const peer = createRecordingPresencePeer("connection-1");
+      const pastTime = Date.now() - 1000; // 1 second in the past
+      await room.resume(peer, {
+        connectionId: "connection-1",
+        credential: { kind: "access-token", token: "t" },
+        heartbeatExpiresAt: pastTime, // Already expired!
+        identity,
+        joined: true,
+        rateLimit: null,
+      });
+
+      // Send a heartbeat frame after the deadline
+      peer.sent.length = 0;
+      await room.receive(
+        peer,
+        heartbeatWire(ROOM_ID, "connection-1", "ping-revival"),
+      );
+
+      // Assert that the peer remains open and receives the heartbeat acknowledgement
       checkEqual(
-        peer.closes[0]?.code,
-        1001,
-        "expected heartbeat-expiry close in background mode",
+        peer.closes.length,
+        0,
+        "expected peer to remain open after receiving heartbeat frame",
+      );
+      const acks = framesOfType(peer, PRESENCE_FRAME.HeartbeatAck);
+      checkEqual(
+        acks.length,
+        1,
+        "expected peer to receive heartbeat acknowledgement",
+      );
+      const ack = acks[0] as { payload: { pingId: string } };
+      checkEqual(
+        ack.payload.pingId,
+        "ping-revival",
+        "expected the pingId to be echoed",
       );
     },
   },

--- a/packages/collab-runtime/src/testing/presence-room-conformance.ts
+++ b/packages/collab-runtime/src/testing/presence-room-conformance.ts
@@ -1,0 +1,561 @@
+import { PRESENCE_FRAME } from "../presence-codec";
+import type { ConnectionLimiter } from "../connection-limiter";
+import type { PresenceFanout } from "../presence-fanout";
+import type { PresenceRoom, PresenceRoomOptions } from "../presence-room";
+import type { PresenceStore } from "../presence-store";
+import { check, checkEqual, type ConformanceCase } from "./conformance-case";
+import {
+  TEST_PRESENCE_WIRE_TYPE,
+  createRecordingPresencePeer,
+  type StubPresenceSessionHooks,
+} from "./fakes";
+
+export interface PresenceRoomHarness {
+  readonly connections: ConnectionLimiter;
+  readonly fanout: PresenceFanout;
+  readonly room: PresenceRoom;
+  readonly sessions: StubPresenceSessionHooks;
+  readonly store: PresenceStore;
+}
+
+/** Must return a fully independent harness (fresh fakes) on every call. */
+export type PresenceRoomFactory = (
+  options?: PresenceRoomOptions,
+) => PresenceRoomHarness;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const framesOfType = (
+  peer: ReturnType<typeof createRecordingPresencePeer>,
+  type: string,
+): unknown[] =>
+  peer.sent.filter((frame) => isRecord(frame) && frame.type === type);
+
+const wire = (
+  type: string,
+  roomId: string,
+  senderId: string,
+  payload?: unknown,
+): string => JSON.stringify({ payload, roomId, senderId, type });
+
+const authWire = (
+  roomId: string,
+  connectionId: string,
+  userId: string,
+): string =>
+  wire(TEST_PRESENCE_WIRE_TYPE.Auth, roomId, connectionId, {
+    connectionId,
+    credential: { kind: "access-token", token: "test-token" },
+    userId,
+  });
+
+const joinWire = (roomId: string, connectionId: string): string =>
+  wire(TEST_PRESENCE_WIRE_TYPE.Join, roomId, connectionId);
+
+const syncWire = (roomId: string, connectionId: string): string =>
+  wire(TEST_PRESENCE_WIRE_TYPE.Sync, roomId, connectionId);
+
+const heartbeatWire = (
+  roomId: string,
+  connectionId: string,
+  pingId: string,
+): string =>
+  wire(TEST_PRESENCE_WIRE_TYPE.Heartbeat, roomId, connectionId, { pingId });
+
+const updateWire = (
+  roomId: string,
+  connectionId: string,
+  userId: string,
+  clock: number,
+  extra?: unknown,
+): string =>
+  wire(TEST_PRESENCE_WIRE_TYPE.Update, roomId, connectionId, {
+    clock,
+    connectionId,
+    extra,
+    userId,
+  });
+
+const leaveWire = (roomId: string, connectionId: string): string =>
+  wire(TEST_PRESENCE_WIRE_TYPE.Leave, roomId, connectionId);
+
+const ROOM_ID = "room-a";
+
+/** Authenticates and joins one peer; asserts each step succeeded. */
+const authenticateAndJoin = async (
+  room: PresenceRoom,
+  connectionId: string,
+  userId = `user-${connectionId}`,
+): Promise<ReturnType<typeof createRecordingPresencePeer>> => {
+  const peer = createRecordingPresencePeer(connectionId);
+  await room.join(peer);
+  await room.receive(peer, authWire(ROOM_ID, connectionId, userId));
+  check(
+    framesOfType(peer, PRESENCE_FRAME.AuthOk).length === 1,
+    `expected ${connectionId} to receive exactly one auth-ok`,
+  );
+  await room.receive(peer, joinWire(ROOM_ID, connectionId));
+  check(
+    peer.closes.length === 0,
+    `expected ${connectionId} to stay open after joining`,
+  );
+  return peer;
+};
+
+/**
+ * Behavioural conformance for `PresenceRoom`: the full rule table (room
+ * match, sender binding, identity match, monotonic clock, TTL refresh, rate
+ * limiting, expiry, cleanup order, close codes) plus fan-out reach,
+ * resume-without-re-Auth, sweep idempotence, and refresh-mode equivalence.
+ */
+export const presenceRoomConformance = (
+  factory: PresenceRoomFactory,
+): ConformanceCase[] => [
+  {
+    name: "Auth denial closes 1008 and sends auth-error",
+    async run() {
+      const { room, sessions } = factory();
+      sessions.authorizeImpl = async () => null;
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      checkEqual(peer.closes[0]?.code, 1008, "expected a 1008 close on denial");
+      check(
+        framesOfType(peer, PRESENCE_FRAME.AuthError).length === 1,
+        "expected exactly one auth-error frame",
+      );
+    },
+  },
+  {
+    name: "Auth with a room-id mismatch closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(
+        peer,
+        authWire("other-room", "connection-1", "user-1"),
+      );
+      checkEqual(peer.closes[0]?.code, 1008, "expected a room-mismatch close");
+    },
+  },
+  {
+    name: "Auth with a sender/connectionId mismatch closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(
+        peer,
+        wire(TEST_PRESENCE_WIRE_TYPE.Auth, ROOM_ID, "someone-else", {
+          connectionId: "connection-1",
+          credential: { kind: "access-token", token: "t" },
+          userId: "user-1",
+        }),
+      );
+      checkEqual(
+        peer.closes[0]?.code,
+        1008,
+        "expected a sender-mismatch close",
+      );
+    },
+  },
+  {
+    name: "a second Auth closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      checkEqual(peer.closes[0]?.code, 1008, "expected a duplicate-auth close");
+    },
+  },
+  {
+    name: "a non-Auth message before authentication closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(peer, syncWire(ROOM_ID, "connection-1"));
+      checkEqual(
+        peer.closes[0]?.code,
+        1008,
+        "expected an unauthenticated close",
+      );
+    },
+  },
+  {
+    name: "a post-auth sender mismatch closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      await room.receive(peer, syncWire(ROOM_ID, "someone-else"));
+      checkEqual(
+        peer.closes[0]?.code,
+        1008,
+        "expected a sender-mismatch close",
+      );
+    },
+  },
+  {
+    name: "an unsupported wire type closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      await room.receive(peer, wire("nonsense", ROOM_ID, "connection-1"));
+      checkEqual(
+        peer.closes[0]?.code,
+        1008,
+        "expected an unsupported-type close",
+      );
+    },
+  },
+  {
+    name: "malformed JSON sends an error frame and does not close",
+    async run() {
+      const { room } = factory();
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(peer, "{not json");
+      check(peer.closes.length === 0, "expected no close for malformed JSON");
+      const errors = framesOfType(peer, PRESENCE_FRAME.Error);
+      checkEqual(errors.length, 1, "expected exactly one error frame");
+      const errorFrame = errors[0] as { roomId: string; senderId: string };
+      checkEqual(errorFrame.roomId, "unknown", 'expected roomId "unknown"');
+      checkEqual(errorFrame.senderId, "server", 'expected senderId "server"');
+    },
+  },
+  {
+    name: "an invalid envelope sends an error frame and does not close",
+    async run() {
+      const { room } = factory();
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(peer, JSON.stringify({ garbage: true }));
+      check(
+        peer.closes.length === 0,
+        "expected no close for an invalid envelope",
+      );
+      checkEqual(
+        framesOfType(peer, PRESENCE_FRAME.Error).length,
+        1,
+        "expected exactly one error frame",
+      );
+    },
+  },
+  {
+    name: "Join fans out to a second joined peer",
+    async run() {
+      const { room } = factory();
+      const first = await authenticateAndJoin(room, "connection-1");
+      first.sent.length = 0;
+      await authenticateAndJoin(room, "connection-2");
+      checkEqual(
+        framesOfType(first, PRESENCE_FRAME.Join).length,
+        1,
+        "expected the first peer to observe the second peer's Join",
+      );
+    },
+  },
+  {
+    name: "a second Join closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.receive(peer, joinWire(ROOM_ID, "connection-1"));
+      checkEqual(peer.closes[0]?.code, 1008, "expected a duplicate-join close");
+    },
+  },
+  {
+    name: "Update before Join closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      await room.receive(
+        peer,
+        updateWire(ROOM_ID, "connection-1", "user-connection-1", 1),
+      );
+      checkEqual(
+        peer.closes[0]?.code,
+        1008,
+        "expected an update-before-join close",
+      );
+    },
+  },
+  {
+    name: "an identity mismatch on Update closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.receive(
+        peer,
+        updateWire(ROOM_ID, "connection-1", "someone-else", 1),
+      );
+      checkEqual(
+        peer.closes[0]?.code,
+        1008,
+        "expected an identity-mismatch close",
+      );
+    },
+  },
+  {
+    name: "an Update with clock <= current is silently dropped",
+    async run() {
+      const { room, fanout } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.receive(
+        peer,
+        updateWire(ROOM_ID, "connection-1", "user-connection-1", 5),
+      );
+      let deliveries = 0;
+      await fanout.subscribe(ROOM_ID, () => {
+        deliveries += 1;
+      });
+      await room.receive(
+        peer,
+        updateWire(ROOM_ID, "connection-1", "user-connection-1", 3),
+      );
+      check(peer.closes.length === 0, "expected no close on a stale clock");
+      checkEqual(deliveries, 0, "expected no publish on a stale clock");
+    },
+  },
+  {
+    name: "an Update with a clock jump beyond +1000 closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.receive(
+        peer,
+        updateWire(ROOM_ID, "connection-1", "user-connection-1", 5_000),
+      );
+      checkEqual(peer.closes[0]?.code, 1008, "expected a clock-jump close");
+    },
+  },
+  {
+    name: "a valid Update publishes exactly one update broadcast",
+    async run() {
+      const { room } = factory();
+      const first = await authenticateAndJoin(room, "connection-1");
+      const second = await authenticateAndJoin(room, "connection-2");
+      second.sent.length = 0;
+      await room.receive(
+        first,
+        updateWire(ROOM_ID, "connection-1", "user-connection-1", 1, {
+          cursor: "x",
+        }),
+      );
+      checkEqual(
+        framesOfType(second, PRESENCE_FRAME.Update).length,
+        1,
+        "expected exactly one update broadcast",
+      );
+    },
+  },
+  {
+    name: "Sync reports a lapsed member as Leave exactly once, before the response",
+    async run() {
+      const { room, store } = factory();
+      const observer = await authenticateAndJoin(room, "connection-1");
+      observer.sent.length = 0;
+      await store.setMember(
+        ROOM_ID,
+        { clock: 0, connectionId: "ghost", userId: "ghost-user" },
+        10,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await room.receive(observer, syncWire(ROOM_ID, "connection-1"));
+      checkEqual(
+        framesOfType(observer, PRESENCE_FRAME.Leave).length,
+        1,
+        "expected exactly one Leave for the lapsed member",
+      );
+      const leaveIndex = observer.sent.findIndex(
+        (frame) => isRecord(frame) && frame.type === PRESENCE_FRAME.Leave,
+      );
+      const responseIndex = observer.sent.findIndex(
+        (frame) =>
+          isRecord(frame) && frame.type === PRESENCE_FRAME.SyncResponse,
+      );
+      check(
+        leaveIndex < responseIndex,
+        "expected the Leave before the sync response",
+      );
+    },
+  },
+  {
+    name: "Heartbeat acknowledges with the matching pingId and sender",
+    async run() {
+      const { room } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      peer.sent.length = 0;
+      await room.receive(
+        peer,
+        heartbeatWire(ROOM_ID, "connection-1", "ping-1"),
+      );
+      const acks = framesOfType(peer, PRESENCE_FRAME.HeartbeatAck);
+      checkEqual(acks.length, 1, "expected exactly one heartbeat-ack");
+      const ack = acks[0] as { payload: { pingId: string }; senderId: string };
+      checkEqual(
+        ack.payload.pingId,
+        "ping-1",
+        "expected the pingId to be echoed",
+      );
+      checkEqual(
+        ack.senderId,
+        "connection-1",
+        "expected senderId to be the connectionId",
+      );
+    },
+  },
+  {
+    name: "Heartbeat with an invalid pingId closes 1008",
+    async run() {
+      const { room } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.receive(
+        peer,
+        wire(TEST_PRESENCE_WIRE_TYPE.Heartbeat, ROOM_ID, "connection-1", {}),
+      );
+      checkEqual(
+        peer.closes[0]?.code,
+        1008,
+        "expected an invalid-heartbeat close",
+      );
+    },
+  },
+  {
+    name: "closing a joined peer publishes exactly one Leave to survivors",
+    async run() {
+      const { room } = factory();
+      const first = await authenticateAndJoin(room, "connection-1");
+      const second = await authenticateAndJoin(room, "connection-2");
+      second.sent.length = 0;
+      await room.leave(first);
+      checkEqual(
+        framesOfType(second, PRESENCE_FRAME.Leave).length,
+        1,
+        "expected exactly one Leave broadcast",
+      );
+    },
+  },
+  {
+    name: "closing a never-joined peer publishes no Leave",
+    async run() {
+      const { room } = factory();
+      const observer = await authenticateAndJoin(room, "connection-1");
+      observer.sent.length = 0;
+      const peer = createRecordingPresencePeer("connection-2");
+      await room.join(peer);
+      await room.receive(peer, authWire(ROOM_ID, "connection-2", "user-2"));
+      await room.leave(peer);
+      checkEqual(
+        framesOfType(observer, PRESENCE_FRAME.Leave).length,
+        0,
+        "expected no Leave for a peer that never joined",
+      );
+    },
+  },
+  {
+    name: "a wire Leave message closes 1000",
+    async run() {
+      const { room } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.receive(peer, leaveWire(ROOM_ID, "connection-1"));
+      checkEqual(peer.closes[0]?.code, 1000, "expected a clean 1000 close");
+    },
+  },
+  {
+    name: "leaving releases the connection lease for immediate re-acquisition",
+    async run() {
+      const { room } = factory();
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.leave(peer);
+      const rejoined = await authenticateAndJoin(room, "connection-1");
+      check(
+        rejoined.closes.length === 0,
+        "expected the same connectionId to be re-acquirable after leaving",
+      );
+    },
+  },
+  {
+    name: "resume() restores an authenticated session without a new Auth exchange",
+    async run() {
+      const { room, sessions } = factory();
+      const identity = { name: "Resumed User", userId: "user-1" };
+      sessions.authorizeImpl = async () => identity;
+      sessions.refreshImpl = async () => identity;
+      const peer = createRecordingPresencePeer("connection-1");
+      const session = await room.resume(peer, {
+        connectionId: "connection-1",
+        credential: { kind: "access-token", token: "t" },
+        heartbeatExpiresAt: 0,
+        identity,
+        joined: false,
+        rateLimit: null,
+      });
+      check(session !== null, "expected resume to restore a session");
+      checkEqual(
+        framesOfType(peer, PRESENCE_FRAME.AuthOk).length,
+        0,
+        "expected no second auth-ok frame on resume",
+      );
+      await room.receive(peer, joinWire(ROOM_ID, "connection-1"));
+      check(
+        peer.closes.length === 0,
+        "expected the resumed peer to join successfully",
+      );
+    },
+  },
+  {
+    name: "sweep() closes a peer past its heartbeat deadline with 1001",
+    async run() {
+      const { room } = factory({ refreshMode: "on-message" });
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await room.sweep(Date.now() + 10 * 60_000);
+      checkEqual(
+        peer.closes[0]?.code,
+        1001,
+        "expected a heartbeat-expiry close",
+      );
+    },
+  },
+  {
+    name: "sweep() is idempotent",
+    async run() {
+      const { room } = factory({ refreshMode: "on-message" });
+      const peer = await authenticateAndJoin(room, "connection-1");
+      const future = Date.now() + 10 * 60_000;
+      await room.sweep(future);
+      const closesAfterFirstSweep = peer.closes.length;
+      await room.sweep(future);
+      checkEqual(
+        peer.closes.length,
+        closesAfterFirstSweep,
+        "expected a second sweep to be a no-op",
+      );
+    },
+  },
+  {
+    name: "both refresh modes reach the same terminal state",
+    async run() {
+      for (const refreshMode of ["background", "on-message"] as const) {
+        const { room } = factory({ refreshMode });
+        const first = await authenticateAndJoin(room, "connection-1");
+        const second = await authenticateAndJoin(room, "connection-2");
+        second.sent.length = 0;
+        await room.leave(first);
+        checkEqual(
+          framesOfType(second, PRESENCE_FRAME.Leave).length,
+          1,
+          `expected exactly one Leave in ${refreshMode} mode`,
+        );
+      }
+    },
+  },
+];

--- a/packages/collab-runtime/src/testing/presence-room-conformance.ts
+++ b/packages/collab-runtime/src/testing/presence-room-conformance.ts
@@ -561,7 +561,7 @@ export const presenceRoomConformance = (
   {
     name: "a post-deadline frame in background mode still refreshes the heartbeat",
     async run() {
-      const { room, sessions } = factory({ refreshMode: "background" });
+      const { room, sessions, store } = factory({ refreshMode: "background" });
       const identity = { name: "User 1", userId: "user-1" };
       sessions.authorizeImpl = async () => identity;
       sessions.refreshImpl = async () => identity;
@@ -577,6 +577,16 @@ export const presenceRoomConformance = (
         joined: true,
         rateLimit: null,
       });
+      await store.setMember(
+        ROOM_ID,
+        {
+          clock: 0,
+          connectionId: "connection-1",
+          name: identity.name,
+          userId: identity.userId,
+        },
+        60_000,
+      );
 
       // Send a heartbeat frame after the deadline
       peer.sent.length = 0;

--- a/packages/collab-runtime/test/presence-capabilities.test.ts
+++ b/packages/collab-runtime/test/presence-capabilities.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "vitest";
+import {
+  connectionLimiterConformance,
+  createMemoryConnectionLimiter,
+  createMemoryPresenceFanout,
+  createMemoryPresenceStore,
+  presenceFanoutConformance,
+  presenceStoreConformance,
+} from "../src/testing";
+
+describe("presence store (memory)", () => {
+  for (const testCase of presenceStoreConformance(() =>
+    createMemoryPresenceStore(),
+  )) {
+    it(testCase.name, testCase.run);
+  }
+});
+
+describe("presence fanout (memory)", () => {
+  for (const testCase of presenceFanoutConformance(() =>
+    createMemoryPresenceFanout(),
+  )) {
+    it(testCase.name, testCase.run);
+  }
+});
+
+describe("presence connection limiter (memory)", () => {
+  for (const testCase of connectionLimiterConformance(() =>
+    createMemoryConnectionLimiter(),
+  )) {
+    it(testCase.name, testCase.run);
+  }
+});

--- a/packages/collab-runtime/test/presence-room.test.ts
+++ b/packages/collab-runtime/test/presence-room.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "vitest";
+import {
+  DEFAULT_PRESENCE_ROOM_POLICY,
+  createPresenceRoom,
+  type PresenceRoomOptions,
+} from "../src";
+import {
+  createMemoryConnectionLimiter,
+  createMemoryPresenceFanout,
+  createMemoryPresenceStore,
+  createOpaqueTestCodec,
+  createStubPresenceSessionHooks,
+  presenceRoomConformance,
+  type PresenceRoomHarness,
+} from "../src/testing";
+
+const createHarness = (options?: PresenceRoomOptions): PresenceRoomHarness => {
+  const store = createMemoryPresenceStore();
+  const fanout = createMemoryPresenceFanout();
+  const connections = createMemoryConnectionLimiter();
+  const sessions = createStubPresenceSessionHooks();
+  const room = createPresenceRoom(
+    "room-a",
+    {
+      codec: createOpaqueTestCodec(),
+      connections,
+      fanout,
+      policy: DEFAULT_PRESENCE_ROOM_POLICY,
+      sessions,
+      store,
+    },
+    options,
+  );
+  return { connections, fanout, room, sessions, store };
+};
+
+describe("PresenceRoom conformance", () => {
+  for (const testCase of presenceRoomConformance(createHarness)) {
+    it(testCase.name, testCase.run);
+  }
+});

--- a/packages/collab-runtime/tsup.config.ts
+++ b/packages/collab-runtime/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/testing/index.ts"],
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/eslint-config/__tests__/collaboration-layers.test.js
+++ b/packages/eslint-config/__tests__/collaboration-layers.test.js
@@ -298,6 +298,8 @@ test("collab-protocol allows block-model but forbids host and higher layers", ()
 test("collab-runtime allows protocol contracts but forbids host infrastructure", () => {
   for (const specifier of [
     "@softmaple/awareness",
+    "@softmaple/awareness/protocol",
+    "@softmaple/awareness/types/presence",
     "@softmaple/eg-walker",
     "@softmaple/binding-lexical",
     "@softmaple/db",
@@ -316,6 +318,7 @@ test("collab-runtime allows protocol contracts but forbids host infrastructure",
     "react",
     "lexical",
     "lodash",
+    "vitest",
   ]) {
     const messages = lintWithPatterns(
       collabRuntimeCollaborationPatterns,


### PR DESCRIPTION
Adds a complete runtime-independent `PresenceRoom` implementation alongside comprehensive conformance test suites for presence and connection capabilities.

## Changes proposed in this pull request:

- **PresenceRoom implementation** (`presence-room-implementation.ts`): Full state machine for managing peer presence sessions with authentication, heartbeat/TTL management, rate limiting, fanout subscription, and graceful shutdown. Supports both immediate and hibernation-based resume flows.

- **Presence capability contracts** (`presence-room.ts`, `presence-session.ts`, `presence-store.ts`, `presence-fanout.ts`, `presence-codec.ts`): Defines the service boundaries between the room and its adapters (codec, sessions, store, fanout, connections).

- **Conformance test suites**:
  - `presence-room-conformance.ts`: 30+ behavioral tests covering authentication, sender binding, room isolation, rate limiting, TTL expiry, fanout reach, resume semantics, and sweep idempotence
  - `capability-conformance.ts`: Tests for `PresenceStore`, `PresenceFanout`, and `ConnectionLimiter` adapters
  - `conformance-case.ts`: Assertion-library-free test case interface for host integration

- **Test fakes** (`fakes.ts`): In-memory implementations of all presence adapters (store, fanout, connections, codec, sessions) with TTL purge-on-read semantics matching production Redis/Durable Object behavior.

- **Test integration** (`presence-room.test.ts`, `presence-capabilities.test.ts`): Vitest harnesses running all conformance suites against memory fakes.

- **Documentation updates**: Extended `collaboration-runtime.md` and `collaboration-layers.md` to describe PresenceRoom's role, capability boundary, and isolation from DocumentRoom.

- **Package exports**: Added `./testing` subpath export for conformance suites and fakes; updated `tsup.config.ts` to build testing module.

## Test Plan

All conformance tests pass against memory implementations. The test suites are designed to be run by production hosts against their own adapters (Redis, Durable Objects, etc.) to verify compliance with the shared contract.

https://claude.ai/code/session_016sZFsj7w6pYc26CL1ucQ26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Presence Rooms with authentication, session resumption, heartbeats, updates, fan-out, expiry, and cleanup.
  * Added public APIs for presence codecs, storage, sessions, room policies, and broadcasting.
  * Added a public testing package with conformance suites and in-memory utilities.
* **Documentation**
  * Documented Presence Room lifecycle, storage, authorization, TTL handling, refresh modes, and integration requirements.
* **Tests**
  * Added comprehensive coverage for presence capabilities, room behavior, validation, isolation, expiration, and session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->