### PR TITLE
fix(collab-runtime): address presence room review findings

### DIFF
--- a/packages/collab-runtime/src/presence-codec.ts
+++ b/packages/collab-runtime/src/presence-codec.ts
@@ -80,10 +80,15 @@ export interface PresenceQuotaResult {
  * selection, name, color, activity/liveness timestamps) live behind this
  * interface; `collab-runtime` never imports awareness.
  *
- * Every parse/classify method throws on invalid input; there is no null
- * sentinel to check.
+ * **Throwing contract:** `parseEnvelope`, `parseAuth`, `parseHeartbeat`,
+ * `parsePatch`, and `classify` throw on invalid input; there is no null
+ * sentinel to check. `applyPatch`, `consumeQuota`, `createMember`, `encode`,
+ * and `isMember` must not throw — they are pure transforms/validators the
+ * room calls outside parse-specific `try` blocks (including `consumeQuota`
+ * on every inbound frame and `encode` on error responses).
  */
 export interface PresenceCodec {
+  /** Must not throw; returns the patched member and broadcast payload. */
   applyPatch(
     current: PresenceMemberRecord,
     patch: PresencePatch,
@@ -91,21 +96,25 @@ export interface PresenceCodec {
   ): PresencePatchApplication;
   /** Throws for a wire type the room does not understand. */
   classify(envelope: PresenceEnvelope): PresenceMessageKind;
+  /** Must not throw; returns the next rate-limit state and allowance. */
   consumeQuota(
     current: PresenceRateLimitState | null,
     now: number,
   ): PresenceQuotaResult;
+  /** Must not throw; materializes a new stored member from identity. */
   createMember(
     identity: PresenceIdentity,
     connectionId: string,
     now: number,
   ): PresenceMemberRecord;
+  /** Must not throw; encodes an outbound frame for the transport. */
   encode(
     kind: PresenceFrameKind,
     roomId: string,
     senderId: string,
     payload: unknown,
   ): unknown;
+  /** Must not throw; narrows an opaque stored value. */
   isMember(value: unknown): value is PresenceMemberRecord;
   parseAuth(payload: unknown): PresenceAuthPayload;
   parseEnvelope(value: unknown): PresenceEnvelope;

--- a/packages/collab-runtime/src/presence-room-implementation.ts
+++ b/packages/collab-runtime/src/presence-room-implementation.ts
@@ -50,7 +50,6 @@ interface PeerState {
   phase: PeerPhase;
   readonly peer: PresencePeer;
   queue: Promise<void>;
-  queuePending: number;
   rateLimit: unknown;
 }
 
@@ -68,7 +67,6 @@ const createPeerState = (peer: PresencePeer): PeerState => ({
   phase: PEER_PHASE.Connected,
   peer,
   queue: Promise.resolve(),
-  queuePending: 0,
   rateLimit: null,
 });
 
@@ -144,7 +142,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       await this.enqueue(state, async () => {
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
       });
@@ -175,7 +172,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       await this.enqueue(state, async () => {
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
       });
@@ -203,7 +199,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       await this.enqueue(state, async () => {
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
       });
@@ -219,7 +214,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       await this.enqueue(state, async () => {
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
       });
@@ -240,7 +234,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       await this.enqueue(state, async () => {
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
       });
@@ -255,7 +248,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       await this.enqueue(state, async () => {
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
       });
@@ -267,14 +259,30 @@ class RuntimePresenceRoom implements PresenceRoom {
       if (!(await this.refreshAuthorizationForMessage(state))) return;
       if (!this.isPeerLive(state)) return;
 
-      await this.rearmHeartbeat(state);
+      const now = Date.now();
 
       if (this.refreshMode === PRESENCE_ROOM_REFRESH_MODE.OnMessage) {
+        // Sweep other peers before rearming this one. Exclude `state` so
+        // sweepLocked does not enqueue cleanup on this peer's queue (deadlock).
         await this.withMessageMaintenanceLock(async () => {
-          await this.sweepLocked(Date.now());
+          await this.sweepLocked(now, state);
         });
         if (!this.isPeerLive(state)) return;
       }
+
+      // Evaluate heartbeat expiry before rearming so post-deadline frames close 1001.
+      if (
+        state.heartbeatExpiresAt > 0 &&
+        state.heartbeatExpiresAt <= now
+      ) {
+        state.leaveRequested = true;
+        this.clearHeartbeatTimer(state);
+        await this.closePeer(state.peer, 1001, "Presence heartbeat expired");
+        await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
+        return;
+      }
+
+      await this.rearmHeartbeat(state);
 
       switch (kind) {
         case PRESENCE_MESSAGE.Join:
@@ -305,7 +313,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     state.leaveRequested = true;
     this.clearHeartbeatTimer(state);
     await this.enqueue(state, async () => {
-      await this.resetState(state, true, endReasonFromLeave(reason));
+      await this.resetState(state, endReasonFromLeave(reason));
     });
   }
 
@@ -336,7 +344,6 @@ class RuntimePresenceRoom implements PresenceRoom {
         await this.enqueue(state, async () => {
           await this.resetState(
             state,
-            true,
             PRESENCE_SESSION_END_REASON.RoomClosed,
           );
         });
@@ -368,7 +375,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       void this.enqueue(state, async () => {
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
       }).catch((error: unknown) => {
@@ -388,35 +394,48 @@ class RuntimePresenceRoom implements PresenceRoom {
     state: PeerState,
     envelope: PresenceEnvelope,
   ): Promise<void> {
+    let auth;
     try {
-      const auth = this.services.codec.parseAuth(envelope.payload);
+      auth = this.services.codec.parseAuth(envelope.payload);
       if (envelope.senderId !== auth.connectionId) {
         throw new Error("presence sender mismatch");
       }
+    } catch (error) {
+      await this.failAuthentication(state, error);
+      return;
+    }
 
-      const identity = await this.services.sessions.authorize({
+    let identity: PresenceIdentity | null;
+    try {
+      identity = await this.services.sessions.authorize({
         connectionId: auth.connectionId,
         credential: auth.credential,
         roomId: this.roomId,
         userId: auth.userId,
       });
-      if (identity === null) {
-        throw new Error("presence membership denied");
-      }
+    } catch (error) {
+      await this.failInfrastructure(state, error, "auth");
+      return;
+    }
 
-      if (state.leaveRequested || this.closed) {
-        await this.resetState(
-          state,
-          true,
-          this.closed
-            ? PRESENCE_SESSION_END_REASON.RoomClosed
-            : PRESENCE_SESSION_END_REASON.PeerLeft,
-        );
-        return;
-      }
+    if (identity === null || identity.userId !== auth.userId) {
+      await this.failAuthentication(state);
+      return;
+    }
 
-      // Set before admission so a concurrent cleanup can identify the peer.
-      state.connectionId = auth.connectionId;
+    if (state.leaveRequested || this.closed) {
+      await this.resetState(
+        state,
+        this.closed
+          ? PRESENCE_SESSION_END_REASON.RoomClosed
+          : PRESENCE_SESSION_END_REASON.PeerLeft,
+      );
+      return;
+    }
+
+    // Set before admission so a concurrent cleanup can identify the peer.
+    state.connectionId = auth.connectionId;
+    try {
       const admission = await this.services.connections.acquire({
         documentId: this.roomId,
         peerId: auth.connectionId,
@@ -430,18 +449,13 @@ class RuntimePresenceRoom implements PresenceRoom {
           1013,
           "Presence room is full or duplicated",
         );
-        await this.resetState(
-          state,
-          true,
-          PRESENCE_SESSION_END_REASON.PeerLeft,
-        );
+        await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
         return;
       }
       state.lease = admission.lease;
       if (state.leaveRequested || this.closed) {
         await this.resetState(
           state,
-          true,
           this.closed
             ? PRESENCE_SESSION_END_REASON.RoomClosed
             : PRESENCE_SESSION_END_REASON.PeerLeft,
@@ -453,7 +467,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       if (state.leaveRequested || this.closed) {
         await this.resetState(
           state,
-          true,
           this.closed
             ? PRESENCE_SESSION_END_REASON.RoomClosed
             : PRESENCE_SESSION_END_REASON.PeerLeft,
@@ -478,25 +491,39 @@ class RuntimePresenceRoom implements PresenceRoom {
         "auth-ok",
       );
     } catch (error) {
-      this.report(error, state, "auth");
-      state.leaveRequested = true;
-      await this.resetState(
-        state,
-        true,
-        PRESENCE_SESSION_END_REASON.AccessRevoked,
-      );
-      await this.sendIgnoringFailure(
-        state.peer,
-        this.services.codec.encode(
-          PRESENCE_FRAME.AuthError,
-          this.roomId,
-          "server",
-          { message: "Authentication or document membership failed" },
-        ),
-        "auth-error",
-      );
-      await this.closePeer(state.peer, 1008, "Unauthorized");
+      await this.failInfrastructure(state, error, "auth");
     }
+  }
+
+  private async failAuthentication(
+    state: PeerState,
+    error?: unknown,
+  ): Promise<void> {
+    if (error !== undefined) this.report(error, state, "auth");
+    state.leaveRequested = true;
+    await this.resetState(state, PRESENCE_SESSION_END_REASON.AccessRevoked);
+    await this.sendIgnoringFailure(
+      state.peer,
+      this.services.codec.encode(
+        PRESENCE_FRAME.AuthError,
+        this.roomId,
+        "server",
+        { message: "Authentication or document membership failed" },
+      ),
+      "auth-error",
+    );
+    await this.closePeer(state.peer, 1008, "Unauthorized");
+  }
+
+  private async failInfrastructure(
+    state: PeerState,
+    error: unknown,
+    messageType: string,
+  ): Promise<void> {
+    this.report(error, state, messageType);
+    state.leaveRequested = true;
+    await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
+    await this.closePeer(state.peer, 1011, "Presence runtime unavailable");
   }
 
   private async resumeSession(
@@ -518,14 +545,13 @@ class RuntimePresenceRoom implements PresenceRoom {
       this.report(error, state, "session-resume");
       state.leaveRequested = true;
       await this.closePeer(state.peer, 1011, "Presence runtime unavailable");
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       return null;
     }
 
     if (state.leaveRequested || this.closed) {
       await this.resetState(
         state,
-        true,
         this.closed
           ? PRESENCE_SESSION_END_REASON.RoomClosed
           : PRESENCE_SESSION_END_REASON.PeerLeft,
@@ -537,7 +563,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       await this.closePeer(state.peer, 1008, "Presence access was revoked");
       await this.resetState(
         state,
-        true,
         PRESENCE_SESSION_END_REASON.AccessRevoked,
       );
       return null;
@@ -566,7 +591,6 @@ class RuntimePresenceRoom implements PresenceRoom {
         );
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
         return null;
@@ -575,7 +599,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       if (state.leaveRequested || this.closed) {
         await this.resetState(
           state,
-          true,
           this.closed
             ? PRESENCE_SESSION_END_REASON.RoomClosed
             : PRESENCE_SESSION_END_REASON.PeerLeft,
@@ -587,7 +610,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       if (state.leaveRequested || this.closed) {
         await this.resetState(
           state,
-          true,
           this.closed
             ? PRESENCE_SESSION_END_REASON.RoomClosed
             : PRESENCE_SESSION_END_REASON.PeerLeft,
@@ -595,8 +617,7 @@ class RuntimePresenceRoom implements PresenceRoom {
         return null;
       }
 
-      state.authorizationExpiresAt =
-        Date.now() + this.services.policy.authorizationRefreshIntervalMs;
+      state.authorizationExpiresAt = resumed.authorizationExpiresAt;
       state.phase = state.joined ? PEER_PHASE.Joined : PEER_PHASE.Authenticated;
       if (
         this.refreshMode === PRESENCE_ROOM_REFRESH_MODE.Background &&
@@ -613,7 +634,7 @@ class RuntimePresenceRoom implements PresenceRoom {
       this.report(error, state, "session-resume");
       state.leaveRequested = true;
       await this.closePeer(state.peer, 1011, "Presence runtime unavailable");
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       return null;
     }
   }
@@ -639,7 +660,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     } catch (error) {
       this.report(error, state, "authorization-recheck");
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1011, "Authorization recheck failed");
       return false;
     }
@@ -649,7 +670,6 @@ class RuntimePresenceRoom implements PresenceRoom {
       state.leaveRequested = true;
       await this.resetState(
         state,
-        true,
         PRESENCE_SESSION_END_REASON.AccessRevoked,
       );
       await this.closePeer(
@@ -671,7 +691,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     if (state.phase !== PEER_PHASE.Authenticated) {
       state.leaveRequested = true;
       await this.closePeer(state.peer, 1008, "Presence already joined");
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       return;
     }
     const identity = state.identity;
@@ -690,7 +710,7 @@ class RuntimePresenceRoom implements PresenceRoom {
         member,
         this.services.policy.memberTtlMs,
       );
-      if (state.lease !== null) await state.lease.refresh();
+      if (!(await this.refreshLeaseOrClose(state))) return;
       state.joined = true;
       await this.persistSnapshot(state);
       state.phase = PEER_PHASE.Joined;
@@ -706,7 +726,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     } catch (error) {
       this.report(error, state, "join");
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1011, "Presence join failed");
     }
   }
@@ -733,7 +753,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     } catch (error) {
       this.report(error, state, "sync");
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1011, "Presence sync failed");
     }
   }
@@ -747,7 +767,7 @@ class RuntimePresenceRoom implements PresenceRoom {
       pingId = this.services.codec.parseHeartbeat(envelope.payload);
     } catch {
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1008, "Invalid presence heartbeat");
       return;
     }
@@ -766,7 +786,6 @@ class RuntimePresenceRoom implements PresenceRoom {
         state.leaveRequested = true;
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
         await this.closePeer(state.peer, 1008, "Presence lease expired");
@@ -785,7 +804,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     } catch (error) {
       this.report(error, state, "heartbeat");
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1011, "Presence heartbeat failed");
     }
   }
@@ -808,7 +827,6 @@ class RuntimePresenceRoom implements PresenceRoom {
         state.leaveRequested = true;
         await this.resetState(
           state,
-          true,
           PRESENCE_SESSION_END_REASON.PeerLeft,
         );
         await this.closePeer(state.peer, 1008, "Join presence before updating");
@@ -818,7 +836,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     } catch (error) {
       this.report(error, state, "update");
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1011, "Presence update failed");
       return;
     }
@@ -834,7 +852,7 @@ class RuntimePresenceRoom implements PresenceRoom {
       }
     } catch {
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1008, "Invalid presence update");
       return;
     }
@@ -842,7 +860,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     if (patch.clock <= current.clock) return; // Stale write; silently dropped.
     if (patch.clock > current.clock + 1_000) {
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1008, "Invalid presence update");
       return;
     }
@@ -855,7 +873,7 @@ class RuntimePresenceRoom implements PresenceRoom {
         application.member,
         this.services.policy.memberTtlMs,
       );
-      if (state.lease !== null) await state.lease.refresh();
+      if (!(await this.refreshLeaseOrClose(state))) return;
       await this.services.fanout.publish({
         roomId: this.roomId,
         frame: this.services.codec.encode(
@@ -873,7 +891,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     } catch (error) {
       this.report(error, state, "update");
       state.leaveRequested = true;
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
       await this.closePeer(state.peer, 1011, "Presence update failed");
     }
   }
@@ -881,7 +899,7 @@ class RuntimePresenceRoom implements PresenceRoom {
   private async receiveLeave(state: PeerState): Promise<void> {
     state.leaveRequested = true;
     await this.closePeer(state.peer, 1000, "Presence left");
-    await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+    await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
   }
 
   private async publishLeave(
@@ -899,14 +917,18 @@ class RuntimePresenceRoom implements PresenceRoom {
     });
   }
 
-  private async sweepLocked(now: number): Promise<void> {
+  private async sweepLocked(
+    now: number,
+    excludePeer?: PeerState,
+  ): Promise<void> {
     const expiredHeartbeats = [...this.peers.values()].filter(
-      (state) =>
-        (state.phase === PEER_PHASE.Authenticated ||
-          state.phase === PEER_PHASE.Joined) &&
-        !state.leaveRequested &&
-        state.heartbeatExpiresAt > 0 &&
-        state.heartbeatExpiresAt <= now,
+      (candidate) =>
+        candidate !== excludePeer &&
+        (candidate.phase === PEER_PHASE.Authenticated ||
+          candidate.phase === PEER_PHASE.Joined) &&
+        !candidate.leaveRequested &&
+        candidate.heartbeatExpiresAt > 0 &&
+        candidate.heartbeatExpiresAt <= now,
     );
     await Promise.all(
       expiredHeartbeats.map(async (state) => {
@@ -914,11 +936,7 @@ class RuntimePresenceRoom implements PresenceRoom {
         this.clearHeartbeatTimer(state);
         await this.closePeer(state.peer, 1001, "Presence heartbeat expired");
         await this.enqueue(state, async () => {
-          await this.resetState(
-            state,
-            true,
-            PRESENCE_SESSION_END_REASON.PeerLeft,
-          );
+          await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
         });
       }),
     );
@@ -931,6 +949,16 @@ class RuntimePresenceRoom implements PresenceRoom {
     } catch (error) {
       this.report(error, null, "sweep");
     }
+  }
+
+  private async refreshLeaseOrClose(state: PeerState): Promise<boolean> {
+    if (state.lease === null) return true;
+    const leaseAlive = await state.lease.refresh();
+    if (leaseAlive) return true;
+    state.leaveRequested = true;
+    await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
+    await this.closePeer(state.peer, 1008, "Presence lease expired");
+    return false;
   }
 
   private async rearmHeartbeat(state: PeerState): Promise<void> {
@@ -981,7 +1009,7 @@ class RuntimePresenceRoom implements PresenceRoom {
     state.leaveRequested = true;
     await this.closePeer(state.peer, 1001, "Presence heartbeat expired");
     await this.enqueue(state, async () => {
-      await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+      await this.resetState(state, PRESENCE_SESSION_END_REASON.PeerLeft);
     });
   }
 
@@ -1079,7 +1107,6 @@ class RuntimePresenceRoom implements PresenceRoom {
 
   private async resetState(
     state: PeerState,
-    remove: boolean,
     endReason: PresenceSessionEndReason,
   ): Promise<void> {
     this.clearHeartbeatTimer(state);
@@ -1139,21 +1166,12 @@ class RuntimePresenceRoom implements PresenceRoom {
     }
 
     state.connectionId = null;
-
-    if (remove) {
-      state.phase = PEER_PHASE.Left;
-      this.peers.delete(state.peer);
-    } else {
-      state.phase = PEER_PHASE.Connected;
-      state.leaveRequested = false;
-    }
+    state.phase = PEER_PHASE.Left;
+    this.peers.delete(state.peer);
   }
 
   private enqueue<T>(state: PeerState, work: () => Promise<T>): Promise<T> {
-    state.queuePending += 1;
-    const operation = state.queue.then(work, work).finally(() => {
-      state.queuePending -= 1;
-    });
+    const operation = state.queue.then(work, work);
     state.queue = operation.then(
       () => undefined,
       () => undefined,

--- a/packages/collab-runtime/src/presence-room.ts
+++ b/packages/collab-runtime/src/presence-room.ts
@@ -38,6 +38,8 @@ export interface PresencePeerSnapshot {
 
 /** Server-owned session metadata restored by a hibernating transport host. */
 export interface PresenceRoomResumeState {
+  /** Preserved as-is; the room does not recompute it on resume. */
+  readonly authorizationExpiresAt: number;
   readonly connectionId: string;
   readonly credential: CollabCredential;
   /** Preserved as-is; the room does not recompute it on resume. */

--- a/packages/collab-runtime/src/presence-store.ts
+++ b/packages/collab-runtime/src/presence-store.ts
@@ -43,8 +43,11 @@ export interface PresenceStore {
     connectionId: string,
     ttlMs: number,
   ): Promise<boolean>;
-  /** Returns the removed record, or null when nothing was stored. */
-  removeMember(roomId: string, connectionId: string): Promise<unknown>;
+  /**
+   * Returns the removed live record, or `null` when nothing was stored or the
+   * member had already lapsed. Implementations must never return `undefined`.
+   */
+  removeMember(roomId: string, connectionId: string): Promise<unknown | null>;
   setMember(
     roomId: string,
     member: PresenceMemberRecord,

--- a/packages/collab-runtime/src/testing/capability-conformance.ts
+++ b/packages/collab-runtime/src/testing/capability-conformance.ts
@@ -9,8 +9,10 @@ import { check, checkEqual, type ConformanceCase } from "./conformance-case";
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
-const TEST_TTL_MS = 15;
-const TEST_TTL_MARGIN_MS = 60;
+export interface PresenceStoreConformanceOptions {
+  readonly testTtlMarginMs?: number;
+  readonly testTtlMs?: number;
+}
 
 const testMember = (
   overrides: Partial<PresenceMemberRecord> = {},
@@ -29,7 +31,12 @@ const testMember = (
  */
 export const presenceStoreConformance = (
   createStore: () => PresenceStore,
-): ConformanceCase[] => [
+  options: PresenceStoreConformanceOptions = {},
+): ConformanceCase[] => {
+  const TEST_TTL_MS = options.testTtlMs ?? 15;
+  const TEST_TTL_MARGIN_MS = options.testTtlMarginMs ?? 60;
+
+  return [
   {
     name: "getMember returns null for an absent member",
     async run() {
@@ -152,6 +159,17 @@ export const presenceStoreConformance = (
     },
   },
   {
+    name: "getMember returns null after TTL lapses",
+    async run() {
+      const store = createStore();
+      const member = testMember();
+      await store.setMember("room-a", member, TEST_TTL_MS);
+      await sleep(TEST_TTL_MS + TEST_TTL_MARGIN_MS);
+      const stored = await store.getMember("room-a", member.connectionId);
+      check(stored === null, "expected null for a lapsed member");
+    },
+  },
+  {
     name: "a purged member is not reported expired again",
     async run() {
       const store = createStore();
@@ -164,6 +182,7 @@ export const presenceStoreConformance = (
     },
   },
 ];
+};
 
 /**
  * Loopback delivery (required for browser self-suppression by senderId),

--- a/packages/collab-runtime/src/testing/fakes.ts
+++ b/packages/collab-runtime/src/testing/fakes.ts
@@ -89,12 +89,13 @@ export const createMemoryPresenceStore = (): PresenceStore => {
       return true;
     },
     async removeMember(roomId, connectionId) {
-      const entries = rooms.get(roomId);
-      if (entries === undefined) return null;
-      const current = entries.get(connectionId)?.member ?? null;
+      const { entries } = purge(roomId, Date.now());
+      const current = entries.get(connectionId);
+      if (current === undefined) return null;
       entries.delete(connectionId);
       if (entries.size === 0) rooms.delete(roomId);
-      return current;
+      else rooms.set(roomId, entries);
+      return current.member;
     },
     async setMember(roomId, member, ttlMs) {
       const { entries } = purge(roomId, Date.now());
@@ -145,14 +146,19 @@ export interface MemoryConnectionLimiterOptions {
 export const createMemoryConnectionLimiter = (
   options: MemoryConnectionLimiterOptions = {},
 ): ConnectionLimiter => {
-  const rooms = new Map<string, Map<string, { expiresAt: number }>>();
+  const rooms = new Map<
+    string,
+    Map<string, { expiresAt: number; token: number }>
+  >();
+  let nextToken = 1;
 
   const purge = (
     documentId: string,
     now: number,
-  ): Map<string, { expiresAt: number }> => {
+  ): Map<string, { expiresAt: number; token: number }> => {
     const entries =
-      rooms.get(documentId) ?? new Map<string, { expiresAt: number }>();
+      rooms.get(documentId) ??
+      new Map<string, { expiresAt: number; token: number }>();
     for (const [peerId, entry] of entries) {
       if (entry.expiresAt <= now) entries.delete(peerId);
     }
@@ -180,32 +186,34 @@ export const createMemoryConnectionLimiter = (
           reason: CONNECTION_REJECTION_REASON.Capacity,
         };
       }
+      const token = nextToken++;
       entries.set(request.peerId, {
         expiresAt: now + request.policy.leaseTtlMs,
+        token,
       });
       rooms.set(request.documentId, entries);
-      let released = false;
       return {
         accepted: true,
         lease: {
           async refresh() {
-            if (released) return false;
             const live = purge(request.documentId, Date.now());
-            if (!live.has(request.peerId)) return false;
+            const entry = live.get(request.peerId);
+            if (entry === undefined || entry.token !== token) return false;
             live.set(request.peerId, {
               expiresAt: Date.now() + request.policy.leaseTtlMs,
+              token,
             });
             rooms.set(request.documentId, live);
             return true;
           },
           async release() {
-            if (released) return;
-            released = true;
             const live = rooms.get(request.documentId);
-            live?.delete(request.peerId);
-            if (live !== undefined && live.size === 0) {
-              rooms.delete(request.documentId);
-            }
+            if (live === undefined) return;
+            const entry = live.get(request.peerId);
+            if (entry === undefined || entry.token !== token) return;
+            live.delete(request.peerId);
+            if (live.size === 0) rooms.delete(request.documentId);
+            else rooms.set(request.documentId, live);
           },
         },
       };
@@ -242,8 +250,8 @@ export const createRecordingPresencePeer = (
       await peer.closeImpl(code, reason);
     },
     async send(frame) {
-      await peer.sendImpl(frame);
       sent.push(frame);
+      await peer.sendImpl(frame);
     },
     async persist(snapshot) {
       persisted.push(snapshot);

--- a/packages/collab-runtime/src/testing/index.ts
+++ b/packages/collab-runtime/src/testing/index.ts
@@ -7,6 +7,7 @@ export {
   connectionLimiterConformance,
   presenceFanoutConformance,
   presenceStoreConformance,
+  type PresenceStoreConformanceOptions,
 } from "./capability-conformance";
 export {
   TEST_PRESENCE_WIRE_TYPE,
@@ -21,7 +22,9 @@ export {
   type StubPresenceSessionHooks,
 } from "./fakes";
 export {
+  PRESENCE_CONFORMANCE_ROOM_ID,
   presenceRoomConformance,
+  type PresenceRoomConformanceOptions,
   type PresenceRoomFactory,
   type PresenceRoomHarness,
 } from "./presence-room-conformance";

--- a/packages/collab-runtime/src/testing/presence-room-conformance.ts
+++ b/packages/collab-runtime/src/testing/presence-room-conformance.ts
@@ -1,7 +1,10 @@
 import { PRESENCE_FRAME } from "../presence-codec";
 import type { ConnectionLimiter } from "../connection-limiter";
 import type { PresenceFanout } from "../presence-fanout";
-import type { PresenceRoom, PresenceRoomOptions } from "../presence-room";
+import type {
+  PresenceRoom,
+  PresenceRoomOptions,
+} from "../presence-room";
 import type { PresenceStore } from "../presence-store";
 import { check, checkEqual, type ConformanceCase } from "./conformance-case";
 import {
@@ -9,6 +12,13 @@ import {
   createRecordingPresencePeer,
   type StubPresenceSessionHooks,
 } from "./fakes";
+
+export interface PresenceRoomConformanceOptions extends PresenceRoomOptions {
+  readonly heartbeatExpiryMs?: number;
+  readonly memberTtlMs?: number;
+  readonly testTtlMarginMs?: number;
+  readonly testTtlMs?: number;
+}
 
 export interface PresenceRoomHarness {
   readonly connections: ConnectionLimiter;
@@ -20,7 +30,7 @@ export interface PresenceRoomHarness {
 
 /** Must return a fully independent harness (fresh fakes) on every call. */
 export type PresenceRoomFactory = (
-  options?: PresenceRoomOptions,
+  options?: PresenceRoomConformanceOptions,
 ) => PresenceRoomHarness;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -80,7 +90,10 @@ const updateWire = (
 const leaveWire = (roomId: string, connectionId: string): string =>
   wire(TEST_PRESENCE_WIRE_TYPE.Leave, roomId, connectionId);
 
-const ROOM_ID = "room-a";
+export const PRESENCE_CONFORMANCE_ROOM_ID = "room-a";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 /** Authenticates and joins one peer; asserts each step succeeded. */
 const authenticateAndJoin = async (
@@ -90,12 +103,12 @@ const authenticateAndJoin = async (
 ): Promise<ReturnType<typeof createRecordingPresencePeer>> => {
   const peer = createRecordingPresencePeer(connectionId);
   await room.join(peer);
-  await room.receive(peer, authWire(ROOM_ID, connectionId, userId));
+  await room.receive(peer, authWire(PRESENCE_CONFORMANCE_ROOM_ID, connectionId, userId));
   check(
     framesOfType(peer, PRESENCE_FRAME.AuthOk).length === 1,
     `expected ${connectionId} to receive exactly one auth-ok`,
   );
-  await room.receive(peer, joinWire(ROOM_ID, connectionId));
+  await room.receive(peer, joinWire(PRESENCE_CONFORMANCE_ROOM_ID, connectionId));
   check(
     peer.closes.length === 0,
     `expected ${connectionId} to stay open after joining`,
@@ -111,7 +124,15 @@ const authenticateAndJoin = async (
  */
 export const presenceRoomConformance = (
   factory: PresenceRoomFactory,
-): ConformanceCase[] => [
+  suiteOptions: Pick<
+    PresenceRoomConformanceOptions,
+    "testTtlMarginMs" | "testTtlMs"
+  > = {},
+): ConformanceCase[] => {
+  const TEST_TTL_MS = suiteOptions.testTtlMs ?? 10;
+  const TEST_TTL_MARGIN_MS = suiteOptions.testTtlMarginMs ?? 60;
+
+  return [
   {
     name: "Auth denial closes 1008 and sends auth-error",
     async run() {
@@ -119,7 +140,7 @@ export const presenceRoomConformance = (
       sessions.authorizeImpl = async () => null;
       const peer = createRecordingPresencePeer("connection-1");
       await room.join(peer);
-      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      await room.receive(peer, authWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-1"));
       checkEqual(peer.closes[0]?.code, 1008, "expected a 1008 close on denial");
       check(
         framesOfType(peer, PRESENCE_FRAME.AuthError).length === 1,
@@ -148,7 +169,7 @@ export const presenceRoomConformance = (
       await room.join(peer);
       await room.receive(
         peer,
-        wire(TEST_PRESENCE_WIRE_TYPE.Auth, ROOM_ID, "someone-else", {
+        wire(TEST_PRESENCE_WIRE_TYPE.Auth, PRESENCE_CONFORMANCE_ROOM_ID, "someone-else", {
           connectionId: "connection-1",
           credential: { kind: "access-token", token: "t" },
           userId: "user-1",
@@ -166,7 +187,7 @@ export const presenceRoomConformance = (
     async run() {
       const { room } = factory();
       const peer = await authenticateAndJoin(room, "connection-1");
-      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      await room.receive(peer, authWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-1"));
       checkEqual(peer.closes[0]?.code, 1008, "expected a duplicate-auth close");
     },
   },
@@ -176,7 +197,7 @@ export const presenceRoomConformance = (
       const { room } = factory();
       const peer = createRecordingPresencePeer("connection-1");
       await room.join(peer);
-      await room.receive(peer, syncWire(ROOM_ID, "connection-1"));
+      await room.receive(peer, syncWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1"));
       checkEqual(
         peer.closes[0]?.code,
         1008,
@@ -190,8 +211,8 @@ export const presenceRoomConformance = (
       const { room } = factory();
       const peer = createRecordingPresencePeer("connection-1");
       await room.join(peer);
-      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
-      await room.receive(peer, syncWire(ROOM_ID, "someone-else"));
+      await room.receive(peer, authWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-1"));
+      await room.receive(peer, syncWire(PRESENCE_CONFORMANCE_ROOM_ID, "someone-else"));
       checkEqual(
         peer.closes[0]?.code,
         1008,
@@ -205,8 +226,8 @@ export const presenceRoomConformance = (
       const { room } = factory();
       const peer = createRecordingPresencePeer("connection-1");
       await room.join(peer);
-      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
-      await room.receive(peer, wire("nonsense", ROOM_ID, "connection-1"));
+      await room.receive(peer, authWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-1"));
+      await room.receive(peer, wire("nonsense", PRESENCE_CONFORMANCE_ROOM_ID, "connection-1"));
       checkEqual(
         peer.closes[0]?.code,
         1008,
@@ -266,7 +287,7 @@ export const presenceRoomConformance = (
     async run() {
       const { room } = factory();
       const peer = await authenticateAndJoin(room, "connection-1");
-      await room.receive(peer, joinWire(ROOM_ID, "connection-1"));
+      await room.receive(peer, joinWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1"));
       checkEqual(peer.closes[0]?.code, 1008, "expected a duplicate-join close");
     },
   },
@@ -276,10 +297,10 @@ export const presenceRoomConformance = (
       const { room } = factory();
       const peer = createRecordingPresencePeer("connection-1");
       await room.join(peer);
-      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      await room.receive(peer, authWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-1"));
       await room.receive(
         peer,
-        updateWire(ROOM_ID, "connection-1", "user-connection-1", 1),
+        updateWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-1", 1),
       );
       checkEqual(
         peer.closes[0]?.code,
@@ -295,7 +316,7 @@ export const presenceRoomConformance = (
       const peer = await authenticateAndJoin(room, "connection-1");
       await room.receive(
         peer,
-        updateWire(ROOM_ID, "connection-1", "someone-else", 1),
+        updateWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "someone-else", 1),
       );
       checkEqual(
         peer.closes[0]?.code,
@@ -311,15 +332,15 @@ export const presenceRoomConformance = (
       const peer = await authenticateAndJoin(room, "connection-1");
       await room.receive(
         peer,
-        updateWire(ROOM_ID, "connection-1", "user-connection-1", 5),
+        updateWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-connection-1", 5),
       );
       let deliveries = 0;
-      await fanout.subscribe(ROOM_ID, () => {
+      await fanout.subscribe(PRESENCE_CONFORMANCE_ROOM_ID, () => {
         deliveries += 1;
       });
       await room.receive(
         peer,
-        updateWire(ROOM_ID, "connection-1", "user-connection-1", 3),
+        updateWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-connection-1", 3),
       );
       check(peer.closes.length === 0, "expected no close on a stale clock");
       checkEqual(deliveries, 0, "expected no publish on a stale clock");
@@ -332,7 +353,7 @@ export const presenceRoomConformance = (
       const peer = await authenticateAndJoin(room, "connection-1");
       await room.receive(
         peer,
-        updateWire(ROOM_ID, "connection-1", "user-connection-1", 5_000),
+        updateWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-connection-1", 5_000),
       );
       checkEqual(peer.closes[0]?.code, 1008, "expected a clock-jump close");
     },
@@ -346,7 +367,7 @@ export const presenceRoomConformance = (
       second.sent.length = 0;
       await room.receive(
         first,
-        updateWire(ROOM_ID, "connection-1", "user-connection-1", 1, {
+        updateWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "user-connection-1", 1, {
           cursor: "x",
         }),
       );
@@ -364,12 +385,12 @@ export const presenceRoomConformance = (
       const observer = await authenticateAndJoin(room, "connection-1");
       observer.sent.length = 0;
       await store.setMember(
-        ROOM_ID,
+        PRESENCE_CONFORMANCE_ROOM_ID,
         { clock: 0, connectionId: "ghost", userId: "ghost-user" },
-        10,
+        TEST_TTL_MS,
       );
-      await new Promise((resolve) => setTimeout(resolve, 60));
-      await room.receive(observer, syncWire(ROOM_ID, "connection-1"));
+      await sleep(TEST_TTL_MS + TEST_TTL_MARGIN_MS);
+      await room.receive(observer, syncWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1"));
       checkEqual(
         framesOfType(observer, PRESENCE_FRAME.Leave).length,
         1,
@@ -396,7 +417,7 @@ export const presenceRoomConformance = (
       peer.sent.length = 0;
       await room.receive(
         peer,
-        heartbeatWire(ROOM_ID, "connection-1", "ping-1"),
+        heartbeatWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "ping-1"),
       );
       const acks = framesOfType(peer, PRESENCE_FRAME.HeartbeatAck);
       checkEqual(acks.length, 1, "expected exactly one heartbeat-ack");
@@ -420,7 +441,7 @@ export const presenceRoomConformance = (
       const peer = await authenticateAndJoin(room, "connection-1");
       await room.receive(
         peer,
-        wire(TEST_PRESENCE_WIRE_TYPE.Heartbeat, ROOM_ID, "connection-1", {}),
+        wire(TEST_PRESENCE_WIRE_TYPE.Heartbeat, PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", {}),
       );
       checkEqual(
         peer.closes[0]?.code,
@@ -452,7 +473,7 @@ export const presenceRoomConformance = (
       observer.sent.length = 0;
       const peer = createRecordingPresencePeer("connection-2");
       await room.join(peer);
-      await room.receive(peer, authWire(ROOM_ID, "connection-2", "user-2"));
+      await room.receive(peer, authWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-2", "user-2"));
       await room.leave(peer);
       checkEqual(
         framesOfType(observer, PRESENCE_FRAME.Leave).length,
@@ -466,7 +487,7 @@ export const presenceRoomConformance = (
     async run() {
       const { room } = factory();
       const peer = await authenticateAndJoin(room, "connection-1");
-      await room.receive(peer, leaveWire(ROOM_ID, "connection-1"));
+      await room.receive(peer, leaveWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1"));
       checkEqual(peer.closes[0]?.code, 1000, "expected a clean 1000 close");
     },
   },
@@ -492,6 +513,7 @@ export const presenceRoomConformance = (
       sessions.refreshImpl = async () => identity;
       const peer = createRecordingPresencePeer("connection-1");
       const session = await room.resume(peer, {
+        authorizationExpiresAt: Date.now() + 8_000,
         connectionId: "connection-1",
         credential: { kind: "access-token", token: "t" },
         heartbeatExpiresAt: 0,
@@ -505,7 +527,7 @@ export const presenceRoomConformance = (
         0,
         "expected no second auth-ok frame on resume",
       );
-      await room.receive(peer, joinWire(ROOM_ID, "connection-1"));
+      await room.receive(peer, joinWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1"));
       check(
         peer.closes.length === 0,
         "expected the resumed peer to join successfully",
@@ -542,6 +564,48 @@ export const presenceRoomConformance = (
     },
   },
   {
+    name: "a post-deadline inbound frame closes 1001 (on-message)",
+    async run() {
+      const heartbeatExpiryMs = 10;
+      const { room } = factory({
+        heartbeatExpiryMs,
+        refreshMode: "on-message",
+      });
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await sleep(heartbeatExpiryMs + TEST_TTL_MARGIN_MS);
+      await room.receive(
+        peer,
+        heartbeatWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "ping-late"),
+      );
+      checkEqual(
+        peer.closes[0]?.code,
+        1001,
+        "expected a post-deadline close in on-message mode",
+      );
+    },
+  },
+  {
+    name: "a post-deadline inbound frame closes 1001 (background)",
+    async run() {
+      const heartbeatExpiryMs = 10;
+      const { room } = factory({
+        heartbeatExpiryMs,
+        refreshMode: "background",
+      });
+      const peer = await authenticateAndJoin(room, "connection-1");
+      await sleep(heartbeatExpiryMs + TEST_TTL_MARGIN_MS);
+      await room.receive(
+        peer,
+        heartbeatWire(PRESENCE_CONFORMANCE_ROOM_ID, "connection-1", "ping-late"),
+      );
+      checkEqual(
+        peer.closes[0]?.code,
+        1001,
+        "expected a post-deadline close in background mode",
+      );
+    },
+  },
+  {
     name: "both refresh modes reach the same terminal state",
     async run() {
       for (const refreshMode of ["background", "on-message"] as const) {
@@ -559,3 +623,4 @@ export const presenceRoomConformance = (
     },
   },
 ];
+};

--- a/packages/collab-runtime/test/presence-room.test.ts
+++ b/packages/collab-runtime/test/presence-room.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import {
   DEFAULT_PRESENCE_ROOM_POLICY,
   createPresenceRoom,
-  type PresenceRoomOptions,
+  type PresenceRoomPolicy,
 } from "../src";
 import {
   createMemoryConnectionLimiter,
@@ -10,22 +10,35 @@ import {
   createMemoryPresenceStore,
   createOpaqueTestCodec,
   createStubPresenceSessionHooks,
+  PRESENCE_CONFORMANCE_ROOM_ID,
   presenceRoomConformance,
+  type PresenceRoomConformanceOptions,
   type PresenceRoomHarness,
 } from "../src/testing";
 
-const createHarness = (options?: PresenceRoomOptions): PresenceRoomHarness => {
+const createHarness = (
+  options?: PresenceRoomConformanceOptions,
+): PresenceRoomHarness => {
   const store = createMemoryPresenceStore();
   const fanout = createMemoryPresenceFanout();
   const connections = createMemoryConnectionLimiter();
   const sessions = createStubPresenceSessionHooks();
+  const policy: PresenceRoomPolicy = {
+    ...DEFAULT_PRESENCE_ROOM_POLICY,
+    ...(options?.heartbeatExpiryMs === undefined
+      ? {}
+      : { heartbeatExpiryMs: options.heartbeatExpiryMs }),
+    ...(options?.memberTtlMs === undefined
+      ? {}
+      : { memberTtlMs: options.memberTtlMs }),
+  };
   const room = createPresenceRoom(
-    "room-a",
+    PRESENCE_CONFORMANCE_ROOM_ID,
     {
       codec: createOpaqueTestCodec(),
       connections,
       fanout,
-      policy: DEFAULT_PRESENCE_ROOM_POLICY,
+      policy,
       sessions,
       store,
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verifies and fixes still-valid presence room review findings in `@softmaple/collab-runtime`:

- **Lease refresh:** `receiveJoin` / `receiveUpdate` now honor `lease.refresh()` returning `false` (close 1008) like `receiveHeartbeat`.
- **Heartbeat ordering:** inbound frames sweep other peers first (excluding self to avoid queue deadlock), then evaluate self-expiry before rearming; post-deadline frames close 1001 in both refresh modes.
- **Auth infrastructure errors:** `retainFanout` / store failures follow the `resumeSession` 1011 path; genuine auth failures still use AuthError + 1008. `authenticate` also verifies resolved `identity.userId` matches `auth.userId`.
- **Codec contract:** documents non-throwing methods (`applyPatch`, `consumeQuota`, `createMember`, `encode`, `isMember`).
- **Resume state:** `PresenceRoomResumeState` now carries `authorizationExpiresAt` and restores it on resume.
- **Store contract:** `removeMember` return type strengthened to `unknown | null`; fake store purges on remove; added `getMember` expiry conformance.
- **Fake lease fencing:** memory connection limiter uses per-admission tokens so stale releases cannot clobber newer leases.
- **Conformance/test harness:** configurable TTL timing, fixed update-before-join identity, exported `PRESENCE_CONFORMANCE_ROOM_ID`, fake peer `send` records before `sendImpl`.

## Test plan

- [x] `pnpm --filter @softmaple/collab-runtime build`
- [x] `pnpm --filter @softmaple/collab-runtime test` (91 tests passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e3fb5ae-d058-4a47-bf98-0fec878e956a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e3fb5ae-d058-4a47-bf98-0fec878e956a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

