### PR TITLE
test(apps/web): keep stale presence connect pending across userId change

### DIFF
--- a/apps/web/modules/docs/document-presence.test.tsx
+++ b/apps/web/modules/docs/document-presence.test.tsx
@@ -319,7 +319,9 @@ describe("DocumentPresence auth lifecycle", () => {
     expect(connectResolvers).toHaveLength(1);
     const resolveUser1Connect = connectResolvers[0];
     if (resolveUser1Connect === undefined) {
-      throw new Error("expected the user-1 adapter connect() to remain pending");
+      throw new Error(
+        "expected the user-1 adapter connect() to remain pending",
+      );
     }
     expect(container.textContent).not.toContain("Connecting presence");
 
@@ -356,7 +358,9 @@ describe("DocumentPresence auth lifecycle", () => {
     expect(connectResolvers).toHaveLength(2);
     const resolveUser2Connect = connectResolvers[1];
     if (resolveUser2Connect === undefined) {
-      throw new Error("expected the user-2 adapter connect() to remain pending");
+      throw new Error(
+        "expected the user-2 adapter connect() to remain pending",
+      );
     }
 
     await act(async () => {

--- a/apps/web/modules/docs/document-presence.test.tsx
+++ b/apps/web/modules/docs/document-presence.test.tsx
@@ -17,8 +17,15 @@ const fakeAdapter = () => ({
   subscribe: () => () => undefined,
   updatePresence: () => undefined,
 });
+const connectResolvers: Array<() => void> = [];
 const createWebSocketAdapter = vi.fn(() => ({
   ...fakeAdapter(),
+  connect: vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        connectResolvers.push(resolve);
+      }),
+  ),
   disconnect,
 }));
 const createNoopAdapter = vi.fn(fakeAdapter);
@@ -38,21 +45,35 @@ type SessionResult = {
 let authListener: AuthListener | null = null;
 let resolveGetSession: ((value: SessionResult) => void) | null = null;
 
-vi.mock("@softmaple/awareness", () => ({
-  PresenceProvider: ({ children }: { children: ReactNode }) => children,
-  createNoopAdapter: () => createNoopAdapter(),
-  createWebSocketAdapter: () => createWebSocketAdapter(),
-  isDirectionalSelectionRange: () => false,
-  isStableCursorPosition: () => false,
-  useOthers: () => [],
-  usePresence: () => ({
-    connectionState: "connected",
-    presence: new Map(),
-    updatePresence: vi.fn(),
-  }),
-  useUpdateCursor: () => () => undefined,
-  useUpdateSelection: () => () => undefined,
-}));
+vi.mock("@softmaple/awareness", async () => {
+  const { useEffect } = await import("react");
+  return {
+    PresenceProvider: ({
+      adapter,
+      children,
+    }: {
+      adapter: { connect: () => Promise<unknown> };
+      children: ReactNode;
+    }) => {
+      useEffect(() => {
+        void adapter.connect();
+      }, [adapter]);
+      return children;
+    },
+    createNoopAdapter: () => createNoopAdapter(),
+    createWebSocketAdapter: () => createWebSocketAdapter(),
+    isDirectionalSelectionRange: () => false,
+    isStableCursorPosition: () => false,
+    useOthers: () => [],
+    usePresence: () => ({
+      connectionState: "connected",
+      presence: new Map(),
+      updatePresence: vi.fn(),
+    }),
+    useUpdateCursor: () => () => undefined,
+    useUpdateSelection: () => () => undefined,
+  };
+});
 
 vi.mock("@softmaple/ui/components/avatar", () => ({
   Avatar: ({ children }: { children: ReactNode }) =>
@@ -138,6 +159,7 @@ describe("DocumentPresence auth lifecycle", () => {
   beforeEach(() => {
     authListener = null;
     resolveGetSession = null;
+    connectResolvers.length = 0;
     disconnect.mockClear();
     createWebSocketAdapter.mockClear();
     createNoopAdapter.mockClear();
@@ -294,9 +316,14 @@ describe("DocumentPresence auth lifecycle", () => {
     });
 
     expect(createWebSocketAdapter).toHaveBeenCalledTimes(1);
+    expect(connectResolvers).toHaveLength(1);
+    const resolveUser1Connect = connectResolvers[0];
+    if (resolveUser1Connect === undefined) {
+      throw new Error("expected the user-1 adapter connect() to remain pending");
+    }
     expect(container.textContent).not.toContain("Connecting presence");
 
-    // Switch signed-in user before the new connection attempt resolves.
+    // Switch signed-in user before the in-flight user-1 connect resolves.
     await act(async () => {
       root.render(
         createElement(DocumentPresence, { ...baseProps, userId: "user-2" }),
@@ -304,10 +331,18 @@ describe("DocumentPresence auth lifecycle", () => {
       await Promise.resolve();
     });
 
-    // The user-1 adapter must be disconnected and never shown as live under
-    // user-2's identity while the new connection is in flight.
     expect(disconnect).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Connecting presence");
+
+    // Resolving the stale user-1 connection must not restore it as live.
+    await act(async () => {
+      resolveUser1Connect();
+      await Promise.resolve();
+    });
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Connecting presence");
+    expect(container.textContent).not.toContain("Presence connected");
 
     await act(async () => {
       resolveGetSession?.({
@@ -318,6 +353,17 @@ describe("DocumentPresence auth lifecycle", () => {
     });
 
     expect(createWebSocketAdapter).toHaveBeenCalledTimes(2);
+    expect(connectResolvers).toHaveLength(2);
+    const resolveUser2Connect = connectResolvers[1];
+    if (resolveUser2Connect === undefined) {
+      throw new Error("expected the user-2 adapter connect() to remain pending");
+    }
+
+    await act(async () => {
+      resolveUser2Connect();
+      await Promise.resolve();
+    });
+
     expect(container.textContent).not.toContain("Connecting presence");
 
     await act(async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The userId mid-connect presence test resolved `getSession` and treated the adapter as live immediately, while `fakeAdapter().connect` completed synchronously and the mocked `PresenceProvider` never called `connect()`. That did not cover a stale in-flight connection.

This change:

- Makes websocket `connect()` wait on a controlled promise
- Has the `PresenceProvider` mock call `adapter.connect()` so that promise is actually in flight
- Switches `userId` to `user-2` before resolving the user-1 connect
- Resolves the stale connection and asserts the user-1 adapter stays disconnected and never becomes live
- Then resolves the user-2 connection and keeps the existing successful-connection assertions

## Test commands

- `pnpm turbo run test --filter=@softmaple/web -- modules/docs/document-presence.test.tsx` — 5 passed
- `pnpm --filter @softmaple/web typecheck` — passed
- `pnpm exec biome check apps/web/modules/docs/document-presence.test.tsx` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baae9bca-e672-46ce-a05e-dcde4ab26fab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baae9bca-e672-46ce-a05e-dcde4ab26fab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

