### PR TITLE
test(packages/collab-runtime): add shared DocumentEventStore conformance suite

### DIFF
--- a/apps/collab-cloudflare/test/document-event-store-conformance.test.ts
+++ b/apps/collab-cloudflare/test/document-event-store-conformance.test.ts
@@ -22,6 +22,19 @@ const isConflictLike = (error: unknown): error is ConflictLike =>
   error !== null &&
   (error as { name?: unknown }).name === "DocumentEventConflictError";
 
+const storeErrorResponse = (error: unknown): Response => {
+  if (isConflictLike(error)) {
+    return Response.json(
+      { message: JSON.stringify({ kind: "conflict", ...error.details }) },
+      { status: 400 },
+    );
+  }
+  return Response.json(
+    { message: JSON.stringify({ kind: "unavailable" }) },
+    { status: 500 },
+  );
+};
+
 /**
  * Simulates the two Postgres RPC functions
  * (`append_document_event_batches`, `read_document_event_page`) that
@@ -53,29 +66,24 @@ const createFetchMock =
         );
         return Response.json(ids);
       } catch (error) {
-        if (isConflictLike(error)) {
-          return Response.json(
-            { message: JSON.stringify({ kind: "conflict", ...error.details }) },
-            { status: 400 },
-          );
-        }
-        return Response.json(
-          { message: JSON.stringify({ kind: "unavailable" }) },
-          { status: 500 },
-        );
+        return storeErrorResponse(error);
       }
     }
 
     if (url.pathname === "/rest/v1/rpc/read_document_event_page") {
-      const page = await backingStore.read(
-        body.p_document_id as string,
-        body.p_after_cursor as string,
-      );
-      return Response.json({
-        batches: page.batches,
-        complete: page.complete,
-        nextCursor: page.nextCursor,
-      });
+      try {
+        const page = await backingStore.read(
+          body.p_document_id as string,
+          body.p_after_cursor as string,
+        );
+        return Response.json({
+          batches: page.batches,
+          complete: page.complete,
+          nextCursor: page.nextCursor,
+        });
+      } catch (error) {
+        return storeErrorResponse(error);
+      }
     }
 
     throw new Error(

--- a/apps/collab-cloudflare/test/document-event-store-conformance.test.ts
+++ b/apps/collab-cloudflare/test/document-event-store-conformance.test.ts
@@ -1,0 +1,103 @@
+import type { DocumentEventBatches } from "@softmaple/collab-runtime";
+import {
+  createMemoryDocumentEventStore,
+  documentEventStoreConformance,
+} from "@softmaple/collab-runtime/testing";
+import { env } from "cloudflare:workers";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { createSupabaseDocumentBackend } from "../src/supabase-backend";
+
+type ConflictLike = {
+  readonly details: {
+    readonly batchIds?: ReadonlyArray<string>;
+    readonly conflictType: string;
+    readonly documentId: string;
+    readonly eventIds?: ReadonlyArray<string>;
+    readonly missingParentIds?: ReadonlyArray<string>;
+  };
+};
+
+const isConflictLike = (error: unknown): error is ConflictLike =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { name?: unknown }).name === "DocumentEventConflictError";
+
+/**
+ * Simulates the two Postgres RPC functions
+ * (`append_document_event_batches`, `read_document_event_page`) that
+ * `createSupabaseDocumentBackend`'s real adapter calls over HTTP, backed by
+ * the same reference `DocumentEventStore` used in
+ * packages/collab-runtime's own conformance run and apps/collab's Prisma
+ * wiring — one source of truth for what the store contract requires.
+ * `supabase-backend.ts` only calls `admin.rpc(...)`, never `.from()`, so
+ * these two endpoints are the entire outbound surface this port exercises.
+ */
+const createFetchMock =
+  (backingStore: ReturnType<typeof createMemoryDocumentEventStore>) =>
+  async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    const body: Record<string, unknown> = await request.json();
+
+    if (url.pathname === "/rest/v1/rpc/append_document_event_batches") {
+      const batches: DocumentEventBatches = (
+        body.p_batches as ReadonlyArray<{
+          readonly payload: DocumentEventBatches[number];
+        }>
+      ).map((entry) => entry.payload);
+      try {
+        const ids = await backingStore.append(
+          body.p_document_id as string,
+          body.p_actor_id as string,
+          batches,
+        );
+        return Response.json(ids);
+      } catch (error) {
+        if (isConflictLike(error)) {
+          return Response.json(
+            { message: JSON.stringify({ kind: "conflict", ...error.details }) },
+            { status: 400 },
+          );
+        }
+        return Response.json(
+          { message: JSON.stringify({ kind: "unavailable" }) },
+          { status: 500 },
+        );
+      }
+    }
+
+    if (url.pathname === "/rest/v1/rpc/read_document_event_page") {
+      const page = await backingStore.read(
+        body.p_document_id as string,
+        body.p_after_cursor as string,
+      );
+      return Response.json({
+        batches: page.batches,
+        complete: page.complete,
+        nextCursor: page.nextCursor,
+      });
+    }
+
+    throw new Error(
+      `document-event-store-conformance fetch mock: unexpected request to ${url}`,
+    );
+  };
+
+let backingStore: ReturnType<typeof createMemoryDocumentEventStore>;
+
+beforeEach(() => {
+  backingStore = createMemoryDocumentEventStore();
+  vi.stubGlobal("fetch", createFetchMock(backingStore));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("document event store (Cloudflare/Supabase adapter)", () => {
+  for (const testCase of documentEventStoreConformance(
+    () => createSupabaseDocumentBackend(env).events,
+  )) {
+    it(testCase.name, testCase.run);
+  }
+});

--- a/apps/collab/test/document-event-store-conformance.test.ts
+++ b/apps/collab/test/document-event-store-conformance.test.ts
@@ -1,0 +1,25 @@
+import { documentEventStoreConformance } from "@softmaple/collab-runtime/testing";
+import { beforeEach, describe, it, vi } from "vitest";
+import { createPrismaEventStoreMock } from "./helpers/prismaEventStoreMock";
+
+const mocks = createPrismaEventStoreMock();
+
+vi.doMock("../server/utils/prisma", () => ({
+  prisma: mocks.prisma,
+}));
+
+const { prismaDocumentEventStore } = await import(
+  "../server/adapters/prisma-document-event-store"
+);
+
+describe("document event store (Nitro/Prisma adapter)", () => {
+  beforeEach(() => {
+    mocks.reset();
+  });
+
+  for (const testCase of documentEventStoreConformance(
+    () => prismaDocumentEventStore,
+  )) {
+    it(testCase.name, testCase.run);
+  }
+});

--- a/apps/collab/test/event-store.test.ts
+++ b/apps/collab/test/event-store.test.ts
@@ -34,6 +34,9 @@ const { appendEventBatches, EVENT_CONFLICT_TYPE, EventConflictError } =
 const DOCUMENT_ID = "00000000-0000-4000-8000-000000000001";
 const ACTOR_ID = "00000000-0000-4000-8000-000000000002";
 
+const hasStoredBatch = (batchId: string): boolean =>
+  [...mocks.state.batches.values()].some((row) => row.batch_id === batchId);
+
 const BOOTSTRAP_BATCH = TEST_BOOTSTRAP_BATCH;
 
 const createCausalBatches = (): {
@@ -150,8 +153,8 @@ describe("appendEventBatches conflict paths", () => {
       first.batchId,
       second.batchId,
     ]);
-    expect(mocks.state.batches.has(first.batchId)).toBe(true);
-    expect(mocks.state.batches.has(second.batchId)).toBe(true);
+    expect(hasStoredBatch(first.batchId)).toBe(true);
+    expect(hasStoredBatch(second.batchId)).toBe(true);
   });
 
   it("stores a causal child after its parent commits under lock ordering", async () => {
@@ -173,8 +176,8 @@ describe("appendEventBatches conflict paths", () => {
         batchIds: [second.batchId],
       },
     });
-    expect(mocks.state.batches.has(first.batchId)).toBe(false);
-    expect(mocks.state.batches.has(second.batchId)).toBe(false);
+    expect(hasStoredBatch(first.batchId)).toBe(false);
+    expect(hasStoredBatch(second.batchId)).toBe(false);
   });
 
   it("accepts causally ordered dependent batches in one request", async () => {
@@ -182,8 +185,8 @@ describe("appendEventBatches conflict paths", () => {
     await expect(
       appendEventBatches(DOCUMENT_ID, ACTOR_ID, [first, second]),
     ).resolves.toEqual([first.batchId, second.batchId]);
-    expect(mocks.state.batches.has(first.batchId)).toBe(true);
-    expect(mocks.state.batches.has(second.batchId)).toBe(true);
+    expect(hasStoredBatch(first.batchId)).toBe(true);
+    expect(hasStoredBatch(second.batchId)).toBe(true);
   });
 
   it("exposes structured conflict details for diagnostics", () => {
@@ -210,7 +213,7 @@ describe("appendEventBatches conflict paths", () => {
     await expect(
       appendEventBatches(DOCUMENT_ID, ACTOR_ID, [BOOTSTRAP_BATCH]),
     ).resolves.toEqual([BOOTSTRAP_BATCH_ID]);
-    expect(mocks.state.batches.has(BOOTSTRAP_BATCH_ID)).toBe(true);
+    expect(hasStoredBatch(BOOTSTRAP_BATCH_ID)).toBe(true);
     expect(mocks.state.eventIds.has(BOOTSTRAP_EVENT_ID)).toBe(true);
   });
 });

--- a/apps/collab/test/event-store.test.ts
+++ b/apps/collab/test/event-store.test.ts
@@ -5,16 +5,9 @@ import {
   createBlockReplica,
   type RichTextEventBatch,
 } from "@softmaple/block-model";
-import { Prisma } from "@softmaple/db";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPrismaEventStoreMock } from "./helpers/prismaEventStoreMock";
 import { TEST_BOOTSTRAP_BATCH } from "./helpers/bootstrapBatch";
-
-type StoredBatch = {
-  readonly batch_id: string;
-  readonly payload_hash: string;
-  readonly payload: RichTextEventBatch;
-  readonly id: bigint;
-};
 
 type Deferred<T> = {
   readonly promise: Promise<T>;
@@ -29,194 +22,14 @@ const deferred = <T>(): Deferred<T> => {
   return { promise, resolve };
 };
 
-const mocks = vi.hoisted(() => {
-  const state = {
-    batches: new Map<string, StoredBatch>(),
-    eventIds: new Map<string, string>(),
-    role: "EDITOR" as string | null,
-    nextRowId: 1n,
-    lockHolders: 0,
-    lockWaiters: [] as Array<() => void>,
-    beforeCreateBatch: null as null | (() => Promise<void>),
-  };
+const mocks = createPrismaEventStoreMock();
 
-  const acquireLock = async (): Promise<void> => {
-    if (state.lockHolders === 0) {
-      state.lockHolders = 1;
-      return;
-    }
-    await new Promise<void>((resolve) => {
-      state.lockWaiters.push(resolve);
-    });
-    // Ownership was transferred by releaseLock; do not toggle holders here.
-  };
-
-  const releaseLock = (): void => {
-    const next = state.lockWaiters.shift();
-    if (next) {
-      // Keep the lock held while transferring ownership to the next waiter.
-      next();
-      return;
-    }
-    state.lockHolders = 0;
-  };
-
-  const transactionClient = {
-    $executeRaw: vi.fn(async () => {
-      // appendEventBatches only uses $executeRaw for the document advisory lock.
-      await acquireLock();
-      return 0;
-    }),
-    $queryRaw: vi.fn(async () =>
-      state.role === null ? [] : [{ role: state.role }],
-    ),
-    documentEventBatch: {
-      findMany: vi.fn(
-        async ({
-          where,
-        }: {
-          readonly where: {
-            readonly document_id: string;
-            readonly batch_id: { readonly in: ReadonlyArray<string> };
-          };
-        }) =>
-          where.batch_id.in.flatMap((batchId) => {
-            const row = state.batches.get(batchId);
-            return row === undefined
-              ? []
-              : [{ batch_id: row.batch_id, payload_hash: row.payload_hash }];
-          }),
-      ),
-      create: vi.fn(
-        async ({
-          data,
-        }: {
-          readonly data: {
-            readonly batch_id: string;
-            readonly payload_hash: string;
-            readonly payload: RichTextEventBatch;
-          };
-        }) => {
-          if (state.beforeCreateBatch !== null) {
-            await state.beforeCreateBatch();
-          }
-          if (state.batches.has(data.batch_id)) {
-            throw new Prisma.PrismaClientKnownRequestError(
-              "Unique constraint",
-              {
-                code: "P2002",
-                clientVersion: "test",
-              },
-            );
-          }
-          const id = state.nextRowId;
-          state.nextRowId += 1n;
-          state.batches.set(data.batch_id, {
-            batch_id: data.batch_id,
-            payload_hash: data.payload_hash,
-            payload: data.payload,
-            id,
-          });
-          return { id };
-        },
-      ),
-    },
-    documentEventId: {
-      findMany: vi.fn(
-        async ({
-          where,
-        }: {
-          readonly where: {
-            readonly event_id: { readonly in: ReadonlyArray<string> };
-          };
-        }) =>
-          where.event_id.in.flatMap((eventId) =>
-            state.eventIds.has(eventId) ? [{ event_id: eventId }] : [],
-          ),
-      ),
-      createMany: vi.fn(
-        async ({
-          data,
-        }: {
-          readonly data: ReadonlyArray<{
-            readonly event_id: string;
-            readonly batch_row_id: bigint;
-          }>;
-        }) => {
-          for (const row of data) {
-            if (state.eventIds.has(row.event_id)) {
-              throw new Prisma.PrismaClientKnownRequestError(
-                "Unique constraint",
-                {
-                  code: "P2002",
-                  clientVersion: "test",
-                },
-              );
-            }
-            state.eventIds.set(row.event_id, String(row.batch_row_id));
-          }
-          return { count: data.length };
-        },
-      ),
-    },
-  };
-
-  return {
-    state,
-    releaseLock,
-    prisma: {
-      $transaction: vi.fn(
-        async (
-          fn: (tx: typeof transactionClient) => unknown,
-          _options?: { readonly maxWait?: number; readonly timeout?: number },
-        ) => {
-          try {
-            return await fn(transactionClient);
-          } finally {
-            releaseLock();
-          }
-        },
-      ),
-      documentEventBatch: {
-        findMany: vi.fn(
-          async ({
-            where,
-          }: {
-            readonly where: {
-              readonly batch_id?: { readonly in: ReadonlyArray<string> };
-            };
-          }) => {
-            const ids = where.batch_id?.in ?? [...state.batches.keys()];
-            return ids.flatMap((batchId) => {
-              const row = state.batches.get(batchId);
-              return row === undefined
-                ? []
-                : [
-                    {
-                      batch_id: row.batch_id,
-                      payload_hash: row.payload_hash,
-                      id: row.id,
-                      payload: row.payload,
-                    },
-                  ];
-            });
-          },
-        ),
-      },
-    },
-    transactionClient,
-  };
-});
-
-vi.mock("../server/utils/prisma", () => ({
+vi.doMock("../server/utils/prisma", () => ({
   prisma: mocks.prisma,
 }));
 
-import {
-  appendEventBatches,
-  EVENT_CONFLICT_TYPE,
-  EventConflictError,
-} from "../server/utils/event-store";
+const { appendEventBatches, EVENT_CONFLICT_TYPE, EventConflictError } =
+  await import("../server/utils/event-store");
 
 const DOCUMENT_ID = "00000000-0000-4000-8000-000000000001";
 const ACTOR_ID = "00000000-0000-4000-8000-000000000002";
@@ -242,15 +55,8 @@ const createCausalBatches = (): {
 
 describe("appendEventBatches conflict paths", () => {
   beforeEach(() => {
-    mocks.state.batches.clear();
-    mocks.state.eventIds.clear();
-    mocks.state.role = "EDITOR";
-    mocks.state.nextRowId = 1n;
-    mocks.state.lockHolders = 0;
-    mocks.state.lockWaiters = [];
-    mocks.state.beforeCreateBatch = null;
+    mocks.reset();
     mocks.state.eventIds.set(BOOTSTRAP_EVENT_ID, "0");
-    vi.clearAllMocks();
   });
 
   it("rejects duplicate event IDs inside the incoming request", async () => {

--- a/apps/collab/test/helpers/prismaEventStoreMock.ts
+++ b/apps/collab/test/helpers/prismaEventStoreMock.ts
@@ -23,6 +23,19 @@ const deferred = (): Deferred => {
   return { promise, resolve };
 };
 
+const documentBatchKey = (documentId: string, batchId: string): string =>
+  `${documentId}\0${batchId}`;
+
+const restoreMap = <K, V>(
+  target: Map<K, V>,
+  snapshot: ReadonlyMap<K, V>,
+): void => {
+  target.clear();
+  for (const [key, value] of snapshot) {
+    target.set(key, value);
+  }
+};
+
 /**
  * A hand-rolled `prisma` mock reproducing the exact behaviour
  * `appendEventBatches`/`readEventPage` (`server/utils/event-store.ts`) rely
@@ -84,7 +97,9 @@ export const createPrismaEventStoreMock = () => {
           };
         }) =>
           where.batch_id.in.flatMap((batchId) => {
-            const row = state.batches.get(batchId);
+            const row = state.batches.get(
+              documentBatchKey(where.document_id, batchId),
+            );
             return row === undefined
               ? []
               : [{ batch_id: row.batch_id, payload_hash: row.payload_hash }];
@@ -104,7 +119,8 @@ export const createPrismaEventStoreMock = () => {
           if (state.beforeCreateBatch !== null) {
             await state.beforeCreateBatch();
           }
-          if (state.batches.has(data.batch_id)) {
+          const key = documentBatchKey(data.document_id, data.batch_id);
+          if (state.batches.has(key)) {
             throw new Prisma.PrismaClientKnownRequestError(
               "Unique constraint",
               {
@@ -115,7 +131,7 @@ export const createPrismaEventStoreMock = () => {
           }
           const id = state.nextRowId;
           state.nextRowId += 1n;
-          state.batches.set(data.batch_id, {
+          state.batches.set(key, {
             batch_id: data.batch_id,
             document_id: data.document_id,
             payload_hash: data.payload_hash,
@@ -158,6 +174,8 @@ export const createPrismaEventStoreMock = () => {
                 },
               );
             }
+          }
+          for (const row of data) {
             state.eventIds.set(row.event_id, String(row.batch_row_id));
           }
           return { count: data.length };
@@ -172,8 +190,14 @@ export const createPrismaEventStoreMock = () => {
         fn: (tx: typeof transactionClient) => unknown,
         _options?: { readonly maxWait?: number; readonly timeout?: number },
       ) => {
+        const snapshotBatches = new Map(state.batches);
+        const snapshotEventIds = new Map(state.eventIds);
         try {
           return await fn(transactionClient);
+        } catch (error) {
+          restoreMap(state.batches, snapshotBatches);
+          restoreMap(state.eventIds, snapshotEventIds);
+          throw error;
         } finally {
           releaseLock();
         }
@@ -198,7 +222,12 @@ export const createPrismaEventStoreMock = () => {
           // needs document scoping / id-order / take.
           if (where.batch_id !== undefined) {
             return where.batch_id.in.flatMap((batchId) => {
-              const row = state.batches.get(batchId);
+              if (where.document_id === undefined) {
+                return [];
+              }
+              const row = state.batches.get(
+                documentBatchKey(where.document_id, batchId),
+              );
               return row === undefined
                 ? []
                 : [{ batch_id: row.batch_id, payload_hash: row.payload_hash }];
@@ -228,7 +257,14 @@ export const createPrismaEventStoreMock = () => {
     state.lockHolders = 0;
     state.lockWaiters = [];
     state.beforeCreateBatch = null;
-    vi.clearAllMocks();
+    transactionClient.$executeRaw.mockClear();
+    transactionClient.$queryRaw.mockClear();
+    transactionClient.documentEventBatch.findMany.mockClear();
+    transactionClient.documentEventBatch.create.mockClear();
+    transactionClient.documentEventId.findMany.mockClear();
+    transactionClient.documentEventId.createMany.mockClear();
+    prisma.$transaction.mockClear();
+    prisma.documentEventBatch.findMany.mockClear();
   };
 
   return { deferred, prisma, releaseLock, reset, state, transactionClient };

--- a/apps/collab/test/helpers/prismaEventStoreMock.ts
+++ b/apps/collab/test/helpers/prismaEventStoreMock.ts
@@ -1,0 +1,235 @@
+import type { RichTextEventBatch } from "@softmaple/block-model";
+import { Prisma } from "@softmaple/db";
+import { vi } from "vitest";
+
+type StoredBatch = {
+  readonly batch_id: string;
+  readonly document_id: string;
+  readonly payload_hash: string;
+  readonly payload: RichTextEventBatch;
+  readonly id: bigint;
+};
+
+type Deferred = {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+};
+
+const deferred = (): Deferred => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+};
+
+/**
+ * A hand-rolled `prisma` mock reproducing the exact behaviour
+ * `appendEventBatches`/`readEventPage` (`server/utils/event-store.ts`) rely
+ * on: the per-document advisory-lock transaction, the write-access role
+ * check, unique-constraint conflicts on `documentEventBatch`/`documentEventId`,
+ * and paginated reads. Shared by `event-store.test.ts` (direct conflict-path
+ * tests) and `document-event-store-conformance.test.ts` (the cross-runtime
+ * conformance suite run against the real `prismaDocumentEventStore` adapter).
+ */
+export const createPrismaEventStoreMock = () => {
+  const state = {
+    batches: new Map<string, StoredBatch>(),
+    eventIds: new Map<string, string>(),
+    role: "EDITOR" as string | null,
+    nextRowId: 1n,
+    lockHolders: 0,
+    lockWaiters: [] as Array<() => void>,
+    beforeCreateBatch: null as null | (() => Promise<void>),
+  };
+
+  const acquireLock = async (): Promise<void> => {
+    if (state.lockHolders === 0) {
+      state.lockHolders = 1;
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      state.lockWaiters.push(resolve);
+    });
+    // Ownership was transferred by releaseLock; do not toggle holders here.
+  };
+
+  const releaseLock = (): void => {
+    const next = state.lockWaiters.shift();
+    if (next) {
+      // Keep the lock held while transferring ownership to the next waiter.
+      next();
+      return;
+    }
+    state.lockHolders = 0;
+  };
+
+  const transactionClient = {
+    $executeRaw: vi.fn(async () => {
+      // appendEventBatches only uses $executeRaw for the document advisory lock.
+      await acquireLock();
+      return 0;
+    }),
+    $queryRaw: vi.fn(async () =>
+      state.role === null ? [] : [{ role: state.role }],
+    ),
+    documentEventBatch: {
+      findMany: vi.fn(
+        async ({
+          where,
+        }: {
+          readonly where: {
+            readonly document_id: string;
+            readonly batch_id: { readonly in: ReadonlyArray<string> };
+          };
+        }) =>
+          where.batch_id.in.flatMap((batchId) => {
+            const row = state.batches.get(batchId);
+            return row === undefined
+              ? []
+              : [{ batch_id: row.batch_id, payload_hash: row.payload_hash }];
+          }),
+      ),
+      create: vi.fn(
+        async ({
+          data,
+        }: {
+          readonly data: {
+            readonly batch_id: string;
+            readonly document_id: string;
+            readonly payload_hash: string;
+            readonly payload: RichTextEventBatch;
+          };
+        }) => {
+          if (state.beforeCreateBatch !== null) {
+            await state.beforeCreateBatch();
+          }
+          if (state.batches.has(data.batch_id)) {
+            throw new Prisma.PrismaClientKnownRequestError(
+              "Unique constraint",
+              {
+                code: "P2002",
+                clientVersion: "test",
+              },
+            );
+          }
+          const id = state.nextRowId;
+          state.nextRowId += 1n;
+          state.batches.set(data.batch_id, {
+            batch_id: data.batch_id,
+            document_id: data.document_id,
+            payload_hash: data.payload_hash,
+            payload: data.payload,
+            id,
+          });
+          return { id };
+        },
+      ),
+    },
+    documentEventId: {
+      findMany: vi.fn(
+        async ({
+          where,
+        }: {
+          readonly where: {
+            readonly event_id: { readonly in: ReadonlyArray<string> };
+          };
+        }) =>
+          where.event_id.in.flatMap((eventId) =>
+            state.eventIds.has(eventId) ? [{ event_id: eventId }] : [],
+          ),
+      ),
+      createMany: vi.fn(
+        async ({
+          data,
+        }: {
+          readonly data: ReadonlyArray<{
+            readonly event_id: string;
+            readonly batch_row_id: bigint;
+          }>;
+        }) => {
+          for (const row of data) {
+            if (state.eventIds.has(row.event_id)) {
+              throw new Prisma.PrismaClientKnownRequestError(
+                "Unique constraint",
+                {
+                  code: "P2002",
+                  clientVersion: "test",
+                },
+              );
+            }
+            state.eventIds.set(row.event_id, String(row.batch_row_id));
+          }
+          return { count: data.length };
+        },
+      ),
+    },
+  };
+
+  const prisma = {
+    $transaction: vi.fn(
+      async (
+        fn: (tx: typeof transactionClient) => unknown,
+        _options?: { readonly maxWait?: number; readonly timeout?: number },
+      ) => {
+        try {
+          return await fn(transactionClient);
+        } finally {
+          releaseLock();
+        }
+      },
+    ),
+    documentEventBatch: {
+      findMany: vi.fn(
+        async ({
+          where,
+          take,
+        }: {
+          readonly where: {
+            readonly batch_id?: { readonly in: ReadonlyArray<string> };
+            readonly document_id?: string;
+            readonly id?: { readonly gt: bigint };
+          };
+          readonly take?: number;
+        }) => {
+          // Two distinct callers share this mock: the P2002-conflict-retry
+          // verification path looks up specific batch ids; readEventPage
+          // paginates by id cursor within one document. Only the latter
+          // needs document scoping / id-order / take.
+          if (where.batch_id !== undefined) {
+            return where.batch_id.in.flatMap((batchId) => {
+              const row = state.batches.get(batchId);
+              return row === undefined
+                ? []
+                : [{ batch_id: row.batch_id, payload_hash: row.payload_hash }];
+            });
+          }
+          const after = where.id?.gt ?? 0n;
+          const rows = [...state.batches.values()]
+            .filter(
+              (row) =>
+                row.id > after &&
+                (where.document_id === undefined ||
+                  row.document_id === where.document_id),
+            )
+            .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+          const limited = take === undefined ? rows : rows.slice(0, take);
+          return limited.map((row) => ({ id: row.id, payload: row.payload }));
+        },
+      ),
+    },
+  };
+
+  const reset = (): void => {
+    state.batches.clear();
+    state.eventIds.clear();
+    state.role = "EDITOR";
+    state.nextRowId = 1n;
+    state.lockHolders = 0;
+    state.lockWaiters = [];
+    state.beforeCreateBatch = null;
+    vi.clearAllMocks();
+  };
+
+  return { deferred, prisma, releaseLock, reset, state, transactionClient };
+};

--- a/packages/collab-runtime/src/testing/capability-conformance.ts
+++ b/packages/collab-runtime/src/testing/capability-conformance.ts
@@ -2,9 +2,20 @@ import type {
   ConnectionLimiter,
   ConnectionPolicy,
 } from "../connection-limiter";
+import {
+  DOCUMENT_EVENT_CONFLICT_TYPE,
+  INITIAL_DOCUMENT_EVENT_CURSOR,
+  type DocumentEventBatches,
+  type DocumentEventStore,
+} from "../event-store";
 import type { PresenceFanout } from "../presence-fanout";
 import type { PresenceMemberRecord, PresenceStore } from "../presence-store";
-import { check, checkEqual, type ConformanceCase } from "./conformance-case";
+import {
+  check,
+  checkEqual,
+  expectRejection,
+  type ConformanceCase,
+} from "./conformance-case";
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -391,6 +402,265 @@ export const connectionLimiterConformance = (
       check(
         reacquired.accepted,
         "expected a released peerId to be re-acquirable",
+      );
+    },
+  },
+];
+
+/**
+ * A single-event batch whose shape satisfies block-model's own
+ * `parseBatch` invariants (batchId === the event's id, batch parentVersion
+ * === the event's parentVersion, non-empty insert text matching the
+ * text-insert effect). Real adapters re-validate stored payloads through
+ * that parser on read, so any batch a case expects to read back must be
+ * built this way — not just "TypeScript-shape-compatible".
+ */
+const validBatch = (
+  eventId: string,
+  parentVersion: ReadonlyArray<string>,
+  text = "hello",
+): DocumentEventBatches[number] => ({
+  schemaVersion: 1,
+  batchId: eventId,
+  parentVersion,
+  events: [
+    {
+      schemaVersion: 1,
+      id: eventId,
+      parentVersion,
+      timestamp: 0,
+      operation: { type: "insert", index: 0, text },
+      effect: { type: "text-insert", blockId: "block-1", text },
+    },
+  ],
+});
+
+/**
+ * A batch shaped only well enough to reach `DocumentEventStore.append` —
+ * batchId is independent of its event ids, so it must never be expected to
+ * survive a real adapter's read-back parser. Only for cases whose fixtures
+ * are rejected before ever being persisted (conflict/isolation checks that
+ * happen ahead of any durable write).
+ */
+const rejectedBatch = (
+  batchId: string,
+  parentVersion: ReadonlyArray<string>,
+  eventId: string,
+  eventParentVersion: ReadonlyArray<string> = parentVersion,
+): DocumentEventBatches[number] => ({
+  schemaVersion: 1,
+  batchId,
+  parentVersion,
+  events: [
+    {
+      schemaVersion: 1,
+      id: eventId,
+      parentVersion: eventParentVersion,
+      timestamp: 0,
+      operation: { type: "insert", index: 0, text: "x" },
+      effect: { type: "text-insert", blockId: "block-1", text: "x" },
+    },
+  ],
+});
+
+const DOCUMENT_ID = "conformance-document";
+const ACTOR_ID = "conformance-actor";
+
+type ConflictLike = {
+  readonly details: {
+    readonly batchIds?: ReadonlyArray<string>;
+    readonly conflictType: string;
+    readonly missingParentIds?: ReadonlyArray<string>;
+  };
+};
+
+/**
+ * Name-based, not `instanceof` — adapters running under a different module
+ * graph (e.g. apps/collab-cloudflare's workerd test runtime) must not be
+ * required to share a class identity with this package to pass conformance.
+ */
+const isConflict = (error: unknown): error is ConflictLike =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { name?: unknown }).name === "DocumentEventConflictError";
+
+/**
+ * Behavioural conformance for `DocumentEventStore`: atomic append, same-
+ * batchId idempotent resend, causal ordering within one request, and the
+ * conflict/cursor semantics documented on the port itself. Every
+ * `DocumentEventStore` adapter (Prisma/Postgres, Supabase RPC/Postgres) must
+ * pass this unmodified — it is the direct evidence that the two
+ * collaboration runtimes' durable history behaves identically.
+ */
+export const documentEventStoreConformance = (
+  createStore: () => DocumentEventStore,
+): ConformanceCase[] => [
+  {
+    name: "read on an empty document returns an empty, complete page at the initial cursor",
+    async run() {
+      const store = createStore();
+      const page = await store.read(DOCUMENT_ID, INITIAL_DOCUMENT_EVENT_CURSOR);
+      checkEqual(page.batches, [], "expected no batches");
+      check(page.complete, "expected an empty document to read as complete");
+      checkEqual(
+        page.nextCursor,
+        INITIAL_DOCUMENT_EVENT_CURSOR,
+        "expected the cursor to stay at its initial value",
+      );
+    },
+  },
+  {
+    name: "append then read round-trips the batch and advances the cursor",
+    async run() {
+      const store = createStore();
+      const batch = validBatch("event-1", []);
+      const ids = await store.append(DOCUMENT_ID, ACTOR_ID, [batch]);
+      checkEqual(ids, ["event-1"], "expected the appended batch id back");
+      const page = await store.read(DOCUMENT_ID, INITIAL_DOCUMENT_EVENT_CURSOR);
+      checkEqual(
+        page.batches.map((stored) => stored.batchId),
+        ["event-1"],
+        "expected the stored batch to be readable",
+      );
+      check(page.complete, "expected the page to be complete");
+      check(
+        page.nextCursor !== INITIAL_DOCUMENT_EVENT_CURSOR,
+        "expected the cursor to advance past the initial value",
+      );
+    },
+  },
+  {
+    name: "an exact duplicate batch resend is idempotent",
+    async run() {
+      const store = createStore();
+      const batch = validBatch("event-1", []);
+      const first = await store.append(DOCUMENT_ID, ACTOR_ID, [batch]);
+      const second = await store.append(DOCUMENT_ID, ACTOR_ID, [batch]);
+      checkEqual(first, ["event-1"], "expected the first append to succeed");
+      checkEqual(second, ["event-1"], "expected the resend to be idempotent");
+      const page = await store.read(DOCUMENT_ID, INITIAL_DOCUMENT_EVENT_CURSOR);
+      checkEqual(
+        page.batches.length,
+        1,
+        "expected the batch to be stored exactly once",
+      );
+    },
+  },
+  {
+    name: "the same batchId with a different payload is a conflict",
+    async run() {
+      const store = createStore();
+      const original = validBatch("event-1", [], "hello");
+      const conflicting = rejectedBatch("event-1", [], "event-1-other");
+      await store.append(DOCUMENT_ID, ACTOR_ID, [original]);
+      const error = await expectRejection(
+        () => store.append(DOCUMENT_ID, ACTOR_ID, [conflicting]),
+        "expected a payload conflict to reject",
+      );
+      check(isConflict(error), "expected a DocumentEventConflictError");
+      if (isConflict(error)) {
+        checkEqual(
+          error.details.conflictType,
+          DOCUMENT_EVENT_CONFLICT_TYPE.BatchPayloadConflict,
+          "expected a batch-payload-conflict",
+        );
+      }
+    },
+  },
+  {
+    name: "a batch referencing an unstored parent is a missing-parent conflict",
+    async run() {
+      const store = createStore();
+      const orphan = rejectedBatch("batch-2", ["event-1"], "event-2", [
+        "event-1",
+      ]);
+      const error = await expectRejection(
+        () => store.append(DOCUMENT_ID, ACTOR_ID, [orphan]),
+        "expected a missing-parent conflict to reject",
+      );
+      check(isConflict(error), "expected a DocumentEventConflictError");
+      if (isConflict(error)) {
+        checkEqual(
+          error.details.conflictType,
+          DOCUMENT_EVENT_CONFLICT_TYPE.MissingParentHistory,
+          "expected missing-parent-history",
+        );
+        check(
+          (error.details.missingParentIds ?? []).includes("event-1"),
+          "expected the missing parent id to be reported",
+        );
+      }
+    },
+  },
+  {
+    name: "a duplicate event id within one request is a conflict",
+    async run() {
+      const store = createStore();
+      const first = rejectedBatch("batch-1", [], "event-x");
+      const second = rejectedBatch("batch-2", [], "event-x");
+      const error = await expectRejection(
+        () => store.append(DOCUMENT_ID, ACTOR_ID, [first, second]),
+        "expected a duplicate event id to reject",
+      );
+      check(isConflict(error), "expected a DocumentEventConflictError");
+      if (isConflict(error)) {
+        checkEqual(
+          error.details.conflictType,
+          DOCUMENT_EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
+          "expected duplicate-incoming-event-id",
+        );
+      }
+    },
+  },
+  {
+    name: "causally ordered batches in one request commit together, in order",
+    async run() {
+      const store = createStore();
+      const parent = validBatch("event-1", []);
+      const child = validBatch("event-2", ["event-1"]);
+      const ids = await store.append(DOCUMENT_ID, ACTOR_ID, [parent, child]);
+      checkEqual(
+        ids,
+        ["event-1", "event-2"],
+        "expected both ids back in input order",
+      );
+      const page = await store.read(DOCUMENT_ID, INITIAL_DOCUMENT_EVENT_CURSOR);
+      checkEqual(
+        page.batches.map((stored) => stored.batchId),
+        ["event-1", "event-2"],
+        "expected both batches to be readable in order",
+      );
+    },
+  },
+  {
+    name: "reversed causal order within one request is rejected atomically",
+    async run() {
+      const store = createStore();
+      const parent = validBatch("event-1", []);
+      const child = validBatch("event-2", ["event-1"]);
+      const error = await expectRejection(
+        () => store.append(DOCUMENT_ID, ACTOR_ID, [child, parent]),
+        "expected the reversed request to reject",
+      );
+      check(isConflict(error), "expected a DocumentEventConflictError");
+      const page = await store.read(DOCUMENT_ID, INITIAL_DOCUMENT_EVENT_CURSOR);
+      checkEqual(page.batches, [], "expected neither batch to have committed");
+    },
+  },
+  {
+    name: "reads for one document do not see another document's batches",
+    async run() {
+      const store = createStore();
+      const batch = validBatch("event-1", []);
+      await store.append(DOCUMENT_ID, ACTOR_ID, [batch]);
+      const page = await store.read(
+        "another-document",
+        INITIAL_DOCUMENT_EVENT_CURSOR,
+      );
+      checkEqual(
+        page.batches,
+        [],
+        "expected an unrelated document to be empty",
       );
     },
   },

--- a/packages/collab-runtime/src/testing/capability-conformance.ts
+++ b/packages/collab-runtime/src/testing/capability-conformance.ts
@@ -491,6 +491,10 @@ const isConflict = (error: unknown): error is ConflictLike =>
  * `DocumentEventStore` adapter (Prisma/Postgres, Supabase RPC/Postgres) must
  * pass this unmodified — it is the direct evidence that the two
  * collaboration runtimes' durable history behaves identically.
+ *
+ * @param createStore Invoked once per case. Each invocation must provide
+ *   empty history for both `DOCUMENT_ID` and `"another-document"`. Shared
+ *   adapter instances must reset backing state before every conformance case.
  */
 export const documentEventStoreConformance = (
   createStore: () => DocumentEventStore,
@@ -558,13 +562,11 @@ export const documentEventStoreConformance = (
         "expected a payload conflict to reject",
       );
       check(isConflict(error), "expected a DocumentEventConflictError");
-      if (isConflict(error)) {
-        checkEqual(
-          error.details.conflictType,
-          DOCUMENT_EVENT_CONFLICT_TYPE.BatchPayloadConflict,
-          "expected a batch-payload-conflict",
-        );
-      }
+      checkEqual(
+        error.details.conflictType,
+        DOCUMENT_EVENT_CONFLICT_TYPE.BatchPayloadConflict,
+        "expected a batch-payload-conflict",
+      );
     },
   },
   {
@@ -579,17 +581,15 @@ export const documentEventStoreConformance = (
         "expected a missing-parent conflict to reject",
       );
       check(isConflict(error), "expected a DocumentEventConflictError");
-      if (isConflict(error)) {
-        checkEqual(
-          error.details.conflictType,
-          DOCUMENT_EVENT_CONFLICT_TYPE.MissingParentHistory,
-          "expected missing-parent-history",
-        );
-        check(
-          (error.details.missingParentIds ?? []).includes("event-1"),
-          "expected the missing parent id to be reported",
-        );
-      }
+      checkEqual(
+        error.details.conflictType,
+        DOCUMENT_EVENT_CONFLICT_TYPE.MissingParentHistory,
+        "expected missing-parent-history",
+      );
+      check(
+        (error.details.missingParentIds ?? []).includes("event-1"),
+        "expected the missing parent id to be reported",
+      );
     },
   },
   {
@@ -603,13 +603,11 @@ export const documentEventStoreConformance = (
         "expected a duplicate event id to reject",
       );
       check(isConflict(error), "expected a DocumentEventConflictError");
-      if (isConflict(error)) {
-        checkEqual(
-          error.details.conflictType,
-          DOCUMENT_EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
-          "expected duplicate-incoming-event-id",
-        );
-      }
+      checkEqual(
+        error.details.conflictType,
+        DOCUMENT_EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
+        "expected duplicate-incoming-event-id",
+      );
     },
   },
   {

--- a/packages/collab-runtime/src/testing/conformance-case.ts
+++ b/packages/collab-runtime/src/testing/conformance-case.ts
@@ -46,3 +46,16 @@ export const checkEqual = <T>(
     );
   }
 };
+
+/** Runs `fn`, returning the thrown value, or throws if `fn` did not reject. */
+export const expectRejection = async (
+  fn: () => Promise<unknown>,
+  message: string,
+): Promise<unknown> => {
+  try {
+    await fn();
+  } catch (error) {
+    return error;
+  }
+  throw new Error(message);
+};

--- a/packages/collab-runtime/src/testing/conformance-case.ts
+++ b/packages/collab-runtime/src/testing/conformance-case.ts
@@ -9,9 +9,9 @@ export interface ConformanceCase {
   run(): Promise<void>;
 }
 
-export const check = (condition: boolean, message: string): void => {
+export function check(condition: boolean, message: string): asserts condition {
   if (!condition) throw new Error(message);
-};
+}
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/collab-runtime/src/testing/fakes.ts
+++ b/packages/collab-runtime/src/testing/fakes.ts
@@ -4,6 +4,15 @@ import {
   type ConnectionLimiter,
 } from "../connection-limiter";
 import {
+  DOCUMENT_EVENT_CONFLICT_TYPE,
+  DOCUMENT_EVENT_PAGE_LIMIT,
+  DocumentEventConflictError,
+  type DocumentEventBatches,
+  type DocumentEventCursor,
+  type DocumentEventPage,
+  type DocumentEventStore,
+} from "../event-store";
+import {
   PRESENCE_MESSAGE,
   type PresenceCodec,
   type PresenceEnvelope,
@@ -478,3 +487,156 @@ export const createOpaqueTestCodec = (): PresenceCodec => ({
     } as PresencePatch & TestPatchPayload;
   },
 });
+
+type StoredDocumentBatch = {
+  readonly batch: DocumentEventBatches[number];
+  readonly canonical: string;
+  readonly cursor: number;
+};
+
+type DocumentState = {
+  readonly batchesById: Map<string, StoredDocumentBatch>;
+  readonly durableEventIds: Set<string>;
+  readonly orderedBatchIds: string[];
+  nextCursor: number;
+};
+
+const canonicalizeBatch = (batch: DocumentEventBatches[number]): string =>
+  JSON.stringify({
+    events: batch.events,
+    parentVersion: batch.parentVersion,
+  });
+
+/**
+ * Reference `DocumentEventStore`: atomic multi-batch append (validates the
+ * whole request before committing any of it), same-batchId idempotent
+ * resend, and the same conflict-type taxonomy real adapters must produce.
+ * Also backs apps/collab-cloudflare's fetchMock RPC simulation, so this is
+ * the single source of truth both harnesses run `documentEventStoreConformance`
+ * against.
+ */
+export const createMemoryDocumentEventStore = (): DocumentEventStore => {
+  const documents = new Map<string, DocumentState>();
+
+  const getOrCreateDocument = (documentId: string): DocumentState => {
+    const existing = documents.get(documentId);
+    if (existing !== undefined) return existing;
+    const created: DocumentState = {
+      batchesById: new Map(),
+      durableEventIds: new Set(),
+      orderedBatchIds: [],
+      nextCursor: 0,
+    };
+    documents.set(documentId, created);
+    return created;
+  };
+
+  return {
+    async append(documentId, _actorId, batches) {
+      const document = getOrCreateDocument(documentId);
+
+      const seenEventIdsInRequest = new Set<string>();
+      for (const batch of batches) {
+        for (const event of batch.events) {
+          if (seenEventIdsInRequest.has(event.id)) {
+            throw new DocumentEventConflictError(
+              `duplicate event id ${event.id} within one append request`,
+              {
+                conflictType:
+                  DOCUMENT_EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
+                documentId,
+                eventIds: [event.id],
+              },
+            );
+          }
+          seenEventIdsInRequest.add(event.id);
+        }
+      }
+
+      const projectedDurableEventIds = new Set(document.durableEventIds);
+      const results: string[] = [];
+      const toCommit: StoredDocumentBatch[] = [];
+
+      for (const batch of batches) {
+        const existing = document.batchesById.get(batch.batchId);
+        const canonical = canonicalizeBatch(batch);
+        if (existing !== undefined) {
+          if (existing.canonical !== canonical) {
+            throw new DocumentEventConflictError(
+              `batch ${batch.batchId} was already stored with a different payload`,
+              {
+                conflictType: DOCUMENT_EVENT_CONFLICT_TYPE.BatchPayloadConflict,
+                documentId,
+                batchIds: [batch.batchId],
+              },
+            );
+          }
+          results.push(batch.batchId);
+          continue;
+        }
+
+        const missingParentIds = batch.parentVersion.filter(
+          (parentId) => !projectedDurableEventIds.has(parentId),
+        );
+        if (missingParentIds.length > 0) {
+          throw new DocumentEventConflictError(
+            `batch ${batch.batchId} references history that has not been stored`,
+            {
+              conflictType: DOCUMENT_EVENT_CONFLICT_TYPE.MissingParentHistory,
+              documentId,
+              batchIds: [batch.batchId],
+              missingParentIds,
+            },
+          );
+        }
+
+        for (const event of batch.events) {
+          projectedDurableEventIds.add(event.id);
+        }
+        toCommit.push({ batch, canonical, cursor: -1 });
+        results.push(batch.batchId);
+      }
+
+      // Nothing above mutated `document`, so a request that partly failed
+      // has left every prior append fully intact — commit only now.
+      for (const staged of toCommit) {
+        document.nextCursor += 1;
+        const stored: StoredDocumentBatch = {
+          ...staged,
+          cursor: document.nextCursor,
+        };
+        document.batchesById.set(staged.batch.batchId, stored);
+        document.orderedBatchIds.push(staged.batch.batchId);
+        for (const event of staged.batch.events) {
+          document.durableEventIds.add(event.id);
+        }
+      }
+
+      return results;
+    },
+
+    async read(
+      documentId: string,
+      afterCursor: DocumentEventCursor,
+    ): Promise<DocumentEventPage> {
+      const document = documents.get(documentId);
+      if (document === undefined) {
+        return { batches: [], complete: true, nextCursor: afterCursor };
+      }
+      const afterNumeric = Number(afterCursor);
+      const pending = document.orderedBatchIds
+        .map((batchId) => document.batchesById.get(batchId))
+        .filter(
+          (stored): stored is StoredDocumentBatch =>
+            stored !== undefined && stored.cursor > afterNumeric,
+        );
+      const page = pending.slice(0, DOCUMENT_EVENT_PAGE_LIMIT);
+      const last = page.at(-1);
+      return {
+        batches: page.map((stored) => stored.batch),
+        complete: page.length === pending.length,
+        nextCursor: last === undefined ? afterCursor : String(last.cursor),
+      };
+    },
+  };
+};

--- a/packages/collab-runtime/src/testing/fakes.ts
+++ b/packages/collab-runtime/src/testing/fakes.ts
@@ -501,11 +501,30 @@ type DocumentState = {
   nextCursor: number;
 };
 
+const canonicalJson = (value: unknown): string => {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+  throw new Error("event batch contains a non-JSON value");
+};
+
 const canonicalizeBatch = (batch: DocumentEventBatches[number]): string =>
-  JSON.stringify({
-    events: batch.events,
-    parentVersion: batch.parentVersion,
-  });
+  canonicalJson(batch);
 
 /**
  * Reference `DocumentEventStore`: atomic multi-batch append (validates the

--- a/packages/collab-runtime/src/testing/index.ts
+++ b/packages/collab-runtime/src/testing/index.ts
@@ -1,16 +1,19 @@
 export {
   check,
   checkEqual,
+  expectRejection,
   type ConformanceCase,
 } from "./conformance-case";
 export {
   connectionLimiterConformance,
+  documentEventStoreConformance,
   presenceFanoutConformance,
   presenceStoreConformance,
 } from "./capability-conformance";
 export {
   TEST_PRESENCE_WIRE_TYPE,
   createMemoryConnectionLimiter,
+  createMemoryDocumentEventStore,
   createMemoryPresenceFanout,
   createMemoryPresenceStore,
   createOpaqueTestCodec,

--- a/packages/collab-runtime/test/document-event-store-conformance.test.ts
+++ b/packages/collab-runtime/test/document-event-store-conformance.test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from "vitest";
+import {
+  createMemoryDocumentEventStore,
+  documentEventStoreConformance,
+} from "../src/testing";
+
+describe("document event store (memory)", () => {
+  for (const testCase of documentEventStoreConformance(() =>
+    createMemoryDocumentEventStore(),
+  )) {
+    it(testCase.name, testCase.run);
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `documentEventStoreConformance`, a case-generator following the existing `presenceStoreConformance` pattern (`packages/collab-runtime/src/testing/capability-conformance.ts`), covering the `DocumentEventStore` port's documented contract: idempotent resend, payload/missing-parent/duplicate-event conflicts, atomic multi-batch commit (including atomicity on rejection), and document isolation.
- Wires the **identical** case list against both real production adapters, not stand-in fakes:
  - `apps/collab`: the real `prismaDocumentEventStore`, via a Prisma-client mock extracted from `event-store.test.ts` into a shared, reusable test helper (`test/helpers/prismaEventStoreMock.ts`) — removes ~180 lines of duplicated mock logic in the process.
  - `apps/collab-cloudflare`: the real `createSupabaseDocumentBackend(env).events`, via `vi.stubGlobal("fetch", ...)` intercepting the two Postgres RPC calls it makes — this closes a pre-existing gap where that adapter had **zero** test coverage (every Durable Object test swapped in an in-memory fake instead).

This is the shared-conformance-suite slice of [issue 874](https://github.com/softmaple/softmaple/issues/874), scoped specifically to the `DocumentEventStore` port. `createDocumentRoom`'s ~40-case state machine (`packages/collab-runtime/test/document-room.test.ts`) is identical code shared by both runtimes and already covered once there — duplicating it per app would test the same code twice rather than proving anything runtime-specific. `RoomFanout` conformance (Redis pub/sub vs. DO-local fanout) is intentionally left for a possible future slice, since the two are architecturally different enough that forcing identical black-box conformance may not be the right test shape.

## Test plan

- [x] `pnpm --filter @softmaple/collab-runtime test` — 99 tests pass (new kit + reference fake)
- [x] `pnpm --filter @softmaple/collab test` — 110 tests pass, including the new suite against the real Prisma adapter and the refactored `event-store.test.ts` (unchanged behavior, shared mock helper)
- [x] `pnpm --filter @softmaple/collab-cloudflare test` — 38 tests pass, including the new suite against the real Supabase adapter
- [x] `typecheck`/`lint`/`build` clean across all three packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added shared conformance coverage for document event stores, including pagination, cursors, idempotent retries, conflicts, missing parents, duplicate events, atomic writes, and document isolation.
  * Added an in-memory event-store implementation for reliable testing.
  * Expanded coverage across Cloudflare/Supabase, Nitro/Prisma, and in-memory implementations.
  * Added reusable test helpers for validating rejected operations and resetting test state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->