### PR TITLE
test: align document event store mocks with review comments

### DIFF
--- a/apps/collab-cloudflare/test/document-event-store-conformance.test.ts
+++ b/apps/collab-cloudflare/test/document-event-store-conformance.test.ts
@@ -22,6 +22,19 @@ const isConflictLike = (error: unknown): error is ConflictLike =>
   error !== null &&
   (error as { name?: unknown }).name === "DocumentEventConflictError";
 
+const storeErrorResponse = (error: unknown): Response => {
+  if (isConflictLike(error)) {
+    return Response.json(
+      { message: JSON.stringify({ kind: "conflict", ...error.details }) },
+      { status: 400 },
+    );
+  }
+  return Response.json(
+    { message: JSON.stringify({ kind: "unavailable" }) },
+    { status: 500 },
+  );
+};
+
 /**
  * Simulates the two Postgres RPC functions
  * (`append_document_event_batches`, `read_document_event_page`) that
@@ -53,29 +66,24 @@ const createFetchMock =
         );
         return Response.json(ids);
       } catch (error) {
-        if (isConflictLike(error)) {
-          return Response.json(
-            { message: JSON.stringify({ kind: "conflict", ...error.details }) },
-            { status: 400 },
-          );
-        }
-        return Response.json(
-          { message: JSON.stringify({ kind: "unavailable" }) },
-          { status: 500 },
-        );
+        return storeErrorResponse(error);
       }
     }
 
     if (url.pathname === "/rest/v1/rpc/read_document_event_page") {
-      const page = await backingStore.read(
-        body.p_document_id as string,
-        body.p_after_cursor as string,
-      );
-      return Response.json({
-        batches: page.batches,
-        complete: page.complete,
-        nextCursor: page.nextCursor,
-      });
+      try {
+        const page = await backingStore.read(
+          body.p_document_id as string,
+          body.p_after_cursor as string,
+        );
+        return Response.json({
+          batches: page.batches,
+          complete: page.complete,
+          nextCursor: page.nextCursor,
+        });
+      } catch (error) {
+        return storeErrorResponse(error);
+      }
     }
 
     throw new Error(

--- a/apps/collab/test/event-store.test.ts
+++ b/apps/collab/test/event-store.test.ts
@@ -34,6 +34,9 @@ const { appendEventBatches, EVENT_CONFLICT_TYPE, EventConflictError } =
 const DOCUMENT_ID = "00000000-0000-4000-8000-000000000001";
 const ACTOR_ID = "00000000-0000-4000-8000-000000000002";
 
+const hasStoredBatch = (batchId: string): boolean =>
+  [...mocks.state.batches.values()].some((row) => row.batch_id === batchId);
+
 const BOOTSTRAP_BATCH = TEST_BOOTSTRAP_BATCH;
 
 const createCausalBatches = (): {
@@ -150,8 +153,8 @@ describe("appendEventBatches conflict paths", () => {
       first.batchId,
       second.batchId,
     ]);
-    expect(mocks.state.batches.has(first.batchId)).toBe(true);
-    expect(mocks.state.batches.has(second.batchId)).toBe(true);
+    expect(hasStoredBatch(first.batchId)).toBe(true);
+    expect(hasStoredBatch(second.batchId)).toBe(true);
   });
 
   it("stores a causal child after its parent commits under lock ordering", async () => {
@@ -173,8 +176,8 @@ describe("appendEventBatches conflict paths", () => {
         batchIds: [second.batchId],
       },
     });
-    expect(mocks.state.batches.has(first.batchId)).toBe(false);
-    expect(mocks.state.batches.has(second.batchId)).toBe(false);
+    expect(hasStoredBatch(first.batchId)).toBe(false);
+    expect(hasStoredBatch(second.batchId)).toBe(false);
   });
 
   it("accepts causally ordered dependent batches in one request", async () => {
@@ -182,8 +185,8 @@ describe("appendEventBatches conflict paths", () => {
     await expect(
       appendEventBatches(DOCUMENT_ID, ACTOR_ID, [first, second]),
     ).resolves.toEqual([first.batchId, second.batchId]);
-    expect(mocks.state.batches.has(first.batchId)).toBe(true);
-    expect(mocks.state.batches.has(second.batchId)).toBe(true);
+    expect(hasStoredBatch(first.batchId)).toBe(true);
+    expect(hasStoredBatch(second.batchId)).toBe(true);
   });
 
   it("exposes structured conflict details for diagnostics", () => {
@@ -210,7 +213,7 @@ describe("appendEventBatches conflict paths", () => {
     await expect(
       appendEventBatches(DOCUMENT_ID, ACTOR_ID, [BOOTSTRAP_BATCH]),
     ).resolves.toEqual([BOOTSTRAP_BATCH_ID]);
-    expect(mocks.state.batches.has(BOOTSTRAP_BATCH_ID)).toBe(true);
+    expect(hasStoredBatch(BOOTSTRAP_BATCH_ID)).toBe(true);
     expect(mocks.state.eventIds.has(BOOTSTRAP_EVENT_ID)).toBe(true);
   });
 });

--- a/apps/collab/test/helpers/prismaEventStoreMock.ts
+++ b/apps/collab/test/helpers/prismaEventStoreMock.ts
@@ -23,6 +23,19 @@ const deferred = (): Deferred => {
   return { promise, resolve };
 };
 
+const documentBatchKey = (documentId: string, batchId: string): string =>
+  `${documentId}\0${batchId}`;
+
+const restoreMap = <K, V>(
+  target: Map<K, V>,
+  snapshot: ReadonlyMap<K, V>,
+): void => {
+  target.clear();
+  for (const [key, value] of snapshot) {
+    target.set(key, value);
+  }
+};
+
 /**
  * A hand-rolled `prisma` mock reproducing the exact behaviour
  * `appendEventBatches`/`readEventPage` (`server/utils/event-store.ts`) rely
@@ -84,7 +97,9 @@ export const createPrismaEventStoreMock = () => {
           };
         }) =>
           where.batch_id.in.flatMap((batchId) => {
-            const row = state.batches.get(batchId);
+            const row = state.batches.get(
+              documentBatchKey(where.document_id, batchId),
+            );
             return row === undefined
               ? []
               : [{ batch_id: row.batch_id, payload_hash: row.payload_hash }];
@@ -104,7 +119,8 @@ export const createPrismaEventStoreMock = () => {
           if (state.beforeCreateBatch !== null) {
             await state.beforeCreateBatch();
           }
-          if (state.batches.has(data.batch_id)) {
+          const key = documentBatchKey(data.document_id, data.batch_id);
+          if (state.batches.has(key)) {
             throw new Prisma.PrismaClientKnownRequestError(
               "Unique constraint",
               {
@@ -115,7 +131,7 @@ export const createPrismaEventStoreMock = () => {
           }
           const id = state.nextRowId;
           state.nextRowId += 1n;
-          state.batches.set(data.batch_id, {
+          state.batches.set(key, {
             batch_id: data.batch_id,
             document_id: data.document_id,
             payload_hash: data.payload_hash,
@@ -158,6 +174,8 @@ export const createPrismaEventStoreMock = () => {
                 },
               );
             }
+          }
+          for (const row of data) {
             state.eventIds.set(row.event_id, String(row.batch_row_id));
           }
           return { count: data.length };
@@ -172,8 +190,14 @@ export const createPrismaEventStoreMock = () => {
         fn: (tx: typeof transactionClient) => unknown,
         _options?: { readonly maxWait?: number; readonly timeout?: number },
       ) => {
+        const snapshotBatches = new Map(state.batches);
+        const snapshotEventIds = new Map(state.eventIds);
         try {
           return await fn(transactionClient);
+        } catch (error) {
+          restoreMap(state.batches, snapshotBatches);
+          restoreMap(state.eventIds, snapshotEventIds);
+          throw error;
         } finally {
           releaseLock();
         }
@@ -198,7 +222,12 @@ export const createPrismaEventStoreMock = () => {
           // needs document scoping / id-order / take.
           if (where.batch_id !== undefined) {
             return where.batch_id.in.flatMap((batchId) => {
-              const row = state.batches.get(batchId);
+              if (where.document_id === undefined) {
+                return [];
+              }
+              const row = state.batches.get(
+                documentBatchKey(where.document_id, batchId),
+              );
               return row === undefined
                 ? []
                 : [{ batch_id: row.batch_id, payload_hash: row.payload_hash }];
@@ -228,7 +257,14 @@ export const createPrismaEventStoreMock = () => {
     state.lockHolders = 0;
     state.lockWaiters = [];
     state.beforeCreateBatch = null;
-    vi.clearAllMocks();
+    transactionClient.$executeRaw.mockClear();
+    transactionClient.$queryRaw.mockClear();
+    transactionClient.documentEventBatch.findMany.mockClear();
+    transactionClient.documentEventBatch.create.mockClear();
+    transactionClient.documentEventId.findMany.mockClear();
+    transactionClient.documentEventId.createMany.mockClear();
+    prisma.$transaction.mockClear();
+    prisma.documentEventBatch.findMany.mockClear();
   };
 
   return { deferred, prisma, releaseLock, reset, state, transactionClient };

--- a/packages/collab-runtime/src/testing/capability-conformance.ts
+++ b/packages/collab-runtime/src/testing/capability-conformance.ts
@@ -491,6 +491,10 @@ const isConflict = (error: unknown): error is ConflictLike =>
  * `DocumentEventStore` adapter (Prisma/Postgres, Supabase RPC/Postgres) must
  * pass this unmodified — it is the direct evidence that the two
  * collaboration runtimes' durable history behaves identically.
+ *
+ * @param createStore Invoked once per case. Each invocation must provide
+ *   empty history for both `DOCUMENT_ID` and `"another-document"`. Shared
+ *   adapter instances must reset backing state before every conformance case.
  */
 export const documentEventStoreConformance = (
   createStore: () => DocumentEventStore,
@@ -558,13 +562,11 @@ export const documentEventStoreConformance = (
         "expected a payload conflict to reject",
       );
       check(isConflict(error), "expected a DocumentEventConflictError");
-      if (isConflict(error)) {
-        checkEqual(
-          error.details.conflictType,
-          DOCUMENT_EVENT_CONFLICT_TYPE.BatchPayloadConflict,
-          "expected a batch-payload-conflict",
-        );
-      }
+      checkEqual(
+        error.details.conflictType,
+        DOCUMENT_EVENT_CONFLICT_TYPE.BatchPayloadConflict,
+        "expected a batch-payload-conflict",
+      );
     },
   },
   {
@@ -579,17 +581,15 @@ export const documentEventStoreConformance = (
         "expected a missing-parent conflict to reject",
       );
       check(isConflict(error), "expected a DocumentEventConflictError");
-      if (isConflict(error)) {
-        checkEqual(
-          error.details.conflictType,
-          DOCUMENT_EVENT_CONFLICT_TYPE.MissingParentHistory,
-          "expected missing-parent-history",
-        );
-        check(
-          (error.details.missingParentIds ?? []).includes("event-1"),
-          "expected the missing parent id to be reported",
-        );
-      }
+      checkEqual(
+        error.details.conflictType,
+        DOCUMENT_EVENT_CONFLICT_TYPE.MissingParentHistory,
+        "expected missing-parent-history",
+      );
+      check(
+        (error.details.missingParentIds ?? []).includes("event-1"),
+        "expected the missing parent id to be reported",
+      );
     },
   },
   {
@@ -603,13 +603,11 @@ export const documentEventStoreConformance = (
         "expected a duplicate event id to reject",
       );
       check(isConflict(error), "expected a DocumentEventConflictError");
-      if (isConflict(error)) {
-        checkEqual(
-          error.details.conflictType,
-          DOCUMENT_EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
-          "expected duplicate-incoming-event-id",
-        );
-      }
+      checkEqual(
+        error.details.conflictType,
+        DOCUMENT_EVENT_CONFLICT_TYPE.DuplicateIncomingEventId,
+        "expected duplicate-incoming-event-id",
+      );
     },
   },
   {

--- a/packages/collab-runtime/src/testing/conformance-case.ts
+++ b/packages/collab-runtime/src/testing/conformance-case.ts
@@ -9,9 +9,9 @@ export interface ConformanceCase {
   run(): Promise<void>;
 }
 
-export const check = (condition: boolean, message: string): void => {
+export function check(condition: boolean, message: string): asserts condition {
   if (!condition) throw new Error(message);
-};
+}
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/collab-runtime/src/testing/fakes.ts
+++ b/packages/collab-runtime/src/testing/fakes.ts
@@ -501,11 +501,30 @@ type DocumentState = {
   nextCursor: number;
 };
 
+const canonicalJson = (value: unknown): string => {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+  throw new Error("event batch contains a non-JSON value");
+};
+
 const canonicalizeBatch = (batch: DocumentEventBatches[number]): string =>
-  JSON.stringify({
-    events: batch.events,
-    parentVersion: batch.parentVersion,
-  });
+  canonicalJson(batch);
 
 /**
  * Reference `DocumentEventStore`: atomic multi-batch append (validates the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes remaining review comments on the document event store conformance work. Each finding was checked against current code; all seven were still valid.

Changes proposed in this pull request:

- Snapshot `state.batches` and `state.eventIds` at the start of the Prisma `$transaction` mock and restore both when the callback throws, so failed `create` / `createMany` writes do not leak
- Key `documentEventBatch` lookups and inserts by `(document_id, batch_id)` to match the Prisma `@@unique` constraint
- Map Cloudflare fetch-mock read failures through the same 400/500 store-error path as append
- Clear only mocks owned by the Prisma event store helper in `reset()`, instead of `vi.clearAllMocks()`
- Document that `documentEventStoreConformance`’s `createStore` must start empty for both `DOCUMENT_ID` and `"another-document"`
- Make `check` an assertion function and drop redundant `isConflict` guards
- Canonicalize memory-store batches with `schemaVersion` and sorted object keys

Test commands run:

- `pnpm turbo run test --filter=@softmaple/collab-runtime --filter=@softmaple/collab --filter=@softmaple/collab-cloudflare` — all passed (collab-runtime 4 files, collab 12 files / 110 tests, collab-cloudflare 6 files / 38 tests)
- `pnpm turbo run typecheck --filter=@softmaple/collab-runtime --filter=@softmaple/collab --filter=@softmaple/collab-cloudflare` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43888065-220b-4c68-b258-485a13c0469b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43888065-220b-4c68-b258-485a13c0469b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

