### PR TITLE
docs: add collaboration runtime operational documentation

### DIFF
--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -6,10 +6,10 @@ issue #873 phase 6. It leaves `apps/collab` and its Nitro/Redis deployment
 unchanged while hosting the same `@softmaple/collab-runtime` `DocumentRoom`
 and `PresenceRoom` semantics in Cloudflare Durable Objects.
 
-It is not yet deployed to a reachable environment — see "Production
-deployment" below and
+The repository does not automate deployment or configure `apps/web` to select
+this runtime by default — see "Production deployment" below and
 [`docs/design/collaboration-operations.md`](../../docs/design/collaboration-operations.md)
-for the cross-runtime operational picture and current rollout stage.
+for the cross-runtime operational picture and configured rollout stage.
 
 ## Runtime shape
 
@@ -36,12 +36,14 @@ silently miss a durable batch. A completely idle revoked socket may remain
 physically open until the next room wake-up, but it cannot receive data past
 its cached validation deadline.
 
-The Durable Object owns only live peer coordination, fan-out, and connection
+`DocumentRoomDO` owns live document peer coordination, fan-out, and connection
 limits. Durable event append/repair goes through Supabase RPCs backed by the
 existing `document_event_batches` and `document_event_ids` Postgres tables.
 The RPC migration uses the same per-document transaction advisory lock as the
 Nitro host. No Redis dependency is needed for fan-out inside a single object,
-and Durable Object SQLite is not used as event history.
+and Durable Object SQLite is not used as document event history. The separate
+`PresenceRoomDO` does use Durable Object storage for live presence membership,
+as described below.
 
 A constructor wake revalidates every attached session against Supabase. The
 default 100-connection room policy therefore assumes a Workers plan with an
@@ -70,7 +72,8 @@ modules). It gets its own DO-local `ConnectionLimiter` and `PresenceFanout`
 (`supabase-presence-backend.ts`), and its own `PresenceCodec` bound to
 `@softmaple/awareness/protocol` (`awareness-presence-codec.ts`) — so a
 presence failure structurally cannot block durable document convergence, and
-a document-store outage cannot block presence.
+an event-store-specific failure cannot block presence. A broader Supabase Auth
+or Data API outage can still affect both rooms.
 
 Presence membership is `ctx.storage`-backed (not in-memory), so it survives
 hibernation: each member is stored with its own expiry and purged lazily on
@@ -90,16 +93,18 @@ empty room does not keep waking the object.
 | `COLLAB_ALLOWED_ORIGINS` | yes | Comma-separated browser Origins allowed to open `/collab/*` |
 | `SUPABASE_URL` | yes | Same Supabase project as `apps/collab` |
 | `SUPABASE_PUBLISHABLE_KEY` | yes | Used for the auth-scoped Supabase client |
-| `SUPABASE_SERVICE_ROLE_KEY` | yes | Elevated, server-only — used for the admin-scoped Supabase client that issues RPC calls (`admin.rpc(...)` in `supabase-backend.ts`). Never expose to browser code. |
+| `SUPABASE_SERVICE_ROLE_KEY` | yes | Elevated, server-only — used for event RPCs and privileged Data API reads of documents, workspace memberships, and user profiles. Never expose to browser code. |
 
-These four are `wrangler.jsonc`'s `secrets.required` list. The two tools
-enforce this differently: `wrangler deploy` validates all four are actually
-configured on the target Worker and **fails** with an error listing what's
-missing; `wrangler dev` (and the Vitest suite, which shares this check) only
-**warns** about missing local values and still starts. Unlike `apps/collab`,
-this app has no direct Postgres connection string; it only ever talks to
-Supabase over its RPC surface (`append_document_event_batches`,
-`read_document_event_page`).
+These four are `wrangler.jsonc`'s `secrets.required` list. A normal
+`wrangler deploy` validates that an existing Worker has all four and fails with
+an error listing missing bindings; a first deploy can provide all four with
+`--secrets-file`. `wrangler dev` (and the Vitest suite, which shares this
+check) only warns about missing local values and still starts. Unlike
+`apps/collab`, this app has no direct Postgres connection string. Durable event
+append/read use `append_document_event_batches` and
+`read_document_event_page`; session authorization and presence also call
+Supabase Auth and query `documents`, `workspace_members`, and `users` through
+the Data API.
 See
 [`docs/design/collaboration-operations.md`](../../docs/design/collaboration-operations.md#environment-configuration)
 for how this compares to Nitro's env config.
@@ -123,46 +128,92 @@ pnpm --filter @softmaple/collab-cloudflare cf-typegen
 pnpm --filter @softmaple/collab-cloudflare dev
 ```
 
-Set the same values with `wrangler secret put` before deployment. Never expose
-the service-role key to browser code.
+Never expose the service-role key to browser code. For production, follow the
+atomic first-deploy or later-rotation procedure below; do not bootstrap a new
+Worker with `wrangler secret put`.
 
 ## Production deployment
 
-**No CD pipeline exists yet, and this app has never been deployed to a
-reachable environment.** `.github/workflows/test-collab-cloudflare.yml`
-only runs `wrangler deploy --dry-run` as part of CI's `build` step; nothing
-runs a real `wrangler deploy`. `wrangler.jsonc` has no `routes` or custom
-domain, so even a manual deploy today would only be reachable at the
-default `workers.dev` subdomain.
+**No CD pipeline exists in the repository.**
+`.github/workflows/test-collab-cloudflare.yml` only runs
+`wrangler deploy --dry-run` as part of CI's `build` step; repository automation
+does not run a real deployment. `wrangler.jsonc` declares no route or custom
+domain, but `workers_dev` defaults to `true`, so a deploy publishes a reachable
+`workers.dev` endpoint. These facts do not prove Cloudflare account state: a
+Worker, deployment, route, custom domain, or traffic may already exist through
+manual commands or the dashboard.
 
-The manual process, until a real pipeline exists:
+### First deployment
 
-1. Set each of the four secrets above with `wrangler secret put <NAME>`
-   against the target Cloudflare account. **Each call creates a new Worker
-   version and deploys it immediately** — it is not a config-only write —
-   so on an already-running Worker this activates a new version per secret,
-   not just at the end of this sequence.
-2. Apply the same Prisma migrations applied for local setup, against the
-   target environment's Supabase project.
-3. `pnpm --filter @softmaple/collab-cloudflare deploy` (runs `wrangler
-   deploy` for real — this is the one command in this app that touches a
-   live Cloudflare account).
-4. Set `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` in `apps/web`'s environment
+Do not bootstrap a missing Worker with `wrangler secret put`. In the pinned
+Wrangler version, that command first creates and deploys placeholder Worker
+code, then deploys another version containing the secret. Supply all required
+secrets with the real application deployment instead:
+
+1. Confirm Wrangler is authenticated to the intended Cloudflare account with
+   `pnpm --filter @softmaple/collab-cloudflare exec wrangler whoami`. Before
+   any mutation, run
+   `pnpm --filter @softmaple/collab-cloudflare exec wrangler deployments status`
+   (a not-found result is expected for a new Worker), and inspect the Cloudflare
+   dashboard for routes, custom domains, and current traffic. Continue this
+   first-deployment procedure only if the Worker is absent and no external
+   trigger points at its intended name. If it exists, treat it as an existing
+   production resource: inventory its active and latest versions, bindings,
+   triggers, and traffic, then use the later-deployment procedure or stop for
+   reconciliation.
+2. Apply the repository's Prisma migrations to the target Supabase/Postgres
+   database.
+3. Create `apps/collab-cloudflare/.dev.vars.production` with all four required
+   values. The repository's `.dev.vars*` ignore rule prevents it from being
+   committed; still treat the file as temporary production secret material.
+4. Deploy the real Worker code, required secrets, and Durable Object migrations
+   together:
+
+   ```bash
+   pnpm --filter @softmaple/collab-cloudflare exec wrangler deploy \
+     --secrets-file .dev.vars.production
+   ```
+
+   A plain first `wrangler deploy` cannot inherit required bindings from a
+   Worker that does not exist.
+5. Securely remove the temporary file or retain it only in an approved secret
+   manager. The Worker is now reachable on its `workers.dev` URL. Verify its
+   HTTP/WebSocket paths, both event RPCs, Auth, and the required Data API table
+   reads before configuring `apps/web` to select it.
+6. Set `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` in `apps/web`'s environment
    to the resulting Worker URL, then **rebuild and redeploy `apps/web`** —
    `NEXT_PUBLIC_*` values are inlined at build time, so setting the
    variable alone does nothing for an already-running deployment; routing
    stays at 0% (all traffic on Nitro) until the rebuilt bundle ships, per
    [`apps/web/README.md`'s routing section](../web/README.md#collaboration-runtime-routing).
 
+### Later deployments and secret rotation
+
+Once the Worker exists, `pnpm --filter @softmaple/collab-cloudflare deploy`
+inherits its existing secrets and fails if a required binding is missing.
+
+For a controlled rotation, use `wrangler versions secret put <NAME>` (or
+`wrangler versions secret bulk <FILE>` for several values) to create an
+undeployed version. Before doing so, compare `wrangler deployments status` with
+`wrangler versions list`: these commands derive the secret version from the
+latest uploaded version, which may contain unrelated, undeployed code. Rotate
+only when that latest version is the intended active base. Review the new
+version, then explicitly activate its reported id with
+`wrangler versions deploy <VERSION_ID>`. Do not revoke the old upstream
+credential until the new version is active and verified.
+
+`wrangler secret put` is an immediate-activation alternative only when the
+latest version is already deployed. It creates and deploys a new version at
+once, so it is not a config-only write and needs no later `wrangler deploy`.
+
 ## Rollback
 
 To revert a bad deploy of the Worker itself (independent of the routing
 decision — see below): `wrangler rollback` reverts to the previously active
 version; `wrangler versions list` first if you need to roll back to a
-specific, older version by id (`wrangler rollback <VERSION_ID>`). Because no
-deployment has ever been exercised, this procedure is documented but
-unverified — confirm it works during the first real Stage 2 deployment
-rather than assuming it does.
+specific, older version by id (`wrangler rollback <VERSION_ID>`). Repository CI
+only exercises a dry run, so this procedure is not verified against account
+state. Confirm it during the first managed Stage 2 deployment.
 
 **Rollback can fail outright.** Cloudflare refuses it if a Durable Object
 class lifecycle change (via `wrangler.jsonc`'s `migrations` array) happened

--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -92,10 +92,14 @@ empty room does not keep waking the object.
 | `SUPABASE_PUBLISHABLE_KEY` | yes | Used for the auth-scoped Supabase client |
 | `SUPABASE_SERVICE_ROLE_KEY` | yes | Elevated, server-only — used for the admin-scoped Supabase client that issues RPC calls (`admin.rpc(...)` in `supabase-backend.ts`). Never expose to browser code. |
 
-These four are `wrangler.jsonc`'s `secrets.required` list — the Worker
-refuses to start without all of them. Unlike `apps/collab`, this app has no
-direct Postgres connection string; it only ever talks to Supabase over its
-RPC surface (`append_document_event_batches`, `read_document_event_page`).
+These four are `wrangler.jsonc`'s `secrets.required` list. The two tools
+enforce this differently: `wrangler deploy` validates all four are actually
+configured on the target Worker and **fails** with an error listing what's
+missing; `wrangler dev` (and the Vitest suite, which shares this check) only
+**warns** about missing local values and still starts. Unlike `apps/collab`,
+this app has no direct Postgres connection string; it only ever talks to
+Supabase over its RPC surface (`append_document_event_batches`,
+`read_document_event_page`).
 See
 [`docs/design/collaboration-operations.md`](../../docs/design/collaboration-operations.md#environment-configuration)
 for how this compares to Nitro's env config.
@@ -134,15 +138,21 @@ default `workers.dev` subdomain.
 The manual process, until a real pipeline exists:
 
 1. Set each of the four secrets above with `wrangler secret put <NAME>`
-   against the target Cloudflare account.
+   against the target Cloudflare account. **Each call creates a new Worker
+   version and deploys it immediately** — it is not a config-only write —
+   so on an already-running Worker this activates a new version per secret,
+   not just at the end of this sequence.
 2. Apply the same Prisma migrations applied for local setup, against the
    target environment's Supabase project.
 3. `pnpm --filter @softmaple/collab-cloudflare deploy` (runs `wrangler
    deploy` for real — this is the one command in this app that touches a
    live Cloudflare account).
 4. Set `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` in `apps/web`'s environment
-   to the resulting Worker URL — routing stays at 0% until this is set,
-   per [`apps/web/README.md`'s routing section](../web/README.md#collaboration-runtime-routing).
+   to the resulting Worker URL, then **rebuild and redeploy `apps/web`** —
+   `NEXT_PUBLIC_*` values are inlined at build time, so setting the
+   variable alone does nothing for an already-running deployment; routing
+   stays at 0% (all traffic on Nitro) until the rebuilt bundle ships, per
+   [`apps/web/README.md`'s routing section](../web/README.md#collaboration-runtime-routing).
 
 ## Rollback
 
@@ -153,6 +163,15 @@ specific, older version by id (`wrangler rollback <VERSION_ID>`). Because no
 deployment has ever been exercised, this procedure is documented but
 unverified — confirm it works during the first real Stage 2 deployment
 rather than assuming it does.
+
+**Rollback can fail outright.** Cloudflare refuses it if a Durable Object
+class lifecycle change (via `wrangler.jsonc`'s `migrations` array) happened
+between the active version and the rollback target, or if the target
+depends on a binding/resource that's since been modified or removed — both
+apply directly here once `DOCUMENT_ROOMS`/`PRESENCE_ROOMS` accumulate more
+than one migration entry. When `wrangler rollback` is refused for either
+reason, fall back to **routing rollback** below (move documents back to
+Nitro) rather than trying to force a Worker-level revert.
 
 This is a different lever from **routing rollback** (moving documents back
 to Nitro without touching what's deployed here) — see

--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -1,10 +1,15 @@
-# Cloudflare collaboration PoC
+# Cloudflare collaboration runtime
 
 This app started as the issue #871 proof of concept, added the hibernatable
 document room lifecycle from issue #872, and now adds a presence room from
 issue #873 phase 6. It leaves `apps/collab` and its Nitro/Redis deployment
 unchanged while hosting the same `@softmaple/collab-runtime` `DocumentRoom`
 and `PresenceRoom` semantics in Cloudflare Durable Objects.
+
+It is not yet deployed to a reachable environment — see "Production
+deployment" below and
+[`docs/design/collaboration-operations.md`](../../docs/design/collaboration-operations.md)
+for the cross-runtime operational picture and current rollout stage.
 
 ## Runtime shape
 
@@ -78,6 +83,23 @@ and broadcast Leave for lapsed members even when the room is otherwise idle.
 The alarm reschedules itself only while a WebSocket is still attached, so an
 empty room does not keep waking the object.
 
+## Environment
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `COLLAB_ALLOWED_ORIGINS` | yes | Comma-separated browser Origins allowed to open `/collab/*` |
+| `SUPABASE_URL` | yes | Same Supabase project as `apps/collab` |
+| `SUPABASE_PUBLISHABLE_KEY` | yes | Used for the auth-scoped Supabase client |
+| `SUPABASE_SERVICE_ROLE_KEY` | yes | Elevated, server-only — used for the admin-scoped Supabase client that issues RPC calls (`admin.rpc(...)` in `supabase-backend.ts`). Never expose to browser code. |
+
+These four are `wrangler.jsonc`'s `secrets.required` list — the Worker
+refuses to start without all of them. Unlike `apps/collab`, this app has no
+direct Postgres connection string; it only ever talks to Supabase over its
+RPC surface (`append_document_event_batches`, `read_document_event_page`).
+See
+[`docs/design/collaboration-operations.md`](../../docs/design/collaboration-operations.md#environment-configuration)
+for how this compares to Nitro's env config.
+
 ## Local setup
 
 Create `apps/collab-cloudflare/.dev.vars` (it is ignored by the repository) with:
@@ -99,6 +121,45 @@ pnpm --filter @softmaple/collab-cloudflare dev
 
 Set the same values with `wrangler secret put` before deployment. Never expose
 the service-role key to browser code.
+
+## Production deployment
+
+**No CD pipeline exists yet, and this app has never been deployed to a
+reachable environment.** `.github/workflows/test-collab-cloudflare.yml`
+only runs `wrangler deploy --dry-run` as part of CI's `build` step; nothing
+runs a real `wrangler deploy`. `wrangler.jsonc` has no `routes` or custom
+domain, so even a manual deploy today would only be reachable at the
+default `workers.dev` subdomain.
+
+The manual process, until a real pipeline exists:
+
+1. Set each of the four secrets above with `wrangler secret put <NAME>`
+   against the target Cloudflare account.
+2. Apply the same Prisma migrations applied for local setup, against the
+   target environment's Supabase project.
+3. `pnpm --filter @softmaple/collab-cloudflare deploy` (runs `wrangler
+   deploy` for real — this is the one command in this app that touches a
+   live Cloudflare account).
+4. Set `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` in `apps/web`'s environment
+   to the resulting Worker URL — routing stays at 0% until this is set,
+   per [`apps/web/README.md`'s routing section](../web/README.md#collaboration-runtime-routing).
+
+## Rollback
+
+To revert a bad deploy of the Worker itself (independent of the routing
+decision — see below): `wrangler rollback` reverts to the previously active
+version; `wrangler versions list` first if you need to roll back to a
+specific, older version by id (`wrangler rollback <VERSION_ID>`). Because no
+deployment has ever been exercised, this procedure is documented but
+unverified — confirm it works during the first real Stage 2 deployment
+rather than assuming it does.
+
+This is a different lever from **routing rollback** (moving documents back
+to Nitro without touching what's deployed here) — see
+[`apps/web/README.md`'s routing section](../web/README.md#collaboration-runtime-routing)
+and
+[`docs/design/collaboration-operations.md`](../../docs/design/collaboration-operations.md#rollback-procedure)
+for that procedure and how the two levels relate.
 
 ## Verification
 

--- a/apps/collab/README.md
+++ b/apps/collab/README.md
@@ -4,11 +4,15 @@ Nitro WebSocket service that authenticates document sessions, persists
 EG-walker event batches to Supabase Postgres, fans committed batches out to
 document peers across instances, and hosts ephemeral awareness rooms.
 
-This replaces Liveblocks for durable document collaboration. The browser host
-(`apps/web`) connects with a Supabase access token over same-origin
-`/collab/*` URLs; this service is the only writer of `document_event_batches`.
+This is the default Nitro host for durable document collaboration. For
+Nitro-routed documents, the browser host (`apps/web`) connects with a Supabase
+credential over same-origin `/collab/*` URLs. Both this service and
+`apps/collab-cloudflare` can write `document_event_batches`; browser clients
+cannot.
 
 ## Role in the stack
+
+The default Nitro path is:
 
 ```text
 Browser ──wss──► /collab/document|presence
@@ -36,7 +40,7 @@ remain outside this service.
 | Rich-text batches / CRDT model | `@softmaple/block-model` / `@softmaple/eg-walker` |
 | Lexical projection | `@softmaple/binding-lexical` + `apps/web` |
 | Presence protocol / client state | `@softmaple/awareness` |
-| Auth, durable-store and Redis adapters; presence rooms | **this service** |
+| Nitro auth, durable-store, and Redis adapters; Nitro presence rooms | **this service** |
 
 ## Storage roles
 
@@ -58,10 +62,12 @@ recovered through Postgres + the existing repair/resync protocol.
 | `/collab/document` | WebSocket | Authenticated collaboration session |
 | `/collab/presence` | WebSocket | Authenticated, ephemeral awareness session |
 
-The browser always connects to the app origin at `/collab/document` and
-`/collab/presence`. In production, Vercel Services routes `/collab/**` to this
-app. Local Playwright uses `apps/web/scripts/e2e-collab-router.mjs` because
-stock `next dev` does not forward WebSocket upgrades.
+For Nitro-routed documents, the browser connects to the app origin at
+`/collab/document` and `/collab/presence`; in production, Vercel Services routes
+`/collab/**` to this app. Cloudflare-routed documents connect directly to the
+configured Worker URL. Local Playwright uses
+`apps/web/scripts/e2e-collab-router.mjs` because stock `next dev` does not
+forward WebSocket upgrades.
 
 Upgrades require a browser `Origin` listed in `COLLAB_ALLOWED_ORIGINS` (or a
 Vercel preview/production host derived from `VERCEL_*` / `NEXT_PUBLIC_APP_URL`).
@@ -80,7 +86,7 @@ membership (and public-document rules) inside each session.
 6. Client sends `event` messages with one or more `RichTextEventBatch` values
    (max 64 per message). Writers only: `OWNER` / `EDITOR`.
 7. Server appends batches transactionally, returns `durable-ack`, then
-   publishes a realtime notification through Redis Pub/Sub so every collab
+   publishes a realtime notification through Redis Pub/Sub so every Nitro
    instance can deliver to its local peers.
 8. Authorization and lease refresh run about every 15s while the socket is open.
    Messages are rate-limited (120 / 10s window per peer).
@@ -101,9 +107,12 @@ TTL.
 
 Multiple Nitro / Vercel Function instances are supported. Configure Upstash
 Redis (Vercel Marketplace) and set `REDIS_URL` (native `redis://` / `rediss://`
-URL for ioredis). Production and Preview deployments on Vercel **require** Redis
-and fail fast if it is missing. They never silently fall back to process-local
-coordination.
+URL for ioredis). Production and Preview deployments on Vercel select Redis and
+never silently fall back to process-local coordination. `REDIS_URL` validation
+is currently lazy: missing configuration fails the first document or presence
+operation that initializes realtime, not the build, startup, or `/health`
+liveness check. Deployment readiness must therefore verify the variable and a
+real collaboration WebSocket handshake.
 
 ## Persistence
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,11 +1,14 @@
 # `@softmaple/web`
 
 Next.js 16 app router host for Softmaple: auth, workspaces, document UI, and
-the Lexical editor. Real-time collaboration goes over same-origin WebSocket
-paths to [`apps/collab`](../collab/README.md); this app does not write
-`document_event_batches` itself and does not proxy WebSocket upgrades.
+the Lexical editor. By default, realtime collaboration uses same-origin
+WebSocket paths routed to [`apps/collab`](../collab/README.md);
+Cloudflare-selected documents connect directly to the configured Worker. This
+app does not write `document_event_batches` or proxy WebSocket upgrades.
 
 ## Role in the stack
+
+The default Nitro path is:
 
 ```text
 Browser ──► apps/web (Next.js)
@@ -20,7 +23,7 @@ Browser ──► apps/web (Next.js)
 | Lexical UI + editor shell | `@softmaple/editor` + `modules/docs` |
 | Lexical ↔ EG-walker binding | `@softmaple/binding-lexical` |
 | Collab wire protocol | `@softmaple/collab-protocol` |
-| Durable event store / Redis fan-out | [`apps/collab`](../collab/README.md) |
+| Durable event persistence / realtime fan-out | [`apps/collab`](../collab/README.md) (Prisma + Redis) or [`apps/collab-cloudflare`](../collab-cloudflare/README.md) (Supabase RPC + DO-local fan-out) |
 | Schema, RLS, Prisma | [`packages/db`](../../packages/db) |
 
 Layer boundaries:
@@ -69,8 +72,9 @@ plus bearer secret are present. Never enable it against production.
 
 ### WebSocket routing
 
-Production routing is owned by the root [`vercel.json`](../../vercel.json)
-Services configuration:
+Same-origin Nitro WebSocket routing is owned by the root
+[`vercel.json`](../../vercel.json) Services configuration. Cloudflare-selected
+documents bypass this mapping and use the configured Worker URL directly:
 
 ```text
 /collab/** → apps/collab
@@ -98,9 +102,10 @@ Keys and URL must belong to the **same** Supabase project. Never put a
 [`modules/docs/collab-runtime-routing.ts`](./modules/docs/collab-runtime-routing.ts)
 picks, per document and on the server before the page renders, whether the
 browser connects to the existing Nitro+Redis runtime (`apps/collab`) or the
-Cloudflare Durable Objects runtime (`apps/collab-cloudflare`). Both runtimes
-read and write the same Supabase tables, so switching a document back and
-forth is reversible with no document-history migration.
+Cloudflare Durable Objects runtime (`apps/collab-cloudflare`). Both document
+runtimes read and write the same Supabase event-history tables, so switching a
+document back and forth needs no document-history migration. Live presence is
+runtime-local and is recreated when the client joins the destination runtime.
 
 | Variable | Effect |
 | --- | --- |
@@ -117,37 +122,34 @@ any newly-rendered page load.
 
 That guarantee applies at page-render time only, not to WebSockets a
 browser already has open. `collabRuntime` is resolved once server-side and
-baked into the live session (`useDocumentSession`); it does not re-resolve
-until the tab reconnects or reloads. So a config change (percent/override/
-allow-deny list) does not move already-connected tabs — they keep talking
-to whichever runtime they opened against, and won't pick up the new
-decision until their next reconnect or a full page reload. **Two tabs open
-on the same document across a config change will therefore be on
-different runtimes for as long as the older tab stays open and
-unreloaded** — potentially indefinitely, not just for a moment — with no
-cross-talk between them until Supabase's durable event log reconciles on
-reconnect/repair.
+baked into the live session (`useDocumentSession`). Automatic reconnect
+reuses that value; only a newly rendered page (normally a reload or fresh
+tab) can pick up changed routing config. Existing tabs therefore remain on
+their original runtime until re-rendered. **Two tabs open on the same
+document across a config change can be on different runtimes for as long
+as the older page remains open** — potentially indefinitely. They receive
+no live cross-runtime fan-out or shared presence. A reconnect can repair
+durable history from shared Postgres but remains on the same runtime; only
+a reload or fresh render transfers runtime ownership.
 
-Because of this, treat any rollout config change that could move a
-document already being edited (percent/override changes; adding/removing
-an id from the allow/deny lists) as requiring a **coordinated reload**:
-confirm no session is actively open on the affected document(s) before
-changing config, or explicitly ask connected users to refresh afterward.
-The automatic reconnect in `use-document-session.ts` does not help here —
-on drop it reopens against the same `collabRuntime` the session already
-committed to, it never re-derives the decision, so a reload (or a fresh
-tab) is the only way an existing session picks up a new routing outcome.
-Before shipping a config change, test both a tab that connected **before**
-the change (confirm it keeps working, unmigrated, until it reloads) and a
-tab that connects **after** (confirm it gets the new decision) against the
-same document.
+Because one document must not have concurrent runtime owners, treat that
+split as a **correctness and dual-write incident**, not only a stale-tab UX
+issue. Stop rollout expansion, identify affected document ids, and drain or
+coordinate a reload of every old-runtime tab before declaring the handoff
+complete; automatic reconnect is not sufficient. Prefer changing routing
+only while no affected editor is connected. Before resuming, verify old
+connections are gone, reloaded clients joined document and presence rooms
+on the selected runtime, and durable repair completed. Test both a page
+rendered before and one rendered after the change against the same
+document.
 
 Rolling back is changing `COLLAB_RUNTIME_OVERRIDE`/`COLLAB_CLOUDFLARE_ROLLOUT_PERCENT`
 back to their safe defaults (or clearing `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL`
 entirely) and redeploying — no data migration is involved, but per above,
-existing open tabs won't observe the rollback until they reconnect or
-reload either. Deploying `apps/collab-cloudflare` itself (secrets,
-`wrangler deploy`, DNS) is a separate operational step; see
+existing open tabs observe the rollback only after a reload or fresh server
+render; automatic reconnect keeps their original runtime. Deploying
+`apps/collab-cloudflare` itself (secrets, `wrangler deploy`, DNS) is a separate
+operational step; see
 [`apps/collab-cloudflare/README.md`](../collab-cloudflare/README.md).
 
 For the cross-runtime picture — when to deploy which runtime, Supabase/

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -150,6 +150,10 @@ reload either. Deploying `apps/collab-cloudflare` itself (secrets,
 `wrangler deploy`, DNS) is a separate operational step; see
 [`apps/collab-cloudflare/README.md`](../collab-cloudflare/README.md).
 
+For the cross-runtime picture — when to deploy which runtime, Supabase/
+Redis/DO responsibilities, and the current default-runtime decision — see
+[`docs/design/collaboration-operations.md`](../../docs/design/collaboration-operations.md).
+
 ## Commands
 
 ```bash

--- a/docs/design/collaboration-operations.md
+++ b/docs/design/collaboration-operations.md
@@ -113,8 +113,14 @@ Two distinct levels — know which one you need before acting:
    [`apps/web/README.md`'s routing section](../../apps/web/README.md#collaboration-runtime-routing):
    reset `COLLAB_RUNTIME_OVERRIDE`/`COLLAB_CLOUDFLARE_ROLLOUT_PERCENT` to
    their safe defaults, or clear `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL`
-   entirely, and redeploy `apps/web`. **Already-open browser tabs don't
-   observe this until they reconnect or reload** — read that section's
+   entirely, and redeploy `apps/web`. **Resetting the override/percent
+   alone does not move documents on `COLLAB_CLOUDFLARE_DOCUMENT_ALLOWLIST`
+   — the allowlist takes precedence over the override.** To stop *all*
+   Cloudflare traffic, either clear the allowlist (or move the affected
+   ids to `COLLAB_CLOUDFLARE_DOCUMENT_DENYLIST`) or clear
+   `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` entirely, which wins regardless
+   of every other variable. **Already-open browser tabs don't observe any
+   of this until they reconnect or reload** — read that section's
    coordinated-reload guidance before changing rollout config on a
    document with active editors.
 2. **Runtime deploy rollback** — reverting what's actually running for a

--- a/docs/design/collaboration-operations.md
+++ b/docs/design/collaboration-operations.md
@@ -1,0 +1,197 @@
+---
+title: Collaboration Runtime Operations
+description: When to deploy Nitro vs. Durable Objects, environment/storage responsibilities, rollback procedures, and the current default-runtime decision.
+---
+
+# Collaboration Runtime Operations
+
+This is the cross-runtime operational summary for the collaboration
+backend: `apps/collab` (Nitro + Redis + Supabase Postgres, the current
+production default) and `apps/collab-cloudflare` (Cloudflare Durable
+Objects + Supabase Postgres). Where a per-app doc already owns a detail,
+this page links to it rather than duplicating it — see
+[`apps/collab/README.md`](../../apps/collab/README.md) and
+[`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md)
+for the full per-runtime picture, and
+[`collaboration-runtime.md`](./collaboration-runtime.md) for the
+runtime-independent semantic contract both hosts implement.
+
+## When to deploy which runtime
+
+**Nitro is the always-on production default.** Every document resolves to
+it unless explicit routing config says otherwise — see
+[`apps/web/README.md`'s "Collaboration runtime routing"](../../apps/web/README.md#collaboration-runtime-routing)
+for the mechanism (`resolveCollabRuntime`, a pure function of
+`(documentId, config)` evaluated server-side per page render).
+
+**Cloudflare is test-only today.** It has never been deployed to a
+reachable endpoint — no CD pipeline, no `routes`/custom domain in
+`wrangler.jsonc`, only a manual `wrangler deploy` script (see "Production
+deployment" in
+[`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md)).
+Routing's own fail-safe already accounts for this:
+`NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` is unset by default, so the routing
+decision resolves to Nitro for every document regardless of the other
+rollout variables until someone actually deploys the Worker and sets that
+URL.
+
+The current stage against the issue's own staged-rollout plan:
+
+| Stage | Description | Status |
+| --- | --- | --- |
+| 1 | Nitro = production, DO = test only | **Current stage.** DO is exercised by `packages/collab-runtime`'s unit suite, both apps' own test suites, and the shared conformance suite below — never by real traffic. |
+| 2 | DO = preview/internal environments | Not started — requires deploying the Worker to a reachable environment first. |
+| 3-5 | Small → expanded → full production cohort | Not applicable yet. |
+
+## Environment configuration
+
+Each app owns its own authoritative env-var table; this is a compact
+summary, not a replacement for either:
+
+| | Nitro (`apps/collab`) | Cloudflare (`apps/collab-cloudflare`) |
+| --- | --- | --- |
+| Durable store connection | `DATABASE_URL` (direct Prisma/Postgres) | `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (Supabase RPC) |
+| Auth project | `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY` | `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY` |
+| Allowed browser origins | `COLLAB_ALLOWED_ORIGINS` | `COLLAB_ALLOWED_ORIGINS` |
+| Realtime fan-out | `COLLAB_REALTIME_DRIVER` (+ `REDIS_URL` on Vercel) | none — DO-local, no external config |
+
+Full tables: [`apps/collab/README.md#environment`](../../apps/collab/README.md#environment),
+[`apps/collab-cloudflare/README.md#environment`](../../apps/collab-cloudflare/README.md#environment).
+
+**The one genuine vendor asymmetry**: Cloudflare's adapter needs
+`SUPABASE_SERVICE_ROLE_KEY` — an elevated, server-only credential —
+because it reaches Supabase over RPC calls from the Worker. Nitro instead
+holds a direct `DATABASE_URL` Prisma connection to the same Postgres
+database and never touches that key at all. Neither is more or less
+secure by design, but they are not interchangeable: don't assume a value
+set for one runtime satisfies the other's requirement.
+
+## Storage responsibilities
+
+### Supabase (shared by both runtimes)
+
+Durable event history (`document_event_batches`, `document_event_ids`)
+and the presence backing store live in the same Supabase/Postgres
+database for both runtimes — this is *why* the routing decision needs no
+data migration when it moves a document between them (see
+[`apps/collab/README.md#persistence`](../../apps/collab/README.md#persistence)
+and [`packages/db/supabase/README.md`](../../packages/db/supabase/README.md)
+for the schema and Data-API access rules). The shared
+`documentEventStoreConformance` suite
+(`packages/collab-runtime/src/testing/capability-conformance.ts`) is the
+direct evidence that both adapters — Nitro's
+`prismaDocumentEventStore` and Cloudflare's
+`createSupabaseDocumentBackend(env).events` — honor the same append/read
+contract against this shared store.
+
+### Redis (Nitro only)
+
+Distributed realtime pub/sub, presence TTLs, and connection leases —
+never the durable store. A missed realtime message recovers through
+Postgres plus the existing repair/resync protocol, not through Redis
+persistence. See
+[`apps/collab/README.md#storage-roles`](../../apps/collab/README.md#storage-roles).
+Production and Preview Vercel deployments require Redis and fail fast if
+it's missing; they never silently fall back to process-local
+coordination.
+
+### Durable Objects (Cloudflare only)
+
+`DocumentRoomDO`/`PresenceRoomDO` own only live peer coordination,
+fan-out, and connection limits inside one object — no Redis dependency,
+and Durable Object SQLite storage is **not** used as event history (that
+role stays with Supabase Postgres, above). See
+[`apps/collab-cloudflare/README.md#runtime-shape`](../../apps/collab-cloudflare/README.md#runtime-shape).
+
+## Rollback procedure
+
+Two distinct levels — know which one you need before acting:
+
+1. **Routing rollback** — moving documents back to Nitro without touching
+   what's deployed. This is the lever for "stop sending traffic to
+   Cloudflare" once it's live. Fully documented in
+   [`apps/web/README.md`'s routing section](../../apps/web/README.md#collaboration-runtime-routing):
+   reset `COLLAB_RUNTIME_OVERRIDE`/`COLLAB_CLOUDFLARE_ROLLOUT_PERCENT` to
+   their safe defaults, or clear `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL`
+   entirely, and redeploy `apps/web`. **Already-open browser tabs don't
+   observe this until they reconnect or reload** — read that section's
+   coordinated-reload guidance before changing rollout config on a
+   document with active editors.
+2. **Runtime deploy rollback** — reverting what's actually running for a
+   given service, independent of routing. For Nitro, this is a normal
+   Vercel deployment rollback. For Cloudflare, see "Rollback" in
+   [`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md) —
+   this has never been exercised against a real deployment, since none
+   exists yet.
+
+## Correctness gates and rollback triggers
+
+The issue's own gate list, and what's actually detectable today given
+what's shipped so far:
+
+| Gate | Detectable today? |
+| --- | --- |
+| `EventConflictError` rate by conflict type | **Yes.** `services.metrics` on both `DocumentRoomServices` implementations emits a typed `event-conflict` event (with `conflictType`) through the shared `report()` fan-in in `packages/collab-runtime/src/document-room-implementation.ts` — see both apps' `logDocumentMetric`/`logMetric` wiring. |
+| Runtime errors / authorization failures | **Yes**, same mechanism — `event-error` / `message-error` events. |
+| Append/durable-ack latency | **Yes.** `event-appended`/`event-acknowledged` events bracket `DocumentEventStore.append` and the `DurableAck` send. |
+| Convergence failures, unexplained durable-history conflicts, missing committed events, incorrect durable acks | Partially — the conformance suite (`documentEventStoreConformance`) proves both adapters satisfy the same contract in isolation, and `packages/collab-runtime/test/document-room.test.ts`'s ~40 state-machine cases cover the shared append→ack→fan-out ordering. Neither is a live production signal; both are pre-merge gates. |
+| Authorization isolation failures, document cross-talk | Only through the shared `DocumentRoom` contract's own invariants (document-scoped fan-out, no cross-document delivery) plus manual log inspection — **no automated cross-talk metric exists.** |
+| Repair loops, reconnect data loss | **No automatic signal today.** Neither transport host reads the WebSocket close code/reason yet — Nitro's crossws `close` hook and Cloudflare's `webSocketClose` handler both discard it (a known limitation below), so reconnect-rate and abnormal-close-rate metrics don't exist. Watching this currently means reading raw logs, not alerting on a metric. |
+
+Given the last two rows, treat any expansion past Stage 1 as requiring
+manual log review during the exercised window, not just a metrics
+dashboard — the automated signal is real but partial.
+
+## Known limitations and vendor-specific behavior
+
+- `apps/collab-cloudflare` has no CD pipeline and has never served
+  production traffic — see "Production deployment" in its README.
+- No reconnect-rate or abnormal-WebSocket-close-rate metrics yet; this
+  needs new plumbing (reading the close code/reason from crossws and from
+  Cloudflare's hibernatable `webSocketClose` handler), not just a new
+  metric call — deferred deliberately rather than rushed.
+- No active-rooms/active-connections gauges or Durable Object
+  wake/hibernation counters — these need a periodic gauge or per-instance
+  registry, a different shape of instrumentation than the event-driven
+  metrics shipped so far.
+- No Postgres/Supabase query/transaction latency instrumentation inside
+  either adapter (`prisma-document-event-store.ts`,
+  `supabase-backend.ts`) — independent of the shared room code, and not
+  yet built.
+- The shared conformance suite covers `DocumentEventStore` only.
+  `RoomFanout` is deliberately not covered: Nitro's cross-instance Redis
+  pub/sub and Cloudflare's single-instance DO-local fanout are
+  architecturally different enough that forcing identical black-box
+  conformance isn't the right test shape.
+- Routing decisions don't propagate to already-open browser tabs — see
+  the rollback section above.
+- Cloudflare-specific: `DocumentRoomDO` revalidates every attached
+  socket's access against Supabase on constructor wake, up to the
+  100-connection room policy. This is a real per-wake cost budget; see
+  "Runtime shape" in
+  [`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md)
+  for the Workers-plan subrequest-budget implication before lowering (or
+  raising) that policy.
+
+## Current decision
+
+**Not yet promotable to default. Stage 1 only.** Cloudflare has no
+production traffic and no deployment, so there is no data to base a
+promotion decision on — recording an optimistic verdict without evidence
+would be worse than recording none. What's needed to revisit this
+decision, in order:
+
+1. Deploy `apps/collab-cloudflare` to a reachable environment (see its
+   README's "Production deployment" section for the current, manual
+   process).
+2. Exercise Stage 2 (preview/internal traffic) and confirm the shared
+   conformance suite and both apps' test suites stay green against that
+   deployment.
+3. Collect the append/ack-latency and conflict/error-rate metrics this
+   phase's instrumentation now makes possible, for a real traffic window,
+   and compare them against Nitro's.
+4. Close enough of the reconnect/close-code gap (above) to watch the
+   remaining correctness gates before expanding past a small cohort.
+
+Until then, this document's own existence is the operational readiness
+work for Stage 2 — not evidence that Stage 2 has happened.

--- a/docs/design/collaboration-operations.md
+++ b/docs/design/collaboration-operations.md
@@ -5,199 +5,219 @@ description: When to deploy Nitro vs. Durable Objects, environment/storage respo
 
 # Collaboration Runtime Operations
 
-This is the cross-runtime operational summary for the collaboration
-backend: `apps/collab` (Nitro + Redis + Supabase Postgres, the current
-production default) and `apps/collab-cloudflare` (Cloudflare Durable
-Objects + Supabase Postgres). Where a per-app doc already owns a detail,
-this page links to it rather than duplicating it — see
-[`apps/collab/README.md`](../../apps/collab/README.md) and
-[`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md)
-for the full per-runtime picture, and
-[`collaboration-runtime.md`](./collaboration-runtime.md) for the
-runtime-independent semantic contract both hosts implement.
+This is the cross-runtime operational summary for the collaboration backend:
+`apps/collab` (Nitro + Redis + Supabase Postgres, the repository-configured
+default) and `apps/collab-cloudflare` (Cloudflare Durable Objects + Supabase
+Postgres). See the repository docs for the full per-runtime picture:
+[`apps/collab/README.md`](https://github.com/softmaple/softmaple/blob/next/apps/collab/README.md),
+[`apps/collab-cloudflare/README.md`](https://github.com/softmaple/softmaple/blob/next/apps/collab-cloudflare/README.md),
+and the runtime-independent
+[`collaboration-runtime.md`](./collaboration-runtime.md) contract.
 
 ## When to deploy which runtime
 
-**Nitro is the always-on production default.** Every document resolves to
-it unless explicit routing config says otherwise — see
-[`apps/web/README.md`'s "Collaboration runtime routing"](../../apps/web/README.md#collaboration-runtime-routing)
-for the mechanism (`resolveCollabRuntime`, a pure function of
-`(documentId, config)` evaluated server-side per page render).
+**Nitro is the repository-configured routing default.** Every document resolves
+to it unless explicit routing config says otherwise. See
+[`apps/web/README.md`'s "Collaboration runtime routing"](https://github.com/softmaple/softmaple/blob/next/apps/web/README.md#collaboration-runtime-routing)
+for the mechanism: the server-side `resolveCollabRuntime(documentId)` wrapper
+reads environment config for each page render, then calls the pure
+`decideCollabRuntime(documentId, config)` decision function.
 
-**Cloudflare is test-only today.** It has never been deployed to a
-reachable endpoint — no CD pipeline, no `routes`/custom domain in
-`wrangler.jsonc`, only a manual `wrangler deploy` script (see "Production
-deployment" in
-[`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md)).
-Routing's own fail-safe already accounts for this:
-`NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` is unset by default, so the routing
-decision resolves to Nitro for every document regardless of the other
-rollout variables until someone actually deploys the Worker and sets that
-URL.
+**The repository is configured for Cloudflare test-only use.** It contains no
+Cloudflare deployment workflow, and `wrangler.jsonc` declares no route or
+custom domain. `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` is unset by default, so
+the web routing fail-safe keeps every document on Nitro. Repository state
+cannot prove what has been deployed manually or configured in the Cloudflare
+dashboard; verify the target account before relying on this stage description.
 
-The current stage against the issue's own staged-rollout plan:
-
-| Stage | Description | Status |
+| Stage | Description | Repository status |
 | --- | --- | --- |
-| 1 | Nitro = production, DO = test only | **Current stage.** DO is exercised by `packages/collab-runtime`'s unit suite, both apps' own test suites, and the shared conformance suite below — never by real traffic. |
-| 2 | DO = preview/internal environments | Not started — requires deploying the Worker to a reachable environment first. |
-| 3-5 | Small → expanded → full production cohort | Not applicable yet. |
+| 1 | Nitro = routing default, DO = test only | **Configured stage.** Local unit, app, and mocked adapter-conformance suites exercise the DO implementation; they do not prove a deployed Worker or production Supabase path. |
+| 2 | DO = preview/internal environments | Not configured. It requires a reachable Worker, a deployed integration smoke test, and operational signals described below. |
+| 3-5 | Small → expanded → full production cohort | Not ready. |
 
 ## Environment configuration
 
-Each app owns its own authoritative env-var table; this is a compact
-summary, not a replacement for either:
+Each app owns its authoritative environment-variable table; this is a compact
+summary:
 
 | | Nitro (`apps/collab`) | Cloudflare (`apps/collab-cloudflare`) |
 | --- | --- | --- |
-| Durable store connection | `DATABASE_URL` (direct Prisma/Postgres) | `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (Supabase RPC) |
-| Auth project | `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY` | `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY` |
+| Durable event store | `DATABASE_URL` (direct Prisma/Postgres) | `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (Supabase RPC) |
+| Auth claims | `SUPABASE_URL` + publishable key | `SUPABASE_URL` + publishable key through Supabase Auth |
+| Membership/profile lookups | `DATABASE_URL` (direct Prisma/Postgres) | `SUPABASE_URL` + service-role key through the Data API |
 | Allowed browser origins | `COLLAB_ALLOWED_ORIGINS` | `COLLAB_ALLOWED_ORIGINS` |
-| Realtime fan-out | `COLLAB_REALTIME_DRIVER` (+ `REDIS_URL` on Vercel) | none — DO-local, no external config |
+| Live fan-out and presence | `COLLAB_REALTIME_DRIVER` (+ `REDIS_URL` on Vercel) | Durable Object-local; no Redis configuration |
 
-Full tables: [`apps/collab/README.md#environment`](../../apps/collab/README.md#environment),
-[`apps/collab-cloudflare/README.md#environment`](../../apps/collab-cloudflare/README.md#environment).
+Full tables:
+[`apps/collab/README.md#environment`](https://github.com/softmaple/softmaple/blob/next/apps/collab/README.md#environment)
+and
+[`apps/collab-cloudflare/README.md#environment`](https://github.com/softmaple/softmaple/blob/next/apps/collab-cloudflare/README.md#environment).
 
-**The one genuine vendor asymmetry**: Cloudflare's adapter needs
-`SUPABASE_SERVICE_ROLE_KEY` — an elevated, server-only credential —
-because it reaches Supabase over RPC calls from the Worker. Nitro instead
-holds a direct `DATABASE_URL` Prisma connection to the same Postgres
-database and never touches that key at all. Neither is more or less
-secure by design, but they are not interchangeable: don't assume a value
-set for one runtime satisfies the other's requirement.
+Cloudflare needs `SUPABASE_SERVICE_ROLE_KEY`, an elevated server-only
+credential. Durable event persistence uses the two event RPCs; authorization
+and presence session hooks also use Supabase Auth and Data API queries for
+documents, workspace memberships, and user profiles. Nitro instead holds a
+direct Prisma connection to the same Postgres database and does not use the
+service-role key. Verify all three Cloudflare access surfaces in the target
+Supabase project; do not assume successful RPC access proves Auth or table
+access.
 
 ## Storage responsibilities
 
-### Supabase (shared by both runtimes)
+### Supabase Postgres (durable event history shared by both runtimes)
 
-Durable event history (`document_event_batches`, `document_event_ids`)
-and the presence backing store live in the same Supabase/Postgres
-database for both runtimes — this is *why* the routing decision needs no
-data migration when it moves a document between them (see
-[`apps/collab/README.md#persistence`](../../apps/collab/README.md#persistence)
-and [`packages/db/supabase/README.md`](../../packages/db/supabase/README.md)
-for the schema and Data-API access rules). The shared
-`documentEventStoreConformance` suite
-(`packages/collab-runtime/src/testing/capability-conformance.ts`) is the
-direct evidence that both adapters — Nitro's
-`prismaDocumentEventStore` and Cloudflare's
-`createSupabaseDocumentBackend(env).events` — honor the same append/read
-contract against this shared store.
+Both document runtimes append and read the same durable event-history tables:
+`document_event_batches` and `document_event_ids`. Moving a document between
+runtimes therefore needs no **event-history** migration. Browser clients do not
+write those tables. See
+[`apps/collab/README.md#persistence`](https://github.com/softmaple/softmaple/blob/next/apps/collab/README.md#persistence)
+and
+[`packages/db/supabase/README.md`](https://github.com/softmaple/softmaple/blob/next/packages/db/supabase/README.md)
+for the schema and access rules.
+
+Presence is not part of this shared durable store. Nitro stores live presence
+membership in Redis (or process memory in local development), while
+Cloudflare stores it in `PresenceRoomDO`'s `ctx.storage`. A runtime handoff does
+not migrate live members: after a reload or fresh page render, clients
+authenticate and join the destination runtime's presence room again. Expect a
+temporary leave/rejoin boundary, and never use presence as durable application
+state.
+
+The `documentEventStoreConformance` suites prove that each adapter maps the
+shared append/read contract correctly against a test double. Nitro injects a
+mock Prisma client; Cloudflare stubs `fetch` over an in-memory reference store.
+They do **not** reach production Postgres, the real Supabase RPC functions, or a
+deployed Worker. A Stage 2 gate must add and run a deployed integration smoke
+test against the target Supabase project.
 
 ### Redis (Nitro only)
 
-Distributed realtime pub/sub, presence TTLs, and connection leases —
-never the durable store. A missed realtime message recovers through
-Postgres plus the existing repair/resync protocol, not through Redis
-persistence. See
-[`apps/collab/README.md#storage-roles`](../../apps/collab/README.md#storage-roles).
-Production and Preview Vercel deployments require Redis and fail fast if
-it's missing; they never silently fall back to process-local
-coordination.
+Redis owns distributed realtime pub/sub, presence TTLs, and connection leases,
+never durable event history. Missed realtime messages recover through Postgres
+and the repair/resync protocol. See
+[`apps/collab/README.md#storage-roles`](https://github.com/softmaple/softmaple/blob/next/apps/collab/README.md#storage-roles).
+
+Production and Preview Vercel deployments select Redis and never fall back to
+process-local coordination. However, `REDIS_URL` validation is lazy: a missing
+URL can pass build, startup, and the current `/health` liveness endpoint, then
+fail when the first document or presence operation initializes realtime.
+Deployment verification must check the variable and exercise a real WebSocket
+handshake; `/health` alone is not a Redis-readiness check.
 
 ### Durable Objects (Cloudflare only)
 
-`DocumentRoomDO`/`PresenceRoomDO` own only live peer coordination,
-fan-out, and connection limits inside one object — no Redis dependency,
-and Durable Object SQLite storage is **not** used as event history (that
-role stays with Supabase Postgres, above). See
-[`apps/collab-cloudflare/README.md#runtime-shape`](../../apps/collab-cloudflare/README.md#runtime-shape).
+`DocumentRoomDO` owns live document coordination, fan-out, and connection
+limits. `PresenceRoomDO` separately owns live presence coordination and stores
+presence membership in Durable Object storage so it survives hibernation.
+Neither object uses its storage as durable document-event history; that role
+stays with Supabase Postgres. See
+[`apps/collab-cloudflare/README.md#runtime-shape`](https://github.com/softmaple/softmaple/blob/next/apps/collab-cloudflare/README.md#runtime-shape)
+and its Presence room section.
 
 ## Rollback procedure
 
-Two distinct levels — know which one you need before acting:
+There are two separate rollback levers:
 
-1. **Routing rollback** — moving documents back to Nitro without touching
-   what's deployed. This is the lever for "stop sending traffic to
-   Cloudflare" once it's live. Fully documented in
-   [`apps/web/README.md`'s routing section](../../apps/web/README.md#collaboration-runtime-routing):
-   reset `COLLAB_RUNTIME_OVERRIDE`/`COLLAB_CLOUDFLARE_ROLLOUT_PERCENT` to
-   their safe defaults, or clear `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL`
-   entirely, and redeploy `apps/web`. **Resetting the override/percent
-   alone does not move documents on `COLLAB_CLOUDFLARE_DOCUMENT_ALLOWLIST`
-   — the allowlist takes precedence over the override.** To stop *all*
-   Cloudflare traffic, either clear the allowlist (or move the affected
-   ids to `COLLAB_CLOUDFLARE_DOCUMENT_DENYLIST`) or clear
-   `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL` entirely, which wins regardless
-   of every other variable. **Already-open browser tabs don't observe any
-   of this until they reconnect or reload** — read that section's
-   coordinated-reload guidance before changing rollout config on a
-   document with active editors.
-2. **Runtime deploy rollback** — reverting what's actually running for a
-   given service, independent of routing. For Nitro, this is a normal
-   Vercel deployment rollback. For Cloudflare, see "Rollback" in
-   [`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md) —
-   this has never been exercised against a real deployment, since none
-   exists yet.
+1. **Routing rollback** stops new page renders from selecting Cloudflare.
+   Reset `COLLAB_RUNTIME_OVERRIDE` and
+   `COLLAB_CLOUDFLARE_ROLLOUT_PERCENT`, or clear
+   `NEXT_PUBLIC_COLLAB_CLOUDFLARE_WS_URL`, then rebuild and redeploy
+   `apps/web`. Resetting only the override or percentage does not move ids on
+   `COLLAB_CLOUDFLARE_DOCUMENT_ALLOWLIST`; clear that list, deny the affected
+   ids, or clear the Worker URL to stop all new Cloudflare selections. See the
+   [web routing procedure](https://github.com/softmaple/softmaple/blob/next/apps/web/README.md#collaboration-runtime-routing).
+2. **Runtime deploy rollback** reverts the service code independently of web
+   routing. Nitro uses the normal Vercel rollback. Cloudflare uses the
+   [Worker rollback procedure](https://github.com/softmaple/softmaple/blob/next/apps/collab-cloudflare/README.md#rollback),
+   subject to Durable Object migration and binding restrictions.
+
+An automatic WebSocket reconnect does **not** re-run routing. The rendered
+page keeps its original `collabRuntime`, and reconnect opens the same runtime
+again. Only a reload or fresh page render can pick up changed routing config.
+
+This makes tabs split across two runtimes a correctness incident, not only a
+UX issue. The two runtimes share durable event history but have no live
+cross-runtime fan-out, shared connection ownership, or shared presence. A
+config change can therefore leave old and new tabs concurrently writing the
+same document through different owners until every old page is re-rendered.
+Shared Postgres repair can reconcile durable history later; it does not make
+concurrent ownership safe.
+
+For any routing change that can affect active documents:
+
+1. Stop rollout expansion and identify the affected document ids.
+2. Prefer changing config while no affected editor is connected. Otherwise,
+   coordinate a reload or close of every old tab; automatic reconnect is not
+   sufficient.
+3. Treat the handoff as incomplete until old-runtime connections are gone and
+   reloaded clients have rejoined document and presence rooms on the selected
+   runtime.
+4. If split ownership is observed, keep the rollout stopped, drain/reload the
+   old tabs, and verify durable repair before resuming.
 
 ## Correctness gates and rollback triggers
 
-The issue's own gate list, and what's actually detectable today given
-what's shipped so far:
+Both hosts currently write structured collaboration events only to their
+console logs, and the log envelopes differ. There is no metrics backend,
+retention guarantee, dashboard, alert, or percentile aggregation in this
+repository. The events are queryable only if the hosting platform retains the
+logs and an operator supplies runtime-specific queries.
 
-| Gate | Detectable today? |
-| --- | --- |
-| `EventConflictError` rate by conflict type | **Yes.** `services.metrics` on both `DocumentRoomServices` implementations emits a typed `event-conflict` event (with `conflictType`) through the shared `report()` fan-in in `packages/collab-runtime/src/document-room-implementation.ts` — see both apps' `logDocumentMetric`/`logMetric` wiring. |
-| Runtime errors / authorization failures | **Yes**, same mechanism — `event-error` / `message-error` events. |
-| Append/durable-ack latency | **Yes.** `event-appended`/`event-acknowledged` events bracket `DocumentEventStore.append` and the `DurableAck` send. |
-| Convergence failures, unexplained durable-history conflicts, missing committed events, incorrect durable acks | Partially — the conformance suite (`documentEventStoreConformance`) proves both adapters satisfy the same contract in isolation, and `packages/collab-runtime/test/document-room.test.ts`'s ~40 state-machine cases cover the shared append→ack→fan-out ordering. Neither is a live production signal; both are pre-merge gates. |
-| Authorization isolation failures, document cross-talk | Only through the shared `DocumentRoom` contract's own invariants (document-scoped fan-out, no cross-document delivery) plus manual log inspection — **no automated cross-talk metric exists.** |
-| Repair loops, reconnect data loss | **No automatic signal today.** Neither transport host reads the WebSocket close code/reason yet — Nitro's crossws `close` hook and Cloudflare's `webSocketClose` handler both discard it (a known limitation below), so reconnect-rate and abnormal-close-rate metrics don't exist. Watching this currently means reading raw logs, not alerting on a metric. |
+| Gate | Evidence available today | Missing before it can be an operational trigger |
+| --- | --- | --- |
+| `EventConflictError` by conflict type | `event-conflict` log event with `conflictType` | Normalized aggregation, rate calculation, threshold, and alert |
+| Runtime and authorization failures | Thrown room/backend failures can produce `event-error` or `message-error` logs | Expected authorization denials/revocations that return `null` and read-only `canWrite === false` rejections are not reported; origin rejection also occurs outside room metrics |
+| Append and durable-ack timing | Per-operation `event-appended` and `event-acknowledged` duration samples | p50/p95/p99 aggregation and alerts; `event-acknowledged` records completion of the server send attempt, not confirmed client receipt |
+| Repair/resync frequency and success | No success/frequency metric | Instrument repair requests, completion, retries, and failures |
+| Adapter contract and append ordering | Local mocked conformance suites plus shared room state-machine tests | A deployed Worker/Supabase integration test and live signal |
+| Cross-document isolation and single-runtime ownership | Shared room contract tests and Cloudflare's document/presence isolation test | No live cross-talk, active-owner, or split-runtime metric |
+| Reconnect data loss and abnormal closes | Raw platform logs may help manually | Both transports discard close code/reason; no reconnect or abnormal-close metric |
 
-Given the last two rows, treat any expansion past Stage 1 as requiring
-manual log review during the exercised window, not just a metrics
-dashboard — the automated signal is real but partial.
+None of these rows is an automated rollback trigger today. Before Stage 2
+traffic, define log retention and normalized queries or export the events to a
+metrics backend, set explicit thresholds, and add alerts. Until then, use the
+local suites as pre-merge gates and a deliberate, retained-log review plus
+deployed smoke tests as rollout gates.
 
 ## Known limitations and vendor-specific behavior
 
-- `apps/collab-cloudflare` has no CD pipeline and has never served
-  production traffic — see "Production deployment" in its README.
-- No reconnect-rate or abnormal-WebSocket-close-rate metrics yet; this
-  needs new plumbing (reading the close code/reason from crossws and from
-  Cloudflare's hibernatable `webSocketClose` handler), not just a new
-  metric call — deferred deliberately rather than rushed.
-- No active-rooms/active-connections gauges or Durable Object
-  wake/hibernation counters — these need a periodic gauge or per-instance
-  registry, a different shape of instrumentation than the event-driven
-  metrics shipped so far.
-- No Postgres/Supabase query/transaction latency instrumentation inside
-  either adapter (`prisma-document-event-store.ts`,
-  `supabase-backend.ts`) — independent of the shared room code, and not
-  yet built.
-- The shared conformance suite covers `DocumentEventStore` only.
-  `RoomFanout` is deliberately not covered: Nitro's cross-instance Redis
-  pub/sub and Cloudflare's single-instance DO-local fanout are
-  architecturally different enough that forcing identical black-box
-  conformance isn't the right test shape.
-- Routing decisions don't propagate to already-open browser tabs — see
-  the rollback section above.
-- Cloudflare-specific: `DocumentRoomDO` revalidates every attached
-  socket's access against Supabase on constructor wake, up to the
-  100-connection room policy. This is a real per-wake cost budget; see
-  "Runtime shape" in
-  [`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md)
-  for the Workers-plan subrequest-budget implication before lowering (or
-  raising) that policy.
+- Repository state shows no Cloudflare CD pipeline or declared route, but it
+  cannot establish Cloudflare account or dashboard state.
+- There are no normalized aggregates, alerts, latency percentiles,
+  repair/resync success metrics, expected authorization-denial metrics,
+  reconnect/close metrics, or active-room/connection gauges.
+- There is no Postgres/Supabase query or transaction latency instrumentation
+  inside either adapter.
+- The mocked conformance suites cover `DocumentEventStore` only. Nitro's
+  cross-instance Redis fan-out and Cloudflare's DO-local fan-out need
+  host-specific integration coverage.
+- Routing changes do not propagate to open tabs. A reload/fresh server render
+  is required, and presence membership is recreated rather than migrated.
+- On each constructor wake, `DocumentRoomDO` revalidates every attached socket
+  against Supabase, up to the 100-connection room policy. Check the Workers
+  plan's external-subrequest budget before changing that policy; see the
+  [Cloudflare runtime shape](https://github.com/softmaple/softmaple/blob/next/apps/collab-cloudflare/README.md#runtime-shape).
 
 ## Current decision
 
-**Not yet promotable to default. Stage 1 only.** Cloudflare has no
-production traffic and no deployment, so there is no data to base a
-promotion decision on — recording an optimistic verdict without evidence
-would be worse than recording none. What's needed to revisit this
-decision, in order:
+**Not yet promotable to the default; keep repository routing at Stage 1.** The
+repository contains no deployed-environment evidence, production metrics, or
+real-store conformance result on which to base a promotion. To revisit this
+decision:
 
-1. Deploy `apps/collab-cloudflare` to a reachable environment (see its
-   README's "Production deployment" section for the current, manual
-   process).
-2. Exercise Stage 2 (preview/internal traffic) and confirm the shared
-   conformance suite and both apps' test suites stay green against that
-   deployment.
-3. Collect the append/ack-latency and conflict/error-rate metrics this
-   phase's instrumentation now makes possible, for a real traffic window,
-   and compare them against Nitro's.
-4. Close enough of the reconnect/close-code gap (above) to watch the
-   remaining correctness gates before expanding past a small cohort.
+1. Verify the target Cloudflare account state, then deploy a reachable Worker
+   with the README's atomic first-deploy procedure.
+2. Keep both mocked conformance suites and app suites as pre-merge checks, and
+   add a deployed smoke/integration test that reaches the Worker, real Supabase
+   RPCs, Auth, and required Data API tables.
+3. Normalize and retain both hosts' events; add aggregation, p50/p95/p99
+   latency, thresholds, alerts, and the missing authorization, repair,
+   reconnect, and ownership signals.
+4. Exercise preview/internal traffic only after protecting active documents
+   from split ownership. Verify reload-based ownership handoff, presence
+   rejoin, durable repair, and absence of old-runtime connections.
+5. Compare a real traffic window with Nitro before expanding the cohort.
 
-Until then, this document's own existence is the operational readiness
-work for Stage 2 — not evidence that Stage 2 has happened.
+This document records what is required for Stage 2; it is not evidence that
+Stage 2 has happened.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,7 +43,8 @@
           "design/awareness-and-presence",
           "design/collaboration-layers",
           "design/collaboration-runtime",
-          "design/collaboration-consistency"
+          "design/collaboration-consistency",
+          "design/collaboration-operations"
         ]
       },
       {


### PR DESCRIPTION
## Summary

- Adds `docs/design/collaboration-operations.md` — the cross-runtime operational summary [issue 874](https://github.com/softmaple/softmaple/issues/874) asks for: when to deploy Nitro vs. Durable Objects, environment configuration, Supabase/Redis/DO responsibilities, a two-level rollback procedure (routing rollback vs. runtime deploy rollback — these are genuinely different levers), a correctness-gate table stating what's actually detectable today given the conformance suite (#890) and metrics (#892) from the prior two slices, known limitations, and an explicit current-decision record.
- That decision is honest, not aspirational: `apps/collab-cloudflare` has never been deployed to a reachable environment (no CD pipeline, no `routes`/custom domain in `wrangler.jsonc`), so there's no production data to base a promotion decision on. The doc records **"not yet promotable to default — Stage 1 only"** and states precisely what's needed to revisit it, rather than fabricating a verdict without evidence.
- Fills the real gap this surfaced: `apps/collab-cloudflare/README.md` had no Environment table, no production deployment section, and no rollback section — only inline `.dev.vars` setup prose. It was still titled "PoC" despite having grown well past that through phases 2–6 (hibernation, full presence room). `apps/web/README.md`'s routing section already promised this README would cover deploying the worker; that promise is now fulfilled.
- Registers the new page in `docs/docs.json`'s "Design Documents" group.

## Test plan

- [x] Verified every cross-link (`apps/web/README.md`, `apps/collab/README.md`, `apps/collab-cloudflare/README.md`, `packages/db/supabase/README.md`, `docs/design/collaboration-runtime.md`) resolves to a real heading/anchor
- [x] `wrangler rollback`/`wrangler versions list` commands verified against the current wrangler skill reference rather than assumed
- [x] `node -e "JSON.parse(...)"` — `docs/docs.json` still valid JSON
- [x] `apps/collab-cloudflare/README.md`'s new Environment table matches `wrangler.jsonc`'s `secrets.required` exactly (4 entries, no drift)
- [x] `pnpm format:check` — clean, no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added operational guidance for collaboration runtime deployment, configuration, storage, rollback procedures, and known limitations.
  * Documented Nitro as the default production runtime and Cloudflare as test-only.
  * Clarified routing behavior, including direct Cloudflare connections and session handling during runtime changes.
  * Documented durable event history, runtime-local presence, deployment responsibilities, and secret management.
  * Added the collaboration operations guide to documentation navigation and linked it from related runtime documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->