### PR TITLE
fix(apps/web): declare COLLAB_RUNTIME_OVERRIDE in package turbo.json

### DIFF
--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://v2-9-12.turborepo.dev/schema.json",
   "extends": ["//"],
   "tasks": {
+    "build": {
+      "env": ["$TURBO_EXTENDS$", "COLLAB_RUNTIME_OVERRIDE"]
+    },
     "test": {
       "dependsOn": ["^build"]
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the Vercel Turborepo warning that `COLLAB_RUNTIME_OVERRIDE` is set on the project but missing from `@softmaple/web#build`.

The root `turbo.json` `build.env` already lists this variable. Vercel’s platform env check for `@softmaple/web#build` still reports it as missing because `apps/web/turbo.json` did not declare a `build` task. This change adds only that one variable on the web package `build` task, inheriting the rest via `$TURBO_EXTENDS$`.

Changes proposed in this pull request:

- Declare `COLLAB_RUNTIME_OVERRIDE` on `@softmaple/web#build` in `apps/web/turbo.json`
- Keep the existing root `build.env` list unchanged

Test commands run:

- `TURBO_PLATFORM_ENV=COLLAB_RUNTIME_OVERRIDE pnpm exec turbo run build --filter=@softmaple/web --dry=json` (resolved `@softmaple/web#build` env includes `COLLAB_RUNTIME_OVERRIDE`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5b88495-c34b-4f6e-94ba-f0c06397e1f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5b88495-c34b-4f6e-94ba-f0c06397e1f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

