### PR TITLE
fix(packages/awareness): accept JWT-length tokens in presence Auth frames

### DIFF
--- a/apps/collab/test/presence-route.test.ts
+++ b/apps/collab/test/presence-route.test.ts
@@ -130,6 +130,9 @@ const AUTHENTICATED_ACCESS = {
 
 const DEFAULT_PROFILE = { full_name: "Test User", avatar_src: null };
 
+/** Stand-in for a real Supabase access token (~1000 characters). */
+const JWT_LENGTH_TOKEN = `${"h".repeat(40)}.${"p".repeat(900)}.${"s".repeat(43)}`;
+
 // `mockResolvedValueOnce` queues leak across tests when only `clearAllMocks`
 // runs between them (it clears call history, not queued implementations).
 // Driving both mocks off mutable state avoids call-count bookkeeping and
@@ -333,6 +336,23 @@ describe("collaboration presence route", () => {
         }),
       );
       expect(peer.close).toHaveBeenCalledWith(1008, "Unauthorized");
+      await route.close(peer);
+    });
+
+    it("authenticates a JWT-length token", async () => {
+      const peer = await upgradedPeer();
+      await route.message(
+        peer,
+        authMessage(ROOM_ID, "connection-1", { token: JWT_LENGTH_TOKEN }),
+      );
+      expect(peer.send).toHaveBeenCalledWith(
+        expect.objectContaining({ type: WS_MESSAGE.AUTH_OK }),
+      );
+      expect(mocks.authorizeDocument).toHaveBeenCalledWith(
+        { kind: "access-token", token: JWT_LENGTH_TOKEN },
+        ROOM_ID,
+      );
+      expect(peer.close).not.toHaveBeenCalled();
       await route.close(peer);
     });
 

--- a/packages/awareness/src/protocol/auth.test.ts
+++ b/packages/awareness/src/protocol/auth.test.ts
@@ -64,9 +64,25 @@ describe("parsePresenceAuth", () => {
     ).toThrow("invalid presence authentication");
   });
 
-  it("rejects a token over 256 characters", () => {
+  it("accepts a JWT-length token", () => {
+    // A Supabase access token is ~1000 characters; the 256 identifier bound
+    // used to reject every real session with "invalid presence authentication".
+    const token = `${"h".repeat(40)}.${"p".repeat(900)}.${"s".repeat(43)}`;
+    expect(parsePresenceAuth({ ...validAuthPayload(), token }).token).toBe(
+      token,
+    );
+  });
+
+  it("accepts a token at the 4096 character bound", () => {
+    const token = "t".repeat(4096);
+    expect(parsePresenceAuth({ ...validAuthPayload(), token }).token).toBe(
+      token,
+    );
+  });
+
+  it("rejects a token over 4096 characters", () => {
     expect(() =>
-      parsePresenceAuth({ ...validAuthPayload(), token: "t".repeat(257) }),
+      parsePresenceAuth({ ...validAuthPayload(), token: "t".repeat(4097) }),
     ).toThrow("invalid presence authentication");
   });
 

--- a/packages/awareness/src/protocol/auth.ts
+++ b/packages/awareness/src/protocol/auth.ts
@@ -5,6 +5,14 @@
 import { isRecord, isShortString } from "./envelope";
 import { PRESENCE_CAPABILITIES, PRESENCE_PROTOCOL_VERSION } from "./version";
 
+/**
+ * A credential is a JWT, not a wire identifier: a Supabase access token is
+ * routinely ~1000 characters, so the shared 256 identifier bound would
+ * reject every real session. Matches the credential bound already used by
+ * the Cloudflare presence attachment parser.
+ */
+const MAX_PRESENCE_TOKEN_LENGTH = 4_096;
+
 export interface PresenceAuthPayload {
   readonly connectionId: string;
   readonly token: string;
@@ -14,7 +22,7 @@ export interface PresenceAuthPayload {
 export const parsePresenceAuth = (payload: unknown): PresenceAuthPayload => {
   if (
     !isRecord(payload) ||
-    !isShortString(payload.token) ||
+    !isShortString(payload.token, MAX_PRESENCE_TOKEN_LENGTH) ||
     !isShortString(payload.connectionId) ||
     !isShortString(payload.userId) ||
     payload.protocolVersion !== PRESENCE_PROTOCOL_VERSION ||


### PR DESCRIPTION
Fixes # — no linked issue; reported from the browser console when opening a document in `apps/web`:

```
Failed to connect presence adapter: Error: Authentication or document membership failed
```

with the workspace presence bar showing **"Presence error"**.

## Root cause

`parsePresenceAuth` validated the credential with the shared 256-character wire-*identifier* bound:

```ts
!isShortString(payload.token) ||   // isShortString defaults to max = 256
```

A Supabase access token is a JWT — a typical one measures ~975 characters. So the parser threw `invalid presence authentication` for **every real browser session**, before authorization was ever attempted. `PresenceRoom.authenticate()` caught it and replied with an `AuthError` frame carrying the generic `"Authentication or document membership failed"` message, which the adapter surfaced as a rejected `connect()` (console error) and a `"error"` connection state — rendered by `WorkspacePresenceBar` as `Presence error`.

The 256 bound is correct for `connectionId` / `userId`; it was only ever wrong for the credential.

## Changes proposed in this pull request:

- Give the presence credential its own 4096-character bound in `packages/awareness/src/protocol/auth.ts`, keeping the 256 bound for identifiers. 4096 is not a new constant — `apps/collab-cloudflare/src/presence-attachment.ts` already parses the same credential with `isShortString(value.token, 4_096)`; the wire parser was the one place that missed it. Both presence runtimes (Nitro and Cloudflare) share this parser, so one fix covers both.
- Replace the unit test that pinned the wrong bound (`rejects a token over 256 characters`) with JWT-length, 4096-boundary, and over-4096 cases.
- Add a route-level regression test in `apps/collab/test/presence-route.test.ts` that drives upgrade → `Auth` → `AUTH_OK` with a ~1000-character token. Existing tests all used short stub tokens such as `"access-token"`, which is why the bug reached production.

## Test commands run

- `pnpm exec vitest run --project unit` (`packages/awareness`) — 606 passed
- `pnpm exec vitest run` (`apps/collab`) — 112 passed, including the new route regression test
- `pnpm --filter @softmaple/awareness typecheck` and `pnpm --filter @softmaple/collab typecheck` — clean
- Biome / pre-commit hooks — clean (no `--no-verify`)

The new regression test was verified to fail against the pre-fix parser (`× authenticates a JWT-length token`), so it is not a no-op.

No UI changes, so no screenshots. The `packages/awareness` browser-mode tests could not run in this environment (Playwright is missing `chrome-headless-shell`); this is unrelated to the change.

## Noted, not fixed (out of scope)

Cloudflare's `MAX_PERSISTED_PRESENCE_BYTES` is 4 KiB, and the attachment holds credential + identity + quota, so a credential near the 4096-character bound would exceed the persisted-attachment budget. Real Supabase tokens (~1000 chars) are comfortably within it, and this inconsistency already existed in `presence-attachment.ts` — worth a separate issue rather than widening this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ykvs6zKjDR8oHiXXvUfas)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Presence authentication now supports tokens up to 4,096 characters, including standard JWT-length tokens.
  - Valid authenticated connections remain open after authorization.

- **Bug Fixes**
  - Authentication payload validation now consistently accepts valid long tokens while rejecting tokens exceeding the maximum length.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->