### PR TITLE
Distinguish auth denials from temporary outages in presence

### DIFF
--- a/apps/collab-cloudflare/eslint.config.js
+++ b/apps/collab-cloudflare/eslint.config.js
@@ -9,8 +9,11 @@ import { config } from "@softmaple/eslint-config/base";
 // symmetrically for the document side. `src/index.ts` and `test/worker.ts`
 // are composition roots that legitimately wire both sides, so neither glob
 // below includes them.
+// `supabase-error` belongs here for the same reason as `constants`: it is a
+// pure formatting function over a PostgREST result error, holding no client,
+// no state, and no capability instance for either side to share.
 const SHARED_UTILITY_FILES =
-  "constants|document-id|origin|message-bytes|supabaseTypes";
+  "constants|document-id|origin|message-bytes|supabase-error|supabaseTypes";
 const PRESENCE_OWN_FILES =
   "presence-[\\w-]*|awareness-presence-codec|supabase-presence-backend|memory-presence-backend";
 const DOCUMENT_OWN_FILES =

--- a/apps/collab-cloudflare/src/constants.ts
+++ b/apps/collab-cloudflare/src/constants.ts
@@ -39,6 +39,24 @@ export const errorMessage = (
   retryable,
 });
 
+/**
+ * `String(someObject)` is `"[object Object]"`, which silently discarded the
+ * whole diagnosis whenever a non-`Error` was thrown (a raw PostgREST result
+ * error, for instance). Serialize structurally instead so the log always
+ * names the failure.
+ */
+const describeError = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null) {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      // Circular or non-serializable: fall through to the string coercion.
+    }
+  }
+  return String(error);
+};
+
 export const logError = (
   error: unknown,
   context: Readonly<Record<string, unknown>>,
@@ -46,7 +64,7 @@ export const logError = (
   console.error(
     JSON.stringify({
       ...context,
-      error: error instanceof Error ? error.message : String(error),
+      error: describeError(error),
       errorName: error instanceof Error ? error.name : "UnknownError",
       message: "Cloudflare collaboration request failed",
     }),

--- a/apps/collab-cloudflare/src/supabase-backend.ts
+++ b/apps/collab-cloudflare/src/supabase-backend.ts
@@ -14,6 +14,7 @@ import {
   type DocumentAccess,
 } from "@softmaple/collab-runtime";
 import type { DocumentBackend } from "./room-services";
+import { supabaseQueryError } from "./supabase-error";
 import type { CollabDatabase } from "./supabaseTypes";
 
 interface SupabaseBackendEnv {
@@ -205,7 +206,7 @@ const authorizePublic = async (
     .eq("id", documentId)
     .eq("is_public", true)
     .maybeSingle();
-  if (error !== null) throw error;
+  if (error !== null) throw supabaseQueryError("public document lookup", error);
   const document = documentRow(data as unknown);
   if (document === null || !document.is_public) return null;
   return publicDocumentAccess();
@@ -233,7 +234,9 @@ const authorizeAuthenticated = async (
     .select("id,is_public,workspace_id")
     .eq("id", documentId)
     .maybeSingle();
-  if (documentError !== null) throw documentError;
+  if (documentError !== null) {
+    throw supabaseQueryError("document lookup", documentError);
+  }
   const document = documentRow(rawDocument as unknown);
   if (document === null) return null;
 
@@ -243,7 +246,9 @@ const authorizeAuthenticated = async (
     .eq("user_id", userId)
     .eq("workspace_id", document.workspace_id)
     .maybeSingle();
-  if (memberError !== null) throw memberError;
+  if (memberError !== null) {
+    throw supabaseQueryError("membership lookup", memberError);
+  }
   const member = memberRow(rawMember as unknown);
   if (member === null) {
     return document.is_public ? publicDocumentAccess() : null;

--- a/apps/collab-cloudflare/src/supabase-error.ts
+++ b/apps/collab-cloudflare/src/supabase-error.ts
@@ -1,0 +1,49 @@
+/**
+ * PostgREST failures reach us as data, not as exceptions.
+ *
+ * `@supabase/postgrest-js` only constructs a `PostgrestError` (which does
+ * extend `Error`) on its `shouldThrowOnError` path. The `{ data, error }`
+ * result this codebase uses carries a **plain object literal**
+ * (`{ code, details, hint, message }`), so re-throwing it verbatim produces a
+ * non-`Error` throw: every downstream `error instanceof Error` check fails,
+ * the name degrades to `"UnknownError"`, and `String(error)` renders the
+ * whole diagnosis as `"[object Object]"`.
+ *
+ * Wrap the result here instead, so the query that failed and PostgREST's own
+ * code/details/hint survive into the log.
+ */
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const field = (source: Record<string, unknown>, key: string): string | null => {
+  const value = source[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+/** `code`/`details`/`hint` are all nullable in a PostgREST error body. */
+const describe = (error: unknown): string => {
+  if (!isRecord(error)) return String(error);
+  const parts = [
+    field(error, "code"),
+    field(error, "message"),
+    field(error, "details"),
+    field(error, "hint"),
+  ].filter((part): part is string => part !== null);
+  return parts.length === 0 ? JSON.stringify(error) : parts.join(" | ");
+};
+
+/**
+ * Converts a PostgREST `{ data, error }` failure into a real `Error` naming
+ * the `operation` that produced it. An `Error` that somehow arrives here is
+ * returned unchanged so a genuine exception keeps its stack.
+ */
+export const supabaseQueryError = (
+  operation: string,
+  error: unknown,
+): Error => {
+  if (error instanceof Error) return error;
+  const wrapped = new Error(`${operation} failed: ${describe(error)}`);
+  wrapped.name = "SupabaseQueryError";
+  return wrapped;
+};

--- a/apps/collab-cloudflare/src/supabase-presence-backend.ts
+++ b/apps/collab-cloudflare/src/supabase-presence-backend.ts
@@ -3,6 +3,7 @@ import type {
   PresenceIdentity,
   PresenceSessionHooks,
 } from "@softmaple/collab-runtime";
+import { supabaseQueryError } from "./supabase-error";
 import type { CollabDatabase } from "./supabaseTypes";
 
 /**
@@ -127,7 +128,9 @@ const resolveIdentity = async (
     .select("id,workspace_id")
     .eq("id", roomId)
     .maybeSingle();
-  if (documentError !== null) throw documentError;
+  if (documentError !== null) {
+    throw supabaseQueryError("presence document lookup", documentError);
+  }
   const document = documentRow(rawDocument as unknown);
   if (document === null) return null;
 
@@ -146,10 +149,14 @@ const resolveIdentity = async (
       .eq("id", userId)
       .maybeSingle(),
   ]);
-  if (memberResult.error !== null) throw memberResult.error;
+  if (memberResult.error !== null) {
+    throw supabaseQueryError("presence membership lookup", memberResult.error);
+  }
   if (memberRow(memberResult.data as unknown) === null) return null;
 
-  if (userResult.error !== null) throw userResult.error;
+  if (userResult.error !== null) {
+    throw supabaseQueryError("presence profile lookup", userResult.error);
+  }
   const user = userRow(userResult.data as unknown);
   if (user === null) return null;
 

--- a/apps/collab-cloudflare/test/constants.test.ts
+++ b/apps/collab-cloudflare/test/constants.test.ts
@@ -48,4 +48,44 @@ describe("logError", () => {
       message: "Cloudflare collaboration request failed",
     });
   });
+
+  // A raw PostgREST result error is a plain object, and `String(...)` on it
+  // logged "[object Object]" — the whole diagnosis was lost.
+  it("serializes a thrown non-Error instead of collapsing it", () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    logError(
+      {
+        code: "42501",
+        details: null,
+        hint: null,
+        message: "permission denied for table users",
+      },
+      { messageType: "auth", roomId: "room-1" },
+    );
+
+    const logged = JSON.parse(error.mock.calls[0]?.[0] as string) as {
+      error: string;
+    };
+    expect(logged.error).not.toBe("[object Object]");
+    expect(logged.error).toContain("42501");
+    expect(logged.error).toContain("permission denied for table users");
+  });
+
+  it("falls back to string coercion for a non-serializable value", () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    logError(circular, { messageType: "auth" });
+
+    expect(JSON.parse(error.mock.calls[0]?.[0] as string)).toMatchObject({
+      error: "[object Object]",
+      errorName: "UnknownError",
+    });
+  });
 });

--- a/apps/collab-cloudflare/test/supabase-error.test.ts
+++ b/apps/collab-cloudflare/test/supabase-error.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { supabaseQueryError } from "../src/supabase-error";
+
+describe("supabaseQueryError", () => {
+  // postgrest-js only builds a `PostgrestError` (which extends Error) on its
+  // shouldThrowOnError path; the `{ data, error }` result carries a plain
+  // object, so re-throwing it verbatim produced `errorName: "UnknownError"`
+  // and `error: "[object Object]"` in the Worker logs.
+  it("turns a plain PostgREST result error into a named Error", () => {
+    const wrapped = supabaseQueryError("presence membership lookup", {
+      code: "42501",
+      details: null,
+      hint: null,
+      message: "permission denied for table workspace_members",
+    });
+
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped.name).toBe("SupabaseQueryError");
+    expect(wrapped.message).toBe(
+      "presence membership lookup failed: 42501 | permission denied for table workspace_members",
+    );
+  });
+
+  it("keeps every non-empty PostgREST field in order", () => {
+    expect(
+      supabaseQueryError("presence document lookup", {
+        code: "PGRST116",
+        details: "Results contain 0 rows",
+        hint: "Check the filter",
+        message: "JSON object requested",
+      }).message,
+    ).toBe(
+      "presence document lookup failed: PGRST116 | JSON object requested | Results contain 0 rows | Check the filter",
+    );
+  });
+
+  it("returns a real Error unchanged so its stack survives", () => {
+    const original = new TypeError("fetch failed");
+    expect(supabaseQueryError("presence profile lookup", original)).toBe(
+      original,
+    );
+  });
+
+  it("describes a value carrying no recognizable fields", () => {
+    expect(supabaseQueryError("presence document lookup", {}).message).toBe(
+      "presence document lookup failed: {}",
+    );
+    expect(supabaseQueryError("presence document lookup", null).message).toBe(
+      "presence document lookup failed: null",
+    );
+  });
+});

--- a/apps/collab/server/adapters/nitro-presence-host.ts
+++ b/apps/collab/server/adapters/nitro-presence-host.ts
@@ -26,6 +26,23 @@ export interface NitroPresenceTransportPeer {
   send(message: unknown): unknown;
 }
 
+/**
+ * `String(someObject)` is `"[object Object]"`, which discards the diagnosis
+ * whenever a non-`Error` is thrown (a raw PostgREST/driver result error, for
+ * instance). Serialize structurally so the log always names the failure.
+ */
+const describeError = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null) {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      // Circular or non-serializable: fall through to the string coercion.
+    }
+  }
+  return String(error);
+};
+
 const logHostError = (
   error: unknown,
   roomId: string | null,
@@ -35,7 +52,7 @@ const logHostError = (
     roomId,
     messageType,
     errorName: error instanceof Error ? error.name : "UnknownError",
-    errorMessage: error instanceof Error ? error.message : String(error),
+    errorMessage: describeError(error),
     stack: error instanceof Error ? error.stack : undefined,
   });
 };

--- a/apps/collab/test/presence-route.test.ts
+++ b/apps/collab/test/presence-route.test.ts
@@ -425,6 +425,85 @@ describe("collaboration presence route", () => {
       await route.close(peer);
     });
 
+    it("reports a denial as a non-retryable auth-error", async () => {
+      currentAccess = null;
+      const peer = await upgradedPeer();
+      await route.message(peer, authMessage(ROOM_ID, "connection-1"));
+      expect(peer.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: WS_MESSAGE.AUTH_ERROR,
+          payload: {
+            message: "Authentication or document membership failed",
+            retryable: false,
+          },
+        }),
+      );
+      await route.close(peer);
+    });
+
+    // Supabase or Prisma being unreachable says nothing about this user's
+    // membership. Reporting it as a denial is what made an outage surface in
+    // the browser as "Authentication or document membership failed" and left
+    // the presence adapter permanently in `error` instead of reconnecting.
+    it.each([
+      [
+        "the identity provider is unreachable",
+        () => {
+          mocks.authorizeDocument.mockImplementation(async () => {
+            throw new Error("supabase auth request failed");
+          });
+        },
+      ],
+      [
+        "the profile lookup fails",
+        () => {
+          mocks.findUniqueUser.mockImplementation(async () => {
+            throw new Error("prisma connection pool timeout");
+          });
+        },
+      ],
+    ])("closes 1011 with a retryable auth-error when %s", async (_name, fail) => {
+      fail();
+      const peer = await upgradedPeer();
+      await route.message(peer, authMessage(ROOM_ID, "connection-1"));
+      expect(peer.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: WS_MESSAGE.AUTH_ERROR,
+          payload: {
+            message: "Presence authorization is temporarily unavailable",
+            retryable: true,
+          },
+        }),
+      );
+      expect(peer.close).toHaveBeenCalledWith(
+        1011,
+        "Presence runtime unavailable",
+      );
+      expect(peer.close).not.toHaveBeenCalledWith(1008, "Unauthorized");
+      await route.close(peer);
+    });
+
+    it("authenticates a reconnect once the identity provider recovers", async () => {
+      mocks.authorizeDocument.mockImplementationOnce(async () => {
+        throw new Error("supabase auth request failed");
+      });
+      const failed = await upgradedPeer();
+      await route.message(failed, authMessage(ROOM_ID, "connection-1"));
+      expect(failed.close).toHaveBeenCalledWith(
+        1011,
+        "Presence runtime unavailable",
+      );
+      await route.close(failed);
+
+      // The outage must not strand the connection lease it never acquired.
+      const retried = await upgradedPeer();
+      await route.message(retried, authMessage(ROOM_ID, "connection-1"));
+      expect(retried.send).toHaveBeenCalledWith(
+        expect.objectContaining({ type: WS_MESSAGE.AUTH_OK }),
+      );
+      await route.close(retried);
+    });
+
     it("does not publish a Leave for an authorization failure", async () => {
       const observer = await authorizeAndJoin("observer", "observer-user");
       observer.send.mockClear();

--- a/docs/design/collaboration-operations.md
+++ b/docs/design/collaboration-operations.md
@@ -180,6 +180,43 @@ metrics backend, set explicit thresholds, and add alerts. Until then, use the
 local suites as pre-merge gates and a deliberate, retained-log review plus
 deployed smoke tests as rollout gates.
 
+## Diagnosing a presence connection failure
+
+Presence surfaces two distinct auth-error frames, and the browser message
+tells you which layer to look at. Both runtimes share the same
+`PresenceRoom`, so this taxonomy applies to Nitro and Cloudflare alike.
+
+| Browser console | Close code | Client behavior | What it means |
+| --- | --- | --- | --- |
+| `Authentication or document membership failed` | 1008 | Adapter stops; `Presence error` in the UI until the page reloads | The room reached a decision and refused: the caller is not an authenticated member of the document's workspace, the claimed `userId` does not match the token's `sub`, the `users` row is missing, or the Auth frame did not parse. Reconnecting cannot help. |
+| `Presence authorization is temporarily unavailable` | 1011 | Adapter reconnects with backoff and recovers on its own | The room never reached a decision because a dependency failed — Supabase auth, the Prisma profile read, or the connection-lease store (Redis on Nitro). Check `SUPABASE_URL` / `SUPABASE_PUBLISHABLE_KEY`, `DATABASE_URL`, and `REDIS_URL` for the collab host, not the user's membership. |
+
+Both frames carry a `retryable` boolean; the client fails closed when it is
+absent, so a server predating the flag still behaves as it did before.
+
+The matching server log is `Presence request failed` (Nitro) or
+`Cloudflare collaboration request failed` (Workers), keyed by `messageType`:
+
+| `messageType` | Failing step |
+| --- | --- |
+| `auth` | The room refused the credential, or the Auth frame did not parse |
+| `auth-provider` | `PresenceSessionHooks.authorize` threw — Supabase auth, or one of the `documents` / `workspace_members` / `users` reads |
+| `auth-admission` | The connection-lease store or peer persistence threw |
+| `auth-fanout` | The fan-out subscription could not be retained |
+
+Read that log before treating a presence failure as a membership problem —
+the generic denial message is not evidence that the credential was rejected.
+
+Both hosts serialize a thrown non-`Error` structurally. PostgREST reports
+query failures as a plain `{ code, details, hint, message }` object rather
+than an `Error`, so a re-thrown result error used to log as
+`errorName: "UnknownError"` with `error: "[object Object]"`, discarding the
+diagnosis. The Cloudflare Supabase backends now wrap those results with
+`supabaseQueryError`, so the log names the query (`presence membership
+lookup failed: 42501 | permission denied for table workspace_members`).
+A `42501`/`PGRST` code there points at the Worker's `SUPABASE_SERVICE_ROLE_KEY`
+secret or a row-level-security policy, not at the user's membership.
+
 ## Known limitations and vendor-specific behavior
 
 - Repository state shows no Cloudflare CD pipeline or declared route, but it

--- a/packages/awareness/src/adapters/websocket/message.ts
+++ b/packages/awareness/src/adapters/websocket/message.ts
@@ -42,6 +42,12 @@ export interface MessageProcessResult {
   readonly syncCompleted?: boolean;
   /** True when auth succeeded */
   readonly authOk?: boolean;
+  /**
+   * Set on an auth-error frame: true when the server reported the failure as
+   * a transient dependency outage rather than a rejected credential, so the
+   * adapter should reconnect instead of failing permanently.
+   */
+  readonly authErrorRetryable?: boolean;
   /** Heartbeat ack pingId when applicable */
   readonly heartbeatAckPingId?: string;
 }
@@ -291,14 +297,18 @@ export const processMessage = (
     }
 
     case WS_MESSAGE.AUTH_ERROR: {
+      const payload = isRecord(message.payload) ? message.payload : null;
       const messageText =
-        isRecord(message.payload) && typeof message.payload.message === "string"
-          ? message.payload.message
+        typeof payload?.message === "string"
+          ? payload.message
           : "Authentication failed";
       return {
         state,
         shouldNotifyPresence: false,
         error: new Error(messageText),
+        // Anything other than an explicit `true` fails closed, so a server
+        // that does not send the flag keeps the original behaviour.
+        authErrorRetryable: payload?.retryable === true,
       };
     }
 

--- a/packages/awareness/src/adapters/websocket/types.ts
+++ b/packages/awareness/src/adapters/websocket/types.ts
@@ -11,6 +11,7 @@
 import type { AdapterConfig, ReconnectConfig } from "../types";
 
 export {
+  type AuthErrorPayload,
   type AuthPayload,
   type ErrorPayload,
   type HeartbeatPayload,

--- a/packages/awareness/src/adapters/websocket/websocket.test.ts
+++ b/packages/awareness/src/adapters/websocket/websocket.test.ts
@@ -313,6 +313,38 @@ describe("WebSocket Message Utilities", () => {
       expect(result.error).toBeDefined();
       expect(result.error?.message).toContain("AUTH_FAILED");
     });
+
+    it("marks a retryable AUTH_ERROR so the adapter can reconnect", () => {
+      const message = createMessage(WS_MESSAGE.AUTH_ERROR, "room-1", "server", {
+        message: "Presence authorization is temporarily unavailable",
+        retryable: true,
+      });
+
+      const result = processMessage(state, message, selfId);
+      expect(result.error?.message).toBe(
+        "Presence authorization is temporarily unavailable",
+      );
+      expect(result.authErrorRetryable).toBe(true);
+    });
+
+    it("treats a denial AUTH_ERROR as non-retryable", () => {
+      const message = createMessage(WS_MESSAGE.AUTH_ERROR, "room-1", "server", {
+        message: "Authentication or document membership failed",
+        retryable: false,
+      });
+
+      const result = processMessage(state, message, selfId);
+      expect(result.authErrorRetryable).toBe(false);
+    });
+
+    it("fails closed when AUTH_ERROR omits the retryable flag", () => {
+      const message = createMessage(WS_MESSAGE.AUTH_ERROR, "room-1", "server", {
+        message: "Authentication or document membership failed",
+      });
+
+      const result = processMessage(state, message, selfId);
+      expect(result.authErrorRetryable).toBe(false);
+    });
   });
 });
 
@@ -633,6 +665,95 @@ describe("WebSocket adapter public API", () => {
     expect(fakeSockets.length).toBeGreaterThanOrEqual(2);
     completeReadyHandshake(fakeSockets[1]!);
     expect(adapter.getConnectionState()).toBe("connected");
+
+    await adapter.disconnect();
+    vi.useRealTimers();
+  });
+
+  it("recovers from a retryable auth error once the server is available", async () => {
+    vi.useFakeTimers();
+    const adapter = createWebSocketAdapter({
+      ...baseConfig,
+      authToken: "jwt",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 100,
+        maxDelayMs: 100,
+      },
+    });
+    const errors: Error[] = [];
+    adapter.onError((error) => {
+      errors.push(error);
+    });
+
+    // `connect()` still rejects — the first attempt genuinely failed — but
+    // the adapter must keep trying rather than latching into `error`.
+    const rejection: Promise<Error | null> = adapter.connect().then(
+      () => null,
+      (error: unknown) => error as Error,
+    );
+    fakeSockets[0]?.emitOpen();
+    fakeSockets[0]?.emitMessage(
+      serializeMessage(
+        createMessage(WS_MESSAGE.AUTH_ERROR, "room-1", "server", {
+          message: "Presence authorization is temporarily unavailable",
+          retryable: true,
+        }),
+      ),
+    );
+    expect(adapter.getConnectionState()).not.toBe("error");
+
+    fakeSockets[0]?.emitClose();
+    expect(adapter.getConnectionState()).toBe("reconnecting");
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(fakeSockets.length).toBeGreaterThanOrEqual(2);
+    completeReadyHandshake(fakeSockets[1]!, "room-1", { authOk: true });
+    expect(adapter.getConnectionState()).toBe("connected");
+
+    expect((await rejection)?.message).toBe(
+      "Presence authorization is temporarily unavailable",
+    );
+    expect(errors).toHaveLength(1);
+
+    await adapter.disconnect();
+    vi.useRealTimers();
+  });
+
+  it("stops reconnecting when the auth error is a denial", async () => {
+    vi.useFakeTimers();
+    const adapter = createWebSocketAdapter({
+      ...baseConfig,
+      authToken: "jwt",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 100,
+        maxDelayMs: 100,
+      },
+    });
+
+    const rejection: Promise<Error | null> = adapter.connect().then(
+      () => null,
+      (error: unknown) => error as Error,
+    );
+    fakeSockets[0]?.emitOpen();
+    fakeSockets[0]?.emitMessage(
+      serializeMessage(
+        createMessage(WS_MESSAGE.AUTH_ERROR, "room-1", "server", {
+          message: "Authentication or document membership failed",
+          retryable: false,
+        }),
+      ),
+    );
+
+    expect(adapter.getConnectionState()).toBe("error");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fakeSockets).toHaveLength(1);
+    expect((await rejection)?.message).toBe(
+      "Authentication or document membership failed",
+    );
 
     await adapter.disconnect();
     vi.useRealTimers();

--- a/packages/awareness/src/adapters/websocket/websocket.ts
+++ b/packages/awareness/src/adapters/websocket/websocket.ts
@@ -269,7 +269,15 @@ export const createWebSocketAdapter = (
     }
     if (result.error !== undefined) {
       subscriptions.notifyError(result.error);
-      if (message.type === WS_MESSAGE.AUTH_ERROR) {
+      // A retryable auth error means the server could not reach its
+      // authorization dependencies, not that this credential was rejected.
+      // Leave the socket alone so its close drives the normal reconnect
+      // backoff; tearing down here would strand presence in `error` until
+      // the adapter is recreated.
+      if (
+        message.type === WS_MESSAGE.AUTH_ERROR &&
+        result.authErrorRetryable !== true
+      ) {
         setState({ connectionState: "error" });
         cleanupWebSocket(internal, handlers);
       }

--- a/packages/awareness/src/protocol/index.ts
+++ b/packages/awareness/src/protocol/index.ts
@@ -17,6 +17,7 @@ export {
   type PresencePatchApplication,
 } from "./member";
 export {
+  type AuthErrorPayload,
   type AuthPayload,
   type ErrorPayload,
   type HeartbeatPayload,

--- a/packages/awareness/src/protocol/messages.ts
+++ b/packages/awareness/src/protocol/messages.ts
@@ -87,6 +87,22 @@ export interface HeartbeatPayload {
 }
 
 /**
+ * Auth failure payload.
+ *
+ * `retryable` separates the two outcomes that used to share one message:
+ * `false` means the room decided against this credential (membership
+ * denied, malformed handshake) and reconnecting cannot change that;
+ * `true` means the room never reached a decision because a dependency —
+ * identity provider, lease store, persistence — was unavailable, so a
+ * reconnect can still succeed. Servers predating the flag omit it, so an
+ * absent value keeps the original fail-closed behaviour.
+ */
+export interface AuthErrorPayload {
+  readonly message: string;
+  readonly retryable?: boolean;
+}
+
+/**
  * Auth handshake payload
  */
 export interface AuthPayload {

--- a/packages/collab-runtime/src/presence-room-implementation.ts
+++ b/packages/collab-runtime/src/presence-room-implementation.ts
@@ -1,9 +1,13 @@
 import type { CollabCredential } from "@softmaple/collab-protocol";
-import type { ConnectionLease } from "./connection-limiter";
+import type {
+  ConnectionAdmission,
+  ConnectionLease,
+} from "./connection-limiter";
 import { ROOM_LEAVE_REASON, type RoomLeaveReason } from "./document-room";
 import {
   PRESENCE_FRAME,
   PRESENCE_MESSAGE,
+  type PresenceAuthPayload,
   type PresenceEnvelope,
   type PresenceMessageKind,
   type PresencePatch,
@@ -404,22 +408,41 @@ class RuntimePresenceRoom implements PresenceRoom {
     state: PeerState,
     envelope: PresenceEnvelope,
   ): Promise<void> {
+    let auth: PresenceAuthPayload;
     try {
-      const auth = this.services.codec.parseAuth(envelope.payload);
+      auth = this.services.codec.parseAuth(envelope.payload);
       if (envelope.senderId !== auth.connectionId) {
         throw new Error("presence sender mismatch");
       }
+    } catch (error) {
+      // A frame this room cannot parse is a client defect, not an outage:
+      // retrying the same handshake would fail identically.
+      await this.denyAuthentication(state, error);
+      return;
+    }
 
-      const identity = await this.services.sessions.authorize({
+    let identity: PresenceIdentity | null;
+    try {
+      identity = await this.services.sessions.authorize({
         connectionId: auth.connectionId,
         credential: auth.credential,
         roomId: this.roomId,
         userId: auth.userId,
       });
-      if (identity === null) {
-        throw new Error("presence membership denied");
-      }
+    } catch (error) {
+      // The provider never returned a decision, so access was not denied.
+      await this.failTemporaryAuthentication(state, error, "auth-provider");
+      return;
+    }
+    if (identity === null) {
+      await this.denyAuthentication(
+        state,
+        new Error("presence membership denied"),
+      );
+      return;
+    }
 
+    try {
       if (state.leaveRequested || this.closed) {
         await this.resetState(
           state,
@@ -433,12 +456,22 @@ class RuntimePresenceRoom implements PresenceRoom {
 
       // Set before admission so a concurrent cleanup can identify the peer.
       state.connectionId = auth.connectionId;
-      const admission = await this.services.connections.acquire({
-        documentId: this.roomId,
-        peerId: auth.connectionId,
-        policy: this.services.policy.connection,
-        sessionId: auth.connectionId,
-      });
+      let admission: ConnectionAdmission;
+      try {
+        admission = await this.services.connections.acquire({
+          documentId: this.roomId,
+          peerId: auth.connectionId,
+          policy: this.services.policy.connection,
+          sessionId: auth.connectionId,
+        });
+      } catch (admissionError) {
+        await this.failTemporaryAuthentication(
+          state,
+          admissionError,
+          "auth-admission",
+        );
+        return;
+      }
       if (!admission.accepted) {
         state.leaveRequested = true;
         await this.closePeer(
@@ -506,24 +539,79 @@ class RuntimePresenceRoom implements PresenceRoom {
         "auth-ok",
       );
     } catch (error) {
-      this.report(error, state, "auth");
-      state.leaveRequested = true;
-      await this.resetState(
-        state,
-        true,
-        PRESENCE_SESSION_END_REASON.AccessRevoked,
-      );
+      // Access was already granted above, so anything failing here is a
+      // runtime fault rather than a rejected credential.
+      await this.failTemporaryAuthentication(state, error, "auth-admission");
+    }
+  }
+
+  /**
+   * Terminal outcome for a credential this room refuses: the same handshake
+   * cannot succeed on a retry, so the client is told not to reconnect.
+   */
+  private async denyAuthentication(
+    state: PeerState,
+    error: unknown,
+  ): Promise<void> {
+    this.report(error, state, "auth");
+    state.leaveRequested = true;
+    await this.resetState(
+      state,
+      true,
+      PRESENCE_SESSION_END_REASON.AccessRevoked,
+    );
+    await this.sendAuthError(
+      state,
+      "Authentication or document membership failed",
+      false,
+    );
+    await this.closePeer(state.peer, 1008, "Unauthorized");
+  }
+
+  /**
+   * Outcome for an authorization that never completed because a dependency
+   * (identity provider, connection lease store, persistence) was
+   * unavailable. Access was neither granted nor denied, so the peer is told
+   * the failure is retryable and closed 1011 like every other presence
+   * runtime fault — a reconnect can still succeed once the dependency
+   * recovers. Collapsing these into the denial path above is what made an
+   * outage read as "Authentication or document membership failed" and left
+   * the client permanently in `error` instead of reconnecting.
+   */
+  private async failTemporaryAuthentication(
+    state: PeerState,
+    error: unknown,
+    messageType: string,
+  ): Promise<void> {
+    this.report(error, state, messageType);
+    state.leaveRequested = true;
+    await this.resetState(state, true, PRESENCE_SESSION_END_REASON.PeerLeft);
+    await this.sendAuthError(
+      state,
+      "Presence authorization is temporarily unavailable",
+      true,
+    );
+    await this.closePeer(state.peer, 1011, "Presence runtime unavailable");
+  }
+
+  private async sendAuthError(
+    state: PeerState,
+    message: string,
+    retryable: boolean,
+  ): Promise<void> {
+    try {
       await this.sendIgnoringFailure(
         state.peer,
         this.services.codec.encode(
           PRESENCE_FRAME.AuthError,
           this.roomId,
           "server",
-          { message: "Authentication or document membership failed" },
+          { message, retryable },
         ),
         "auth-error",
       );
-      await this.closePeer(state.peer, 1008, "Unauthorized");
+    } catch (encodeError) {
+      this.report(encodeError, state, "auth-error-encode");
     }
   }
 

--- a/packages/collab-runtime/src/testing/presence-room-conformance.ts
+++ b/packages/collab-runtime/src/testing/presence-room-conformance.ts
@@ -32,6 +32,10 @@ const framesOfType = (
 ): unknown[] =>
   peer.sent.filter((frame) => isRecord(frame) && frame.type === type);
 
+/** The `{ message, retryable }` body of an auth-error frame, or null. */
+const authErrorPayload = (frame: unknown): unknown =>
+  isRecord(frame) ? (frame.payload ?? null) : null;
+
 const wire = (
   type: string,
   roomId: string,
@@ -113,7 +117,7 @@ export const presenceRoomConformance = (
   factory: PresenceRoomFactory,
 ): ConformanceCase[] => [
   {
-    name: "Auth denial closes 1008 and sends auth-error",
+    name: "Auth denial closes 1008 and sends a non-retryable auth-error",
     async run() {
       const { room, sessions } = factory();
       sessions.authorizeImpl = async () => null;
@@ -121,9 +125,71 @@ export const presenceRoomConformance = (
       await room.join(peer);
       await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
       checkEqual(peer.closes[0]?.code, 1008, "expected a 1008 close on denial");
+      const frames = framesOfType(peer, PRESENCE_FRAME.AuthError);
+      check(frames.length === 1, "expected exactly one auth-error frame");
+      checkEqual(
+        authErrorPayload(frames[0]),
+        {
+          message: "Authentication or document membership failed",
+          retryable: false,
+        },
+        "expected a denial to be reported as non-retryable",
+      );
+    },
+  },
+  {
+    name: "an unavailable authorization provider closes 1011 and sends a retryable auth-error",
+    async run() {
+      const { room, sessions } = factory();
+      sessions.authorizeImpl = async () => {
+        throw new Error("authorization provider unreachable");
+      };
+      const peer = createRecordingPresencePeer("connection-1");
+      await room.join(peer);
+      await room.receive(peer, authWire(ROOM_ID, "connection-1", "user-1"));
+      checkEqual(
+        peer.closes[0]?.code,
+        1011,
+        "expected a 1011 close when the provider is unavailable",
+      );
+      const frames = framesOfType(peer, PRESENCE_FRAME.AuthError);
+      check(frames.length === 1, "expected exactly one auth-error frame");
+      checkEqual(
+        authErrorPayload(frames[0]),
+        {
+          message: "Presence authorization is temporarily unavailable",
+          retryable: true,
+        },
+        "expected an outage to be reported as retryable, not as a denial",
+      );
+    },
+  },
+  {
+    name: "an unavailable authorization provider still admits a later Auth once it recovers",
+    async run() {
+      const { room, sessions } = factory();
+      const working = sessions.authorizeImpl;
+      sessions.authorizeImpl = async () => {
+        throw new Error("authorization provider unreachable");
+      };
+      const failed = createRecordingPresencePeer("connection-1");
+      await room.join(failed);
+      await room.receive(failed, authWire(ROOM_ID, "connection-1", "user-1"));
+
+      // The outage must not have leaked a connection lease or left room
+      // state that blocks the client's reconnect.
+      sessions.authorizeImpl = working;
+      const retried = createRecordingPresencePeer("connection-1");
+      await room.join(retried);
+      await room.receive(retried, authWire(ROOM_ID, "connection-1", "user-1"));
       check(
-        framesOfType(peer, PRESENCE_FRAME.AuthError).length === 1,
-        "expected exactly one auth-error frame",
+        framesOfType(retried, PRESENCE_FRAME.AuthOk).length === 1,
+        "expected the reconnect after an outage to authenticate",
+      );
+      checkEqual(
+        retried.closes.length,
+        0,
+        "expected the reconnect to stay open",
       );
     },
   },

--- a/packages/collab-runtime/test/presence-room.test.ts
+++ b/packages/collab-runtime/test/presence-room.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_PRESENCE_ROOM_POLICY,
+  PRESENCE_FRAME,
   createPresenceRoom,
   type PresenceRoomOptions,
 } from "../src";
@@ -81,9 +82,99 @@ describe("createPresenceRoom metrics", () => {
     expect(metrics).toHaveBeenCalledWith({
       type: "message-error",
       errorKind: "Error",
-      messageType: "auth",
+      messageType: "auth-provider",
       roomId,
     });
+
+    await room.close();
+  });
+
+  it("reports an admission outage separately from a denied credential", async () => {
+    const roomId = "room-admission";
+    const metrics = vi.fn();
+    const room = createPresenceRoom(roomId, {
+      codec: createOpaqueTestCodec(),
+      connections: {
+        acquire: async () => {
+          throw new Error("lease store command timed out");
+        },
+      },
+      fanout: createMemoryPresenceFanout(),
+      metrics,
+      policy: DEFAULT_PRESENCE_ROOM_POLICY,
+      sessions: createStubPresenceSessionHooks(),
+      store: createMemoryPresenceStore(),
+    });
+
+    const peer = createRecordingPresencePeer("connection-1");
+    await room.join(peer);
+    await room.receive(
+      peer,
+      wire(TEST_PRESENCE_WIRE_TYPE.Auth, roomId, "connection-1", {
+        connectionId: "connection-1",
+        credential: { kind: "access-token", token: "test-token" },
+        userId: "user-1",
+      }),
+    );
+
+    // A lease store that never answered says nothing about membership, so
+    // the peer must not be told its credential was rejected.
+    expect(peer.sent).toEqual([
+      {
+        payload: {
+          message: "Presence authorization is temporarily unavailable",
+          retryable: true,
+        },
+        roomId,
+        senderId: "server",
+        type: PRESENCE_FRAME.AuthError,
+      },
+    ]);
+    expect(peer.closes).toEqual([
+      { code: 1011, reason: "Presence runtime unavailable" },
+    ]);
+    expect(metrics).toHaveBeenCalledWith({
+      type: "message-error",
+      errorKind: "Error",
+      messageType: "auth-admission",
+      roomId,
+    });
+
+    await room.close();
+  });
+
+  it("still denies an unparseable Auth frame without offering a retry", async () => {
+    const roomId = "room-malformed";
+    const room = createPresenceRoom(roomId, {
+      codec: createOpaqueTestCodec(),
+      connections: createMemoryConnectionLimiter(),
+      fanout: createMemoryPresenceFanout(),
+      policy: DEFAULT_PRESENCE_ROOM_POLICY,
+      sessions: createStubPresenceSessionHooks(),
+      store: createMemoryPresenceStore(),
+    });
+
+    const peer = createRecordingPresencePeer("connection-1");
+    await room.join(peer);
+    await room.receive(
+      peer,
+      wire(TEST_PRESENCE_WIRE_TYPE.Auth, roomId, "connection-1", {
+        connectionId: "connection-1",
+      }),
+    );
+
+    expect(peer.sent).toEqual([
+      {
+        payload: {
+          message: "Authentication or document membership failed",
+          retryable: false,
+        },
+        roomId,
+        senderId: "server",
+        type: PRESENCE_FRAME.AuthError,
+      },
+    ]);
+    expect(peer.closes).toEqual([{ code: 1008, reason: "Unauthorized" }]);
 
     await room.close();
   });


### PR DESCRIPTION
Fixes #.

## Changes proposed in this pull request

- **Separate auth failure modes**: Split the single `AUTH_ERROR` response into two distinct outcomes:
  - `retryable: false` for terminal failures (denied credential, malformed handshake) where reconnecting cannot help
  - `retryable: true` for transient outages (unavailable identity provider, lease store, or persistence) where reconnecting can succeed
  
- **Improve error handling in presence room**: Refactor `handleAuth` to distinguish between:
  - Parse errors and membership denials → close 1008 "Unauthorized" (terminal)
  - Provider/admission failures → close 1011 "Presence runtime unavailable" (retryable)
  
- **Fix client reconnect behavior**: Update the WebSocket adapter to only stop reconnecting on non-retryable auth errors, allowing recovery from temporary outages instead of leaving presence permanently in `error` state

- **Improve error diagnostics**: 
  - Add `supabaseQueryError` helper to wrap plain PostgREST result objects as proper `Error` instances so diagnoses survive logging
  - Update error serialization in both Nitro and Cloudflare hosts to handle non-Error throws structurally
  - Add documentation distinguishing the two auth-error modes and their server-side `messageType` indicators

- **Add comprehensive test coverage**: New tests verify both auth denial and outage scenarios, including recovery after a transient failure

## Test Plan

Added unit tests covering:
- Auth denial closes 1008 with non-retryable error message
- Provider unavailability closes 1011 with retryable error message  
- Client reconnects successfully after a transient auth outage
- Malformed Auth frames are denied without offering retry
- PostgREST error wrapping preserves diagnostic information

Existing conformance tests updated to verify the new `retryable` flag behavior.

https://claude.ai/code/session_01PzBDrCx2YydYGQJ1H7c2Ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved presence authentication handling by distinguishing permanent access denials from temporary service failures.
  * Added automatic reconnection for retryable authorization failures while preserving clear failure behavior for denied credentials.
  * Improved error messages and logging with contextual details from backend service failures.
  * Added safer handling for structured and non-standard errors.

* **Documentation**
  * Added troubleshooting guidance for presence connection failures, retry behavior, close codes, and authorization diagnostics.

* **Tests**
  * Expanded coverage for authentication failures, reconnection, recovery, error formatting, and service outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->