### PR TITLE
Fix Cloudflare presence authentication

### DIFF
--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -125,8 +125,13 @@ Nitro collaboration service, then run:
 
 ```bash
 pnpm --filter @softmaple/collab-cloudflare cf-typegen
-pnpm --filter @softmaple/collab-cloudflare dev
+pnpm exec turbo run dev --filter=@softmaple/collab-cloudflare
 ```
+
+Run the Worker through Turbo, as above, rather than invoking its package-level
+`dev` script directly. The Worker bundles compiled workspace-package exports;
+Turbo's `dev` dependency graph rebuilds those packages first, so a source
+change cannot be hidden by an older ignored `dist/` directory.
 
 Never expose the service-role key to browser code. For production, follow the
 atomic first-deploy or later-rotation procedure below; do not bootstrap a new
@@ -170,6 +175,9 @@ secrets with the real application deployment instead:
    together:
 
    ```bash
+   pnpm exec turbo run build \
+     --filter=@softmaple/collab-cloudflare... \
+     --filter=!@softmaple/collab-cloudflare
    pnpm --filter @softmaple/collab-cloudflare exec wrangler deploy \
      --secrets-file .dev.vars.production
    ```
@@ -189,8 +197,18 @@ secrets with the real application deployment instead:
 
 ### Later deployments and secret rotation
 
-Once the Worker exists, `pnpm --filter @softmaple/collab-cloudflare deploy`
-inherits its existing secrets and fails if a required binding is missing.
+Once the Worker exists, rebuild its workspace dependencies before deploying;
+the Worker bundles their compiled `dist/` exports rather than their source:
+
+```bash
+pnpm exec turbo run build \
+  --filter=@softmaple/collab-cloudflare... \
+  --filter=!@softmaple/collab-cloudflare
+pnpm --filter @softmaple/collab-cloudflare deploy
+```
+
+The deploy inherits its existing secrets and fails if a required binding is
+missing.
 
 For a controlled rotation, use `wrangler versions secret put <NAME>` (or
 `wrangler versions secret bulk <FILE>` for several values) to create an
@@ -234,6 +252,9 @@ for that procedure and how the two levels relate.
 ## Verification
 
 ```bash
+pnpm exec turbo run build \
+  --filter=@softmaple/collab-cloudflare... \
+  --filter=!@softmaple/collab-cloudflare
 pnpm --filter @softmaple/collab-cloudflare test
 pnpm --filter @softmaple/collab-cloudflare typecheck
 pnpm --filter @softmaple/collab-cloudflare lint

--- a/apps/collab-cloudflare/src/constants.ts
+++ b/apps/collab-cloudflare/src/constants.ts
@@ -39,6 +39,37 @@ export const errorMessage = (
   retryable,
 });
 
+const MAX_LOG_ERROR_FIELD_LENGTH = 2_048;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const boundedString = (value: unknown): string | null =>
+  typeof value === "string" ? value.slice(0, MAX_LOG_ERROR_FIELD_LENGTH) : null;
+
+const serializeError = (error: unknown): Readonly<Record<string, string>> => {
+  const record = isRecord(error) ? error : null;
+  const message =
+    error instanceof Error
+      ? error.message
+      : (boundedString(record?.message) ?? String(error));
+  const name =
+    error instanceof Error
+      ? error.name
+      : (boundedString(record?.name) ?? "UnknownError");
+  const code = boundedString(record?.code);
+  const details = boundedString(record?.details);
+  const hint = boundedString(record?.hint);
+
+  return {
+    error: message.slice(0, MAX_LOG_ERROR_FIELD_LENGTH),
+    errorName: name,
+    ...(code === null ? {} : { errorCode: code }),
+    ...(details === null ? {} : { errorDetails: details }),
+    ...(hint === null ? {} : { errorHint: hint }),
+  };
+};
+
 export const logError = (
   error: unknown,
   context: Readonly<Record<string, unknown>>,
@@ -46,8 +77,7 @@ export const logError = (
   console.error(
     JSON.stringify({
       ...context,
-      error: error instanceof Error ? error.message : String(error),
-      errorName: error instanceof Error ? error.name : "UnknownError",
+      ...serializeError(error),
       message: "Cloudflare collaboration request failed",
     }),
   );

--- a/apps/collab-cloudflare/src/constants.ts
+++ b/apps/collab-cloudflare/src/constants.ts
@@ -63,7 +63,7 @@ const serializeError = (error: unknown): Readonly<Record<string, string>> => {
 
   return {
     error: message.slice(0, MAX_LOG_ERROR_FIELD_LENGTH),
-    errorName: name,
+    errorName: name.slice(0, MAX_LOG_ERROR_FIELD_LENGTH),
     ...(code === null ? {} : { errorCode: code }),
     ...(details === null ? {} : { errorDetails: details }),
     ...(hint === null ? {} : { errorHint: hint }),

--- a/apps/collab-cloudflare/test/constants.test.ts
+++ b/apps/collab-cloudflare/test/constants.test.ts
@@ -48,4 +48,36 @@ describe("logError", () => {
       message: "Cloudflare collaboration request failed",
     });
   });
+
+  it("logs safe PostgREST error fields without serializing credentials", () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    logError(
+      {
+        code: "42501",
+        details: "Data API role lacks SELECT",
+        hint: "Grant the required table privilege",
+        message: "permission denied for table users",
+        token: "must-not-be-logged",
+      },
+      { messageType: "auth" },
+    );
+
+    const logged = JSON.parse(error.mock.calls[0]?.[0] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(logged).toMatchObject({
+      error: "permission denied for table users",
+      errorCode: "42501",
+      errorDetails: "Data API role lacks SELECT",
+      errorHint: "Grant the required table privilege",
+      errorName: "UnknownError",
+      message: "Cloudflare collaboration request failed",
+      messageType: "auth",
+    });
+    expect(logged).not.toHaveProperty("token");
+  });
 });

--- a/apps/collab-cloudflare/test/document-presence-isolation.test.ts
+++ b/apps/collab-cloudflare/test/document-presence-isolation.test.ts
@@ -18,7 +18,10 @@ import { evictAllDurableObjects, runInDurableObject } from "cloudflare:test";
 import { env, exports } from "cloudflare:workers";
 import { afterEach, describe, expect, it } from "vitest";
 import { setMemoryAuthenticatedAccessRevoked } from "./memory-backend";
-import { setMemoryPresenceAccessRevoked } from "./memory-presence-backend";
+import {
+  setMemoryPresenceAccessRevoked,
+  TEST_PRESENCE_ACCESS_TOKEN,
+} from "./memory-presence-backend";
 
 const ORIGIN = "https://app.example";
 
@@ -108,7 +111,7 @@ const authenticatePresence = async (
         capabilities: PRESENCE_CAPABILITIES,
         connectionId: "isolation-presence-connection",
         protocolVersion: PRESENCE_PROTOCOL_VERSION,
-        token: "test-token",
+        token: TEST_PRESENCE_ACCESS_TOKEN,
         userId: "00000000-0000-4000-8000-000000000002",
       },
       roomId,

--- a/apps/collab-cloudflare/test/memory-presence-backend.ts
+++ b/apps/collab-cloudflare/test/memory-presence-backend.ts
@@ -9,7 +9,14 @@ import type {
 import type { PresenceBackend } from "../src/supabase-presence-backend";
 
 const TEST_ACTOR_ID = "00000000-0000-4000-8000-000000000002";
-const TEST_ACCESS_TOKEN = "test-token";
+/**
+ * Keep the Worker integration path on a realistic Supabase JWT length. This
+ * catches stale @softmaple/awareness builds that still apply the 256-character
+ * wire-identifier limit to credentials.
+ */
+export const TEST_PRESENCE_ACCESS_TOKEN = `${"h".repeat(40)}.${"p".repeat(
+  900,
+)}.${"s".repeat(43)}`;
 const TEST_IDENTITY: PresenceIdentity = {
   name: "Ada Lovelace",
   userId: TEST_ACTOR_ID,
@@ -161,7 +168,7 @@ const identityForCredential = (
   state: StoredAuthorizationState,
 ): PresenceIdentity | null => {
   if (state.revoked || credential.kind !== "access-token") return null;
-  if (credential.token !== TEST_ACCESS_TOKEN) return null;
+  if (credential.token !== TEST_PRESENCE_ACCESS_TOKEN) return null;
   if (claimedUserId !== TEST_ACTOR_ID) return null;
   return TEST_IDENTITY;
 };

--- a/apps/collab-cloudflare/test/presence-room-do.test.ts
+++ b/apps/collab-cloudflare/test/presence-room-do.test.ts
@@ -14,11 +14,12 @@ import { normalizeDocumentId } from "../src/document-id";
 import {
   readMemoryPresenceSessionAudit,
   setMemoryPresenceAccessRevoked,
+  TEST_PRESENCE_ACCESS_TOKEN,
 } from "./memory-presence-backend";
 
 const ORIGIN = "https://app.example";
 const TEST_USER_ID = "00000000-0000-4000-8000-000000000002";
-const TEST_TOKEN = "test-token";
+const TEST_TOKEN = TEST_PRESENCE_ACCESS_TOKEN;
 
 interface PresenceWireFrame {
   readonly type: string;

--- a/packages/db/prisma/migrations/20260813101534_grant_cloudflare_presence_profile_read/migration.sql
+++ b/packages/db/prisma/migrations/20260813101534_grant_cloudflare_presence_profile_read/migration.sql
@@ -1,0 +1,7 @@
+-- Presence authorization resolves the authenticated member's display profile
+-- through Supabase's Data API. Data API grants are independent of RLS bypass,
+-- so service_role needs explicit access to every selected/filter column.
+GRANT SELECT (id, full_name, avatar_src)
+    ON TABLE public.users TO service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/db/supabase/scripts/verify-collab-security.sql
+++ b/packages/db/supabase/scripts/verify-collab-security.sql
@@ -13,7 +13,8 @@ BEGIN
             ('20260808230300_harden_auth_profile_trigger'),
             ('20260808230400_fix_workspace_owner_membership_rls'),
             ('20260809000000_core_v1'),
-            ('20260811043830_add_cloudflare_collab_rpc')
+            ('20260811043830_add_cloudflare_collab_rpc'),
+            ('20260813101534_grant_cloudflare_presence_profile_read')
     )
     SELECT string_agg(expected.migration_name, ', ' ORDER BY migration_name)
     INTO missing_migrations
@@ -259,8 +260,14 @@ BEGIN
         'service_role', 'public.documents', 'updated_by', 'UPDATE'
     ) OR NOT has_column_privilege(
         'service_role', 'public.workspace_members', 'updated_at', 'UPDATE'
+    ) OR NOT has_column_privilege(
+        'service_role', 'public.users', 'id', 'SELECT'
+    ) OR NOT has_column_privilege(
+        'service_role', 'public.users', 'full_name', 'SELECT'
+    ) OR NOT has_column_privilege(
+        'service_role', 'public.users', 'avatar_src', 'SELECT'
     ) THEN
-        RAISE EXCEPTION 'collaboration RPC grants are unsafe';
+        RAISE EXCEPTION 'collaboration RPC or presence grants are unsafe';
     END IF;
 
     IF NOT EXISTS (


### PR DESCRIPTION
## Summary

- grant `service_role` the minimum `public.users` column privileges required by Cloudflare presence authorization
- verify the new migration and presence profile grants in the collaboration security check
- preserve JWT-length authentication coverage in Durable Object integration tests
- log bounded PostgREST error fields without serializing credentials
- document dependency-first Turbo builds so stale workspace `dist` output cannot regress token parsing

## Root cause

Presence authorization added a Supabase Data API query for `public.users`, but the Cloudflare collaboration grants only covered documents, workspace memberships, and event tables. On projects using explicit Data API grants, the profile lookup returned a PostgREST permission error that the Worker serialized as `[object Object]`.

## Tests

- `apps/collab-cloudflare: ./node_modules/.bin/vitest run --max-workers=1 --no-isolate` (41 tests)
- `apps/collab-cloudflare: ./node_modules/.bin/tsc --noEmit`
- `apps/collab-cloudflare: ./node_modules/.bin/tsc --noEmit -p test/tsconfig.json`
- ESLint on all changed TypeScript files
- `packages/db: ./node_modules/.bin/prisma validate`
- `apps/collab-cloudflare: ./node_modules/.bin/wrangler deploy --dry-run --outdir=dist`
- `git diff --check`

## Screenshots

Not applicable; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error logging to safely handle structured errors, limit excessive details, and exclude credential-like data.
  - Improved presence-related access to user profile details used during collaboration.
- **Documentation**
  - Updated local development, deployment, and verification instructions to build required packages automatically.
- **Tests**
  - Expanded coverage for secure error logging, presence authentication, and collaboration access isolation.
  - Added verification for required permissions and profile fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->