### PR TITLE
feat(apps/web,apps/playground): unify brand shell and polish playground demo

### DIFF
--- a/apps/playground/public/manifest.json
+++ b/apps/playground/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "TanStack App",
-  "name": "Create TanStack App Sample",
+  "short_name": "SoftMaple",
+  "name": "SoftMaple Playground",
   "icons": [
     {
       "src": "favicon.ico",
@@ -20,6 +20,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#050505",
+  "background_color": "#050505"
 }

--- a/apps/playground/src/components/Header.tsx
+++ b/apps/playground/src/components/Header.tsx
@@ -2,6 +2,7 @@ import {
   Sheet,
   SheetClose,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
@@ -36,7 +37,7 @@ export default function Header() {
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
         <Link
           to="/"
-          className="font-[family-name:var(--font-display)] text-lg font-bold tracking-[-0.03em] text-[var(--pg-ink)]"
+          className="pg-focus-ring rounded-sm font-[family-name:var(--font-display)] text-lg font-bold tracking-[-0.03em] text-[var(--pg-ink)] active:translate-y-px"
         >
           SoftMaple
           <span className="ml-1.5 font-normal text-[var(--pg-ink-muted)]">
@@ -48,7 +49,7 @@ export default function Header() {
           {isHome ? (
             <button
               type="button"
-              className="text-sm text-[var(--pg-ink-muted)] transition-colors hover:text-[var(--pg-ink)]"
+              className="pg-focus-ring rounded-sm px-1 py-2 text-sm text-[var(--pg-ink-muted)] transition-colors hover:text-[var(--pg-ink)] active:translate-y-px"
               onClick={() => {
                 document.getElementById("demos")?.scrollIntoView({
                   behavior: reduceMotion ? "auto" : "smooth",
@@ -61,7 +62,7 @@ export default function Header() {
             <Link
               to="/"
               hash="demos"
-              className="text-sm text-[var(--pg-ink-muted)] transition-colors hover:text-[var(--pg-ink)]"
+              className="pg-focus-ring rounded-sm px-1 py-2 text-sm text-[var(--pg-ink-muted)] transition-colors hover:text-[var(--pg-ink)] active:translate-y-px"
             >
               Demos
             </Link>
@@ -70,14 +71,14 @@ export default function Header() {
             href="https://docs.softmaple.ink"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-[var(--pg-ink-muted)] transition-colors hover:text-[var(--pg-ink)]"
+            className="pg-focus-ring rounded-sm px-1 py-2 text-sm text-[var(--pg-ink-muted)] transition-colors hover:text-[var(--pg-ink)] active:translate-y-px"
           >
             Docs
           </a>
           {!isHome ? (
             <Link
               to="/demo/lexical-eg-walker"
-              className="bg-[var(--pg-ink)] px-3.5 py-1.5 text-sm font-medium text-[var(--pg-paper)] transition-opacity hover:opacity-90"
+              className="pg-focus-ring bg-[var(--pg-ink)] px-3.5 py-2 text-sm font-medium text-[var(--pg-paper)] transition-opacity hover:opacity-90 active:translate-y-px"
             >
               Open Lexical demo
             </Link>
@@ -88,7 +89,7 @@ export default function Header() {
           <SheetTrigger asChild>
             <button
               type="button"
-              className="rounded-sm p-2 text-[var(--pg-ink)] transition-colors hover:bg-[var(--pg-elevated)] md:hidden"
+              className="pg-focus-ring min-h-11 min-w-11 rounded-sm p-2 text-[var(--pg-ink)] transition-colors hover:bg-[var(--pg-elevated)] active:translate-y-px md:hidden"
               aria-label="Open menu"
             >
               <Menu size={22} />
@@ -102,6 +103,9 @@ export default function Header() {
               <SheetTitle className="font-[family-name:var(--font-display)] font-semibold tracking-[-0.02em] text-[var(--pg-ink)]">
                 Navigate
               </SheetTitle>
+              <SheetDescription className="sr-only">
+                Browse Playground demos and documentation.
+              </SheetDescription>
             </SheetHeader>
 
             <nav className="flex-1 overflow-y-auto p-4">
@@ -124,7 +128,7 @@ export default function Header() {
                   <SheetClose asChild>
                     <Link
                       to="/"
-                      className="mb-1 block rounded-sm px-3 py-2.5 text-sm font-medium hover:bg-[var(--pg-elevated)]"
+                      className="pg-focus-ring mb-1 block rounded-sm px-3 py-2.5 text-sm font-medium hover:bg-[var(--pg-elevated)] active:translate-y-px"
                     >
                       Home
                     </Link>
@@ -141,7 +145,7 @@ export default function Header() {
                     <SheetClose asChild>
                       <Link
                         to={demo.link}
-                        className="mb-1 block rounded-sm px-3 py-2.5 text-sm hover:bg-[var(--pg-elevated)]"
+                        className="pg-focus-ring mb-1 block rounded-sm px-3 py-2.5 text-sm hover:bg-[var(--pg-elevated)] active:translate-y-px"
                       >
                         <span className="font-[family-name:var(--font-mono)] text-[10px] text-[var(--pg-ink-muted)]">
                           {demo.id}
@@ -164,7 +168,7 @@ export default function Header() {
                       href="https://docs.softmaple.ink"
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="mt-4 block rounded-sm border border-[var(--pg-line)] px-3 py-2.5 text-sm font-medium"
+                      className="pg-focus-ring mt-4 block rounded-sm border border-[var(--pg-line)] px-3 py-2.5 text-sm font-medium hover:border-[var(--pg-ink-muted)] hover:bg-[var(--pg-elevated)] active:translate-y-px"
                     >
                       Documentation
                     </a>

--- a/apps/playground/src/components/demo/DemoPageShell.tsx
+++ b/apps/playground/src/components/demo/DemoPageShell.tsx
@@ -44,12 +44,12 @@ export function DemoPageShell({
               </div>
             ) : null}
           </div>
-          <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <div className="pg-action-cluster flex shrink-0 flex-wrap items-center gap-2">
             {actions}
             {showBackLink ? (
               <Link
                 to="/"
-                className="inline-flex items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-elevated)] px-3 py-2 text-xs font-semibold text-[var(--pg-ink-muted)] transition-colors hover:border-[var(--pg-ink-muted)] hover:text-[var(--pg-ink)]"
+                className="pg-focus-ring inline-flex min-h-11 items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-elevated)] px-3 py-2 text-xs font-semibold text-[var(--pg-ink-muted)] transition-colors hover:border-[var(--pg-ink-muted)] hover:text-[var(--pg-ink)] active:translate-y-px"
               >
                 <ArrowLeft className="size-3.5" aria-hidden />
                 Playground

--- a/apps/playground/src/components/home/DemoList.tsx
+++ b/apps/playground/src/components/home/DemoList.tsx
@@ -1,12 +1,28 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowUpRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
 import { demos } from "@/lib/demos";
 
 const spring = { type: "spring" as const, stiffness: 320, damping: 30 };
 
 export function DemoList() {
   const reduceMotion = useReducedMotion();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setReady(true);
+  }, []);
+
+  const reveal = (index: number) =>
+    !ready || reduceMotion
+      ? {}
+      : {
+          initial: { opacity: 0, y: 16 },
+          whileInView: { opacity: 1, y: 0 },
+          viewport: { once: true, margin: "-40px" },
+          transition: { ...spring, delay: index * 0.04 },
+        };
 
   return (
     <section id="demos" className="mx-auto max-w-6xl px-6 py-20 md:py-28">
@@ -22,18 +38,12 @@ export function DemoList() {
 
       <ul className="divide-y divide-[var(--pg-line)] border-y border-[var(--pg-line)]">
         {demos.map((demo, index) => (
-          <motion.li
-            key={demo.id}
-            initial={reduceMotion ? false : { opacity: 0, y: 16 }}
-            whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: "-40px" }}
-            transition={{ ...spring, delay: index * 0.04 }}
-          >
+          <motion.li key={demo.id} {...reveal(index)}>
             <Link
               to={demo.link}
-              className="group relative flex flex-col gap-4 py-7 transition-colors md:flex-row md:items-start md:gap-8 md:py-9"
+              className="pg-focus-ring group relative flex flex-col gap-4 py-7 transition-[transform,color] active:translate-y-px md:flex-row md:items-start md:gap-8 md:py-9"
             >
-              <span className="absolute inset-x-[-1rem] inset-y-0 -z-10 rounded-sm bg-[var(--pg-elevated)] opacity-0 transition-opacity duration-200 group-hover:opacity-100 md:inset-x-[-1.5rem]" />
+              <span className="absolute inset-x-[-1rem] inset-y-0 -z-10 rounded-sm bg-[var(--pg-elevated)] opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100 md:inset-x-[-1.5rem]" />
 
               <span className="font-[family-name:var(--font-mono)] text-sm text-[var(--pg-ink-muted)] tabular-nums">
                 {demo.id}
@@ -61,7 +71,7 @@ export function DemoList() {
               </div>
 
               <span
-                className="inline-flex h-10 w-10 shrink-0 items-center justify-center border border-[var(--pg-line)] text-[var(--pg-ink)] transition-all duration-200 group-hover:border-[var(--pg-ink)] group-hover:bg-[var(--pg-ink)] group-hover:text-[var(--pg-paper)] group-hover:scale-105"
+                className="inline-flex h-11 w-11 shrink-0 items-center justify-center border border-[var(--pg-line)] text-[var(--pg-ink)] transition-all duration-200 group-hover:scale-105 group-hover:border-[var(--pg-ink)] group-hover:bg-[var(--pg-ink)] group-hover:text-[var(--pg-paper)] group-focus-visible:scale-105 group-focus-visible:border-[var(--pg-ink)] group-focus-visible:bg-[var(--pg-ink)] group-focus-visible:text-[var(--pg-paper)]"
                 aria-hidden
               >
                 <ArrowUpRight size={18} />

--- a/apps/playground/src/env.ts
+++ b/apps/playground/src/env.ts
@@ -25,6 +25,8 @@ export const env = createEnv({
 
   client: {
     VITE_APP_TITLE: z.string().min(1).optional(),
+    /** Explicit opt-in for the floating TanStack development tools. */
+    VITE_PLAYGROUND_DEVTOOLS: z.enum(["true", "false"]).optional(),
     /** `websocket` (default) or `broadcast` for Lexical / online collab demos */
     VITE_COLLAB_TRANSPORT: z.enum(["websocket", "broadcast"]).optional(),
     /** Override document-sync WebSocket base URL (no roomId query) */

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalDocumentCanvas.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalDocumentCanvas.tsx
@@ -1,0 +1,119 @@
+import type { InitialConfigType } from "@lexical/react/LexicalComposer";
+import type {
+  LexicalBinding,
+  StableBlockSelection,
+} from "@softmaple/binding-lexical";
+import { LexicalEgWalkerPlugin } from "@softmaple/binding-lexical/react";
+import { CoreEditor } from "@softmaple/editor/components/core/CoreEditor";
+import type { LexicalEditor } from "lexical";
+import { ShieldCheck } from "lucide-react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import type { RoomPresence } from "./presence";
+import { RemoteSelectionLayer } from "./RemoteSelectionLayer";
+import type { LexicalRoomState } from "./useLexicalRoom";
+
+interface LexicalDocumentCanvasProps {
+  readonly activeEditor: LexicalEditor | undefined;
+  readonly binding: LexicalBinding | null;
+  readonly editorHostRef: RefObject<HTMLDivElement | null>;
+  readonly lexicalConfig: InitialConfigType;
+  readonly onBindingChange: (binding: LexicalBinding | null) => void;
+  readonly onBindingError: (error: Error) => void;
+  readonly onSelectionChange: (selection: StableBlockSelection | null) => void;
+  readonly presence: RoomPresence;
+  readonly replica: LexicalRoomState["replica"];
+  readonly sessionKey: string;
+  readonly setActiveEditor: Dispatch<SetStateAction<LexicalEditor | undefined>>;
+  readonly visibleError: Error | null;
+}
+
+export function LexicalDocumentCanvas({
+  activeEditor,
+  binding,
+  editorHostRef,
+  lexicalConfig,
+  onBindingChange,
+  onBindingError,
+  onSelectionChange,
+  presence,
+  replica,
+  sessionKey,
+  setActiveEditor,
+  visibleError,
+}: LexicalDocumentCanvasProps) {
+  return (
+    <section className="relative mx-auto flex w-full max-w-[1280px] flex-1 px-3 pb-3 md:px-8 md:pb-8">
+      <div className="pg-panel relative flex min-h-[620px] w-full flex-col overflow-hidden">
+        <div className="pg-panel-header flex items-center justify-between px-4 py-2 font-[family-name:var(--font-mono)] text-[10px] font-medium tracking-[0.14em] text-[var(--pg-ink-muted)] uppercase">
+          <span>Collaborative manuscript</span>
+          <span className="inline-flex items-center gap-1.5 text-teal-400">
+            <ShieldCheck className="size-3.5" aria-hidden />
+            v1 schema
+          </span>
+        </div>
+
+        {replica === null ? (
+          <div
+            className="grid flex-1 place-items-center p-8 text-center"
+            data-testid="lexical-room-loading"
+          >
+            <div>
+              <div className="mx-auto mb-4 flex size-10 items-center justify-center border border-[var(--pg-line)] bg-[var(--pg-paper)]">
+                <span className="size-2 bg-[var(--pg-accent)] motion-safe:animate-pulse" />
+              </div>
+              <p className="font-[family-name:var(--font-display)] text-lg font-semibold">
+                Replaying the room history…
+              </p>
+              <p className="mt-1 text-xs text-[var(--pg-ink-muted)]">
+                Editing opens after the first converged document is ready.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div
+            ref={editorHostRef}
+            className="relative flex-1"
+            data-testid="lexical-room-ready"
+          >
+            <CoreEditor
+              key={sessionKey}
+              activeEditor={activeEditor}
+              setActiveEditor={setActiveEditor}
+              historyMode="disabled"
+              lexicalConfig={lexicalConfig}
+              layoutClassName="pg-lexical-editor mx-0 my-0 max-w-none min-h-full font-normal leading-[1.7] [&_.flex-auto]:w-full [&_.flex-auto]:flex-1 [&_[contenteditable=true]]:min-h-[500px] [&_[contenteditable=true]]:w-full [&_[contenteditable=true]]:px-6 [&_[contenteditable=true]]:py-8 [&_[aria-hidden=true]>div]:left-6 [&_[aria-hidden=true]>div]:right-6 [&_[aria-hidden=true]>div]:top-8 md:[&_[contenteditable=true]]:min-h-[520px] md:[&_[contenteditable=true]]:px-14 md:[&_[contenteditable=true]]:py-12 md:[&_[aria-hidden=true]>div]:left-14 md:[&_[aria-hidden=true]>div]:right-14 md:[&_[aria-hidden=true]>div]:top-12"
+            >
+              <LexicalEgWalkerPlugin
+                replica={replica}
+                onBindingChange={onBindingChange}
+                onError={onBindingError}
+                onSelectionChange={onSelectionChange}
+              />
+            </CoreEditor>
+            <RemoteSelectionLayer
+              binding={binding}
+              hostRef={editorHostRef}
+              selfId={presence.identity.userId}
+              users={presence.users}
+            />
+          </div>
+        )}
+
+        <div className="pg-panel-footer flex items-center justify-between gap-3 px-4 py-2 font-[family-name:var(--font-mono)] text-[9px] tracking-[0.12em] text-[var(--pg-ink-muted)] uppercase">
+          <span>Rich text · real-time · local first</span>
+          <span className="hidden text-teal-400 sm:inline">
+            Stable sequence anchors
+          </span>
+        </div>
+        {visibleError !== null ? (
+          <div
+            role="alert"
+            className="border-t border-rose-400/25 bg-rose-500/10 px-4 py-2 text-xs text-rose-300"
+          >
+            {visibleError.message}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalDocumentHeader.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalDocumentHeader.tsx
@@ -1,0 +1,38 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft, GitFork } from "lucide-react";
+import type { LexicalCollabTransportMode } from "./transport";
+
+interface LexicalDocumentHeaderProps {
+  readonly transportMode: LexicalCollabTransportMode;
+}
+
+export function LexicalDocumentHeader({
+  transportMode,
+}: LexicalDocumentHeaderProps) {
+  return (
+    <header className="mx-auto flex w-full max-w-[1280px] items-start justify-between gap-4 px-4 pt-5 pb-4 md:px-8 md:pt-7 md:pb-5">
+      <div className="min-w-0">
+        <div className="mb-1.5 flex items-center gap-2 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.18em] text-[var(--pg-accent)] uppercase">
+          <GitFork className="size-3.5" aria-hidden />
+          Causal canvas ·{" "}
+          {transportMode === "websocket" ? "WebSocket" : "local first"}
+        </div>
+        <h1 className="font-[family-name:var(--font-display)] text-2xl leading-tight font-bold tracking-[-0.03em] md:text-4xl">
+          EG-walker × Lexical
+        </h1>
+        <p className="mt-1.5 max-w-2xl text-xs leading-relaxed text-[var(--pg-ink-muted)] md:text-sm">
+          {transportMode === "websocket"
+            ? "One document across browsers. Document events and presence sync over WebSocket; a local copy remains on this device."
+            : "One document, any number of tabs. Changes converge through stable sequence anchors and remain on this device after every tab closes. Add ?transport=websocket for cross-browser sync."}
+        </p>
+      </div>
+      <Link
+        to="/"
+        className="pg-focus-ring hidden min-h-11 shrink-0 items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-elevated)] px-3 text-xs font-semibold text-[var(--pg-ink-muted)] transition-colors hover:border-[var(--pg-ink-muted)] hover:text-[var(--pg-ink)] active:translate-y-px md:inline-flex"
+      >
+        <ArrowLeft className="size-3.5" aria-hidden />
+        Playground
+      </Link>
+    </header>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
@@ -2,11 +2,8 @@ import type {
   LexicalBinding,
   StableBlockSelection,
 } from "@softmaple/binding-lexical";
-import { LexicalEgWalkerPlugin } from "@softmaple/binding-lexical/react";
-import { CoreEditor } from "@softmaple/editor/components/core/CoreEditor";
 import { LEXICAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
 import type { LexicalEditor } from "lexical";
-import { ArrowLeft, GitFork, ShieldCheck } from "lucide-react";
 import {
   type SetStateAction,
   useCallback,
@@ -15,13 +12,15 @@ import {
   useRef,
   useState,
 } from "react";
+import { LexicalDocumentCanvas } from "./LexicalDocumentCanvas";
+import { LexicalDocumentHeader } from "./LexicalDocumentHeader";
+import { LexicalPresenceRail } from "./LexicalPresenceRail";
+import { LexicalWorkspaceChrome } from "./LexicalWorkspaceChrome";
 import { useRoomPresence } from "./presence";
-import { RemoteSelectionLayer } from "./RemoteSelectionLayer";
 import { createRoomId, resolveRoomId } from "./room";
 import {
   mergeConnectionStates,
   type PersistenceDisplayState,
-  StatusRail,
 } from "./StatusRail";
 import { toPresenceSelection, useLexicalRoom } from "./useLexicalRoom";
 
@@ -125,7 +124,7 @@ export function LexicalEgWalkerDemo({
 
   return (
     <main
-      className="flex min-h-[100svh] flex-col overflow-hidden bg-[var(--pg-paper)] text-[var(--pg-ink)]"
+      className="flex min-h-[100svh] flex-col overflow-x-hidden bg-[var(--pg-paper)] text-[var(--pg-ink)]"
       data-testid="lexical-eg-walker-demo"
       data-room-id={roomId}
       data-transport={presence.transportMode}
@@ -134,8 +133,9 @@ export function LexicalEgWalkerDemo({
       data-persistence-leader={room.persistence?.leader.status ?? "stopped"}
       data-storage-bytes={room.persistence?.storageBytes ?? 0}
     >
-      <StatusRail
+      <LexicalWorkspaceChrome
         roomId={roomId}
+        identity={presence.identity}
         connectionState={mergeConnectionStates(
           presence.connectionState,
           room.persistence?.syncConnectionState,
@@ -148,98 +148,29 @@ export function LexicalEgWalkerDemo({
         onCopyRoomLink={copyRoomLink}
       />
 
-      <header className="flex items-start justify-between gap-4 px-4 pt-4 pb-3 md:px-8 md:pt-6 md:pb-4">
-        <div className="min-w-0">
-          <div className="mb-1.5 flex items-center gap-2 font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.18em] text-[var(--pg-accent)] uppercase">
-            <GitFork className="size-3.5" />
-            Causal canvas ·{" "}
-            {presence.transportMode === "websocket"
-              ? "WebSocket"
-              : "local first"}
-          </div>
-          <h1 className="font-[family-name:var(--font-display)] text-2xl leading-tight font-bold tracking-[-0.03em] md:text-3xl">
-            EG-walker × Lexical
-          </h1>
-          <p className="mt-1 max-w-xl text-xs leading-relaxed text-[var(--pg-ink-muted)] md:text-sm">
-            {presence.transportMode === "websocket"
-              ? "One document across browsers. Document events and presence sync over WebSocket; a local copy remains on this device."
-              : "One document, any number of tabs. Changes converge through stable sequence anchors and remain on this device after every tab closes. Add ?transport=websocket for cross-browser sync."}
-          </p>
+      <div className="flex min-h-0 flex-1">
+        <LexicalPresenceRail
+          selfId={presence.identity.userId}
+          users={presence.users}
+        />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <LexicalDocumentHeader transportMode={presence.transportMode} />
+          <LexicalDocumentCanvas
+            activeEditor={activeEditor}
+            binding={binding}
+            editorHostRef={editorHostRef}
+            lexicalConfig={lexicalConfig}
+            onBindingChange={updateBinding}
+            onBindingError={reportBindingError}
+            onSelectionChange={updatePresenceSelection}
+            presence={presence}
+            replica={room.replica}
+            sessionKey={sessionKey}
+            setActiveEditor={setActiveEditor}
+            visibleError={visibleError}
+          />
         </div>
-        <a
-          href="/"
-          className="inline-flex shrink-0 items-center gap-1.5 border border-[var(--pg-line)] bg-[var(--pg-elevated)] px-2.5 py-2 text-xs font-semibold text-[var(--pg-ink-muted)] outline-none transition-colors hover:border-[var(--pg-ink-muted)] hover:text-[var(--pg-ink)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
-        >
-          <ArrowLeft className="size-3.5" />
-          <span className="hidden sm:inline">Playground</span>
-        </a>
-      </header>
-
-      <section className="relative mx-auto flex w-full max-w-[1120px] flex-1 px-3 pb-3 md:px-8 md:pb-8">
-        <div className="pg-panel relative flex min-h-[540px] w-full flex-col overflow-hidden">
-          <div className="pg-panel-header flex items-center justify-between px-4 py-2 font-[family-name:var(--font-mono)] text-[10px] font-medium tracking-[0.14em] text-[var(--pg-ink-muted)] uppercase">
-            <span>Collaborative manuscript</span>
-            <span className="inline-flex items-center gap-1.5 text-teal-400">
-              <ShieldCheck className="size-3.5" />
-              v1 schema
-            </span>
-          </div>
-          {room.replica === null ? (
-            <div
-              className="grid flex-1 place-items-center p-8 text-center"
-              data-testid="lexical-room-loading"
-            >
-              <div>
-                <div className="mx-auto mb-4 flex size-10 items-center justify-center border border-[var(--pg-line)] bg-[var(--pg-paper)]">
-                  <span className="size-2 bg-[var(--pg-accent)] motion-safe:animate-pulse" />
-                </div>
-                <p className="font-[family-name:var(--font-display)] text-lg font-semibold">
-                  Replaying the room history…
-                </p>
-                <p className="mt-1 text-xs text-[var(--pg-ink-muted)]">
-                  Editing opens after the first converged document is ready.
-                </p>
-              </div>
-            </div>
-          ) : (
-            <div
-              ref={editorHostRef}
-              className="relative flex-1"
-              data-testid="lexical-room-ready"
-            >
-              <CoreEditor
-                key={sessionKey}
-                activeEditor={activeEditor}
-                setActiveEditor={setActiveEditor}
-                historyMode="disabled"
-                lexicalConfig={lexicalConfig}
-                layoutClassName="mx-0 my-0 max-w-none min-h-full font-normal leading-[1.7] [&_.flex-auto]:w-full [&_.flex-auto]:flex-1 [&_[contenteditable=true]]:min-h-[440px] [&_[contenteditable=true]]:w-full [&_[contenteditable=true]]:px-6 [&_[contenteditable=true]]:py-8 [&_[aria-hidden=true]>div]:left-6 [&_[aria-hidden=true]>div]:right-6 [&_[aria-hidden=true]>div]:top-8 md:[&_[contenteditable=true]]:px-14 md:[&_[contenteditable=true]]:py-12 md:[&_[aria-hidden=true]>div]:left-14 md:[&_[aria-hidden=true]>div]:right-14 md:[&_[aria-hidden=true]>div]:top-12"
-              >
-                <LexicalEgWalkerPlugin
-                  replica={room.replica}
-                  onBindingChange={updateBinding}
-                  onError={reportBindingError}
-                  onSelectionChange={updatePresenceSelection}
-                />
-              </CoreEditor>
-              <RemoteSelectionLayer
-                binding={binding}
-                hostRef={editorHostRef}
-                selfId={presence.identity.userId}
-                users={presence.users}
-              />
-            </div>
-          )}
-          {visibleError !== null ? (
-            <div
-              role="alert"
-              className="border-t border-rose-400/25 bg-rose-500/10 px-4 py-2 text-xs text-rose-300"
-            >
-              {visibleError.message}
-            </div>
-          ) : null}
-        </div>
-      </section>
+      </div>
     </main>
   );
 }

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalEgWalkerDemo.tsx
@@ -75,10 +75,10 @@ export function LexicalEgWalkerDemo({
     window.history.replaceState(null, "", url);
   }, [requestedRoom, roomId]);
 
-  const copyRoomLink = useCallback(() => {
+  const copyRoomLink = useCallback(async () => {
     const url = new URL(window.location.href);
     url.searchParams.set("room", roomId);
-    void navigator.clipboard?.writeText(url.toString()).catch(() => undefined);
+    await navigator.clipboard.writeText(url.toString());
   }, [roomId]);
   const updatePresenceSelection = useCallback(
     (selection: StableBlockSelection | null) => {

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalPresenceRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalPresenceRail.tsx
@@ -1,0 +1,71 @@
+import type { PresenceUser } from "@softmaple/awareness";
+import { MousePointer2, Users } from "lucide-react";
+
+interface LexicalPresenceRailProps {
+  readonly selfId: string;
+  readonly users: ReadonlyArray<PresenceUser>;
+}
+
+const initials = (name: string): string => name.slice(0, 2).toUpperCase();
+
+export function LexicalPresenceRail({
+  selfId,
+  users,
+}: LexicalPresenceRailProps) {
+  return (
+    <aside
+      className="hidden w-52 shrink-0 flex-col border-r border-[var(--pg-line)] bg-[var(--pg-surface)]/35 px-4 py-5 lg:flex"
+      aria-label="Room presence"
+    >
+      <p className="font-[family-name:var(--font-mono)] text-[10px] font-semibold tracking-[0.2em] text-[var(--pg-ink-muted)] uppercase">
+        Presence
+      </p>
+
+      {users.length === 0 ? (
+        <p className="mt-5 text-xs leading-relaxed text-[var(--pg-ink-muted)]">
+          Waiting for room presence…
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-1.5">
+          {users.map((user) => {
+            const hasSelection =
+              user.cursor !== undefined || user.selection !== undefined;
+            const isSelf = user.userId === selfId;
+
+            return (
+              <li
+                key={user.connectionId}
+                className="flex min-w-0 items-center gap-2.5 border border-transparent px-2 py-2 text-xs hover:border-[var(--pg-line)] hover:bg-[var(--pg-elevated)]/55"
+              >
+                <span
+                  className="grid size-7 shrink-0 place-items-center text-[9px] font-bold text-white"
+                  style={{ backgroundColor: user.color }}
+                  aria-hidden
+                >
+                  {hasSelection ? (
+                    <MousePointer2 className="size-3.5" />
+                  ) : (
+                    initials(user.name)
+                  )}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-medium text-[var(--pg-ink)]">
+                    {user.name}
+                  </span>
+                  <span className="block truncate font-[family-name:var(--font-mono)] text-[9px] tracking-wide text-[var(--pg-ink-muted)] uppercase">
+                    {isSelf ? "You" : user.status}
+                  </span>
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="mt-auto flex items-center gap-2 border-t border-[var(--pg-line)] pt-4 font-[family-name:var(--font-mono)] text-[10px] text-[var(--pg-ink-muted)]">
+        <Users className="size-3.5 text-[var(--pg-accent)]" aria-hidden />
+        {users.length} online
+      </div>
+    </aside>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/LexicalWorkspaceChrome.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/LexicalWorkspaceChrome.tsx
@@ -1,0 +1,57 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import type { RoomIdentity } from "./presence";
+import { StatusRail, type StatusRailProps } from "./StatusRail";
+
+interface LexicalWorkspaceChromeProps extends StatusRailProps {
+  readonly identity: RoomIdentity;
+}
+
+export function LexicalWorkspaceChrome({
+  identity,
+  users,
+  ...statusProps
+}: LexicalWorkspaceChromeProps) {
+  return (
+    <div className="relative z-30 border-b border-[var(--pg-line)] bg-[var(--pg-surface)]/95 backdrop-blur-xl">
+      <div className="flex min-h-14 items-center justify-between gap-3 px-4 md:hidden">
+        <Link
+          to="/"
+          className="pg-focus-ring inline-flex min-h-11 min-w-0 items-center gap-2 text-[var(--pg-ink)] active:translate-y-px"
+          aria-label="Back to Playground"
+        >
+          <ArrowLeft className="size-4 shrink-0" aria-hidden />
+          <span className="truncate font-[family-name:var(--font-display)] text-sm font-bold tracking-[-0.02em]">
+            SoftMaple
+            <span className="ml-1.5 font-normal text-[var(--pg-ink-muted)]">
+              Playground
+            </span>
+          </span>
+        </Link>
+        <div className="flex shrink-0 items-center gap-2 font-[family-name:var(--font-mono)] text-[10px] text-[var(--pg-ink-muted)]">
+          <span
+            className="grid size-7 place-items-center text-[9px] font-bold text-white"
+            style={{ backgroundColor: identity.color }}
+            title={identity.name}
+          >
+            {identity.name.slice(0, 2).toUpperCase()}
+          </span>
+          {users.length} online
+        </div>
+      </div>
+
+      <div className="flex min-w-0">
+        <Link
+          to="/"
+          className="pg-focus-ring hidden w-52 shrink-0 items-center border-r border-[var(--pg-line)] px-5 font-[family-name:var(--font-display)] text-sm font-bold tracking-[-0.03em] text-[var(--pg-ink)] hover:bg-[var(--pg-elevated)]/45 active:translate-y-px md:flex"
+        >
+          SoftMaple
+          <span className="ml-1.5 font-normal text-[var(--pg-ink-muted)]">
+            Playground
+          </span>
+        </Link>
+        <StatusRail users={users} {...statusProps} />
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/RoomCopyControl.test.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/RoomCopyControl.test.tsx
@@ -1,0 +1,29 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RoomCopyControl } from "./RoomCopyControl";
+
+describe("room copy control", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows bounded copied feedback after invoking the copy action", () => {
+    vi.useFakeTimers();
+    const onCopyRoomLink = vi.fn();
+
+    render(
+      <RoomCopyControl roomId="sample-room" onCopyRoomLink={onCopyRoomLink} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Copy link for room sample-room",
+      }),
+    );
+
+    expect(onCopyRoomLink).toHaveBeenCalledOnce();
+    expect(screen.getByText("Copied").textContent).toBe("Copied");
+
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.queryByText("Copied")).toBeNull();
+  });
+});

--- a/apps/playground/src/modules/lexical-eg-walker/RoomCopyControl.test.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/RoomCopyControl.test.tsx
@@ -1,15 +1,22 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RoomCopyControl } from "./RoomCopyControl";
 
 describe("room copy control", () => {
   afterEach(() => {
+    cleanup();
     vi.useRealTimers();
   });
 
-  it("shows bounded copied feedback after invoking the copy action", () => {
+  it("shows bounded copied feedback after clipboard write succeeds", async () => {
     vi.useFakeTimers();
-    const onCopyRoomLink = vi.fn();
+    const onCopyRoomLink = vi.fn(() => Promise.resolve());
 
     render(
       <RoomCopyControl roomId="sample-room" onCopyRoomLink={onCopyRoomLink} />,
@@ -20,10 +27,36 @@ describe("room copy control", () => {
       }),
     );
 
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     expect(onCopyRoomLink).toHaveBeenCalledOnce();
     expect(screen.getByText("Copied").textContent).toBe("Copied");
 
     act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.queryByText("Copied")).toBeNull();
+  });
+
+  it("does not show copied feedback when clipboard write is rejected", async () => {
+    const onCopyRoomLink = vi.fn(() =>
+      Promise.reject(new Error("clipboard write failed")),
+    );
+
+    render(
+      <RoomCopyControl roomId="sample-room" onCopyRoomLink={onCopyRoomLink} />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Copy link for room sample-room",
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(onCopyRoomLink).toHaveBeenCalledOnce();
     expect(screen.queryByText("Copied")).toBeNull();
   });
 });

--- a/apps/playground/src/modules/lexical-eg-walker/RoomCopyControl.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/RoomCopyControl.tsx
@@ -1,0 +1,65 @@
+import { Check, Copy } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface RoomCopyControlProps {
+  readonly roomId: string;
+  readonly onCopyRoomLink: () => void;
+}
+
+export function RoomCopyControl({
+  roomId,
+  onCopyRoomLink,
+}: RoomCopyControlProps) {
+  const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimerRef.current !== null) {
+        clearTimeout(resetTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const copyRoomLink = useCallback(() => {
+    onCopyRoomLink();
+    setCopied(true);
+    if (resetTimerRef.current !== null) {
+      clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = setTimeout(() => setCopied(false), 2_000);
+  }, [onCopyRoomLink]);
+
+  return (
+    <span className="inline-flex shrink-0 items-center gap-2">
+      <button
+        type="button"
+        className="pg-focus-ring group inline-flex min-h-11 max-w-52 items-center gap-1.5 px-2 text-[var(--pg-ink)] transition-colors hover:bg-[var(--pg-elevated)] active:translate-y-px"
+        onClick={copyRoomLink}
+        aria-label={`Copy link for room ${roomId}`}
+      >
+        <span className="truncate font-mono">room/{roomId}</span>
+        {copied ? (
+          <Check className="size-3.5 shrink-0 text-teal-400" aria-hidden />
+        ) : (
+          <Copy
+            className="size-3 shrink-0 opacity-50 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+            aria-hidden
+          />
+        )}
+      </button>
+      <span
+        className={
+          copied
+            ? "border border-teal-400/25 bg-teal-400/10 px-2 py-1 text-[10px] font-semibold whitespace-nowrap text-teal-300"
+            : "sr-only"
+        }
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {copied ? "Copied" : ""}
+      </span>
+    </span>
+  );
+}

--- a/apps/playground/src/modules/lexical-eg-walker/RoomCopyControl.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/RoomCopyControl.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 interface RoomCopyControlProps {
   readonly roomId: string;
-  readonly onCopyRoomLink: () => void;
+  readonly onCopyRoomLink: () => void | Promise<void>;
 }
 
 export function RoomCopyControl({
@@ -22,8 +22,12 @@ export function RoomCopyControl({
     [],
   );
 
-  const copyRoomLink = useCallback(() => {
-    onCopyRoomLink();
+  const copyRoomLink = useCallback(async () => {
+    try {
+      await onCopyRoomLink();
+    } catch {
+      return;
+    }
     setCopied(true);
     if (resetTimerRef.current !== null) {
       clearTimeout(resetTimerRef.current);

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
@@ -35,7 +35,7 @@ export interface StatusRailProps {
   readonly pendingCount: number;
   readonly storageBytes: number;
   readonly users: ReadonlyArray<PresenceUser>;
-  readonly onCopyRoomLink: () => void;
+  readonly onCopyRoomLink: () => void | Promise<void>;
 }
 
 const StatusItem = ({

--- a/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
+++ b/apps/playground/src/modules/lexical-eg-walker/StatusRail.tsx
@@ -5,39 +5,27 @@ import type {
 import {
   Check,
   CloudOff,
-  Copy,
   Database,
   LoaderCircle,
   Radio,
   WifiOff,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import type { TransportConnectionState } from "./persistence/channel";
+import { RoomCopyControl } from "./RoomCopyControl";
+import {
+  connectionLabel,
+  formatStorageSize,
+  isReconnectWarningState,
+  type PersistenceDisplayState,
+  persistenceLabel,
+} from "./statusRailLabels";
 
-export type PersistenceDisplayState =
-  | "loading"
-  | "pending"
-  | "saved"
-  | "unsaved";
-
-const CONNECTION_RANK = {
-  error: 0,
-  disconnected: 1,
-  reconnecting: 2,
-  connecting: 3,
-  authenticating: 4,
-  syncing: 5,
-  connected: 6,
-} as const satisfies Record<AdapterConnectionState, number>;
-
-/** Prefer the more degraded of presence + document sync states. */
-export const mergeConnectionStates = (
-  presence: AdapterConnectionState,
-  sync: TransportConnectionState | null | undefined,
-): AdapterConnectionState => {
-  if (sync == null) return presence;
-  return CONNECTION_RANK[presence] <= CONNECTION_RANK[sync] ? presence : sync;
-};
+export {
+  formatStorageSize,
+  mergeConnectionStates,
+  type PersistenceDisplayState,
+  persistenceLabel,
+} from "./statusRailLabels";
 
 export interface StatusRailProps {
   readonly roomId: string;
@@ -49,58 +37,6 @@ export interface StatusRailProps {
   readonly users: ReadonlyArray<PresenceUser>;
   readonly onCopyRoomLink: () => void;
 }
-
-const formatStorageSize = (bytes: number): string => {
-  if (bytes < 1_024) return `${bytes} B`;
-  return `${(bytes / 1_024).toFixed(1)} KB`;
-};
-
-const persistenceLabel = (
-  state: PersistenceDisplayState,
-  pendingCount: number,
-): string => {
-  switch (state) {
-    case "loading":
-      return "Loading local history";
-    case "pending":
-      return `${pendingCount} change${pendingCount === 1 ? "" : "s"} pending`;
-    case "saved":
-      return "Saved on this device";
-    case "unsaved":
-      return "Unsaved · memory only";
-  }
-};
-
-const connectionLabel = (
-  state: AdapterConnectionState,
-  transportMode: "websocket" | "broadcast" = "broadcast",
-): string => {
-  const channel =
-    transportMode === "websocket" ? "WebSocket" : "BroadcastChannel";
-  switch (state) {
-    case "connected":
-      return transportMode === "websocket"
-        ? "WebSocket connected"
-        : "Tabs connected";
-    case "connecting":
-      return `Connecting via ${channel}…`;
-    case "authenticating":
-      return `Authenticating via ${channel}…`;
-    case "syncing":
-      return `Syncing presence via ${channel}…`;
-    case "reconnecting":
-      return `Reconnecting via ${channel}…`;
-    case "error":
-      return `${channel} unavailable — refresh to retry`;
-    case "disconnected":
-      return transportMode === "websocket"
-        ? "WebSocket offline"
-        : "Working in this tab";
-  }
-};
-
-const isReconnectWarningState = (state: AdapterConnectionState): boolean =>
-  state === "disconnected" || state === "reconnecting" || state === "error";
 
 const StatusItem = ({
   icon,
@@ -126,12 +62,12 @@ const StatusItem = ({
 
   return (
     <span
-      className={`inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap ${toneClass}`}
+      className={`inline-flex items-center gap-1.5 whitespace-nowrap ${toneClass}`}
     >
       <span aria-hidden className={iconClass}>
         {icon}
       </span>
-      <span className="truncate">{children}</span>
+      <span>{children}</span>
     </span>
   );
 };
@@ -175,7 +111,7 @@ export function StatusRail({
   return (
     // biome-ignore lint/a11y/useSemanticElements: transport status live region; <output> is for form-calculated values.
     <div
-      className="relative z-20 flex min-h-10 flex-wrap items-center gap-x-4 gap-y-2 border-b border-[var(--pg-line)] bg-[var(--pg-surface)]/90 px-3 py-2 font-[family-name:var(--font-mono)] text-[11px] font-medium tracking-[0.02em] text-[var(--pg-ink-muted)] backdrop-blur-xl md:px-5"
+      className="pg-status-rail relative z-20 min-w-0 flex-1 overflow-x-auto font-[family-name:var(--font-mono)] text-[11px] font-medium tracking-[0.02em] text-[var(--pg-ink-muted)]"
       data-testid="collaboration-status"
       data-transport={transportMode}
       data-connection-state={connectionState}
@@ -186,52 +122,45 @@ export function StatusRail({
         aria-hidden
         className="absolute inset-y-0 left-0 w-[3px] bg-gradient-to-b from-[var(--pg-accent)] via-teal-400 to-orange-400"
       />
-      <button
-        type="button"
-        className="group inline-flex max-w-48 items-center gap-1.5 px-1.5 py-1 text-[var(--pg-ink)] outline-none transition-colors hover:bg-[var(--pg-elevated)] focus-visible:ring-2 focus-visible:ring-[var(--pg-accent)]"
-        onClick={onCopyRoomLink}
-        aria-label={`Copy link for room ${roomId}`}
-      >
-        <span className="truncate font-mono">room/{roomId}</span>
-        <Copy className="size-3 opacity-50 transition-opacity group-hover:opacity-100" />
-      </button>
-
-      <StatusItem icon={connectionIcon} tone={connectionTone}>
-        {connectionLabel(connectionState, transportMode)}
-      </StatusItem>
-      {isReconnectWarningState(connectionState) &&
-      transportMode === "websocket" ? (
-        <span className="border border-amber-400/25 bg-amber-400/10 px-2 py-0.5 text-[10px] font-semibold text-amber-300">
-          Sync paused until reconnect
-        </span>
-      ) : null}
-      <StatusItem icon={persistenceIcon}>
-        {persistenceLabel(persistenceState, pendingCount)}
-      </StatusItem>
-      <StatusItem icon={<Database className="size-3.5" />}>
-        {formatStorageSize(storageBytes)}
-      </StatusItem>
-
-      <div className="ml-auto flex items-center pl-1">
-        {users.slice(0, 5).map((user, index) => (
-          <span
-            key={user.userId}
-            className="grid size-6 place-items-center border-2 border-[var(--pg-surface)] text-[9px] font-bold text-white shadow-sm"
-            style={{
-              backgroundColor: user.color,
-              marginLeft: index === 0 ? 0 : -5,
-            }}
-            title={user.name}
-          >
-            {user.name.slice(0, 2).toUpperCase()}
+      <div className="flex min-h-12 min-w-max flex-1 items-center gap-3 px-3 md:gap-4 md:px-5">
+        <RoomCopyControl roomId={roomId} onCopyRoomLink={onCopyRoomLink} />
+        <span className="h-5 w-px shrink-0 bg-[var(--pg-line)]" aria-hidden />
+        <StatusItem icon={connectionIcon} tone={connectionTone}>
+          {connectionLabel(connectionState, transportMode)}
+        </StatusItem>
+        {isReconnectWarningState(connectionState) &&
+        transportMode === "websocket" ? (
+          <span className="border border-amber-400/25 bg-amber-400/10 px-2 py-0.5 text-[10px] font-semibold text-amber-300">
+            Sync paused until reconnect
           </span>
-        ))}
-        <span className="ml-2 whitespace-nowrap text-[var(--pg-ink-muted)]">
-          {users.length} online
-        </span>
+        ) : null}
+        <span className="h-5 w-px shrink-0 bg-[var(--pg-line)]" aria-hidden />
+        <StatusItem icon={persistenceIcon}>
+          {persistenceLabel(persistenceState, pendingCount)}
+        </StatusItem>
+        <StatusItem icon={<Database className="size-3.5" />}>
+          {formatStorageSize(storageBytes)}
+        </StatusItem>
+
+        <div className="ml-auto hidden items-center pl-1 md:flex">
+          {users.slice(0, 5).map((user, index) => (
+            <span
+              key={user.connectionId}
+              className="grid size-6 place-items-center border-2 border-[var(--pg-surface)] text-[9px] font-bold text-white shadow-sm"
+              style={{
+                backgroundColor: user.color,
+                marginLeft: index === 0 ? 0 : -5,
+              }}
+              title={user.name}
+            >
+              {user.name.slice(0, 2).toUpperCase()}
+            </span>
+          ))}
+          <span className="ml-2 whitespace-nowrap text-[var(--pg-ink-muted)]">
+            {users.length} online
+          </span>
+        </div>
       </div>
     </div>
   );
 }
-
-export { formatStorageSize, persistenceLabel };

--- a/apps/playground/src/modules/lexical-eg-walker/statusRailLabels.ts
+++ b/apps/playground/src/modules/lexical-eg-walker/statusRailLabels.ts
@@ -1,0 +1,81 @@
+import type { AdapterConnectionState } from "@softmaple/awareness";
+import type { TransportConnectionState } from "./persistence/channel";
+
+export type PersistenceDisplayState =
+  | "loading"
+  | "pending"
+  | "saved"
+  | "unsaved";
+
+const CONNECTION_RANK = {
+  error: 0,
+  disconnected: 1,
+  reconnecting: 2,
+  connecting: 3,
+  authenticating: 4,
+  syncing: 5,
+  connected: 6,
+} as const satisfies Record<AdapterConnectionState, number>;
+
+/** Prefer the more degraded of presence + document sync states. */
+export const mergeConnectionStates = (
+  presence: AdapterConnectionState,
+  sync: TransportConnectionState | null | undefined,
+): AdapterConnectionState => {
+  if (sync == null) return presence;
+  return CONNECTION_RANK[presence] <= CONNECTION_RANK[sync] ? presence : sync;
+};
+
+export const formatStorageSize = (bytes: number): string => {
+  if (bytes < 1_024) return `${bytes} B`;
+  return `${(bytes / 1_024).toFixed(1)} KB`;
+};
+
+export const persistenceLabel = (
+  state: PersistenceDisplayState,
+  pendingCount: number,
+): string => {
+  switch (state) {
+    case "loading":
+      return "Loading local history";
+    case "pending":
+      return `${pendingCount} change${pendingCount === 1 ? "" : "s"} pending`;
+    case "saved":
+      return "Saved on this device";
+    case "unsaved":
+      return "Unsaved · memory only";
+  }
+};
+
+export const connectionLabel = (
+  state: AdapterConnectionState,
+  transportMode: "websocket" | "broadcast" = "broadcast",
+): string => {
+  const channel =
+    transportMode === "websocket" ? "WebSocket" : "BroadcastChannel";
+  switch (state) {
+    case "connected":
+      return transportMode === "websocket"
+        ? "WebSocket connected"
+        : "Tabs connected";
+    case "connecting":
+      return `Connecting via ${channel}…`;
+    case "authenticating":
+      return `Authenticating via ${channel}…`;
+    case "syncing":
+      return `Syncing presence via ${channel}…`;
+    case "reconnecting":
+      return `Reconnecting via ${channel}…`;
+    case "error":
+      return `${channel} unavailable — refresh to retry`;
+    case "disconnected":
+      return transportMode === "websocket"
+        ? "WebSocket offline"
+        : "Working in this tab";
+  }
+};
+
+export const isReconnectWarningState = (
+  state: AdapterConnectionState,
+): boolean =>
+  state === "disconnected" || state === "reconnecting" || state === "error";

--- a/apps/playground/src/routes/__root.tsx
+++ b/apps/playground/src/routes/__root.tsx
@@ -9,12 +9,15 @@ import {
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { Analytics } from "@vercel/analytics/react";
 import Header from "@/components/Header";
+import { env } from "@/env";
 import TanStackQueryDevtools from "@/integrations/tanstack-query/devtools";
 import appCss from "@/styles.css?url";
 
 export interface MyRouterContext {
   queryClient: QueryClient;
 }
+
+const showTanStackDevtools = env.VITE_PLAYGROUND_DEVTOOLS === "true";
 
 export const Route = createRootRouteWithContext<MyRouterContext>()({
   head: () => ({
@@ -70,18 +73,20 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <Header />
         {children}
         <Toaster theme="dark" position="bottom-right" />
-        <TanStackDevtools
-          config={{
-            position: "bottom-right",
-          }}
-          plugins={[
-            {
-              name: "Tanstack Router",
-              render: <TanStackRouterDevtoolsPanel />,
-            },
-            TanStackQueryDevtools,
-          ]}
-        />
+        {showTanStackDevtools ? (
+          <TanStackDevtools
+            config={{
+              position: "bottom-right",
+            }}
+            plugins={[
+              {
+                name: "Tanstack Router",
+                render: <TanStackRouterDevtoolsPanel />,
+              },
+              TanStackQueryDevtools,
+            ]}
+          />
+        ) : null}
         <Analytics />
         <Scripts />
       </body>

--- a/apps/playground/src/styles.css
+++ b/apps/playground/src/styles.css
@@ -25,6 +25,7 @@
   --pg-ink-muted: #8b8b96;
   --pg-line: #2a2a32;
   --pg-accent: #e11d48;
+  --pg-grid-line: rgba(139, 139, 150, 0.08);
   --pg-glow-teal: rgba(45, 212, 191, 0.16);
   --pg-glow-orange: rgba(251, 146, 60, 0.12);
   --pg-glow-accent: rgba(225, 29, 72, 0.18);
@@ -48,6 +49,21 @@ code {
 }
 
 /* Shared Motion-inspired demo chrome */
+.pg-focus-ring {
+  outline: none;
+}
+
+.pg-focus-ring:focus-visible,
+.pg-action-cluster :where(a, button, [role="button"]):focus-visible {
+  outline: 2px solid var(--pg-accent);
+  outline-offset: 3px;
+}
+
+.pg-action-cluster
+  :where(a, button, [role="button"]):active:not(:disabled) {
+  transform: translateY(1px);
+}
+
 .pg-panel {
   background: var(--pg-surface);
   border: 1px solid var(--pg-line);
@@ -64,6 +80,43 @@ code {
 .pg-panel-footer {
   border-top: 1px solid var(--pg-line);
   background: color-mix(in srgb, var(--pg-elevated) 70%, var(--pg-paper));
+}
+
+.pg-status-rail {
+  overflow-y: hidden;
+  overscroll-behavior-inline: contain;
+  scrollbar-color: var(--pg-line) transparent;
+  scrollbar-width: thin;
+}
+
+.pg-lexical-editor > div:first-child {
+  min-height: 3.5rem;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  border-color: var(--pg-line);
+  background: color-mix(in srgb, var(--pg-elevated) 58%, var(--pg-paper));
+  scrollbar-color: var(--pg-line) transparent;
+  scrollbar-width: thin;
+}
+
+.pg-lexical-editor > div:first-child :where(button, [role="combobox"]) {
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  flex: none;
+}
+
+.pg-lexical-editor > div:first-child [data-slot="separator"] {
+  flex: none;
+}
+
+.pg-lexical-editor > div:last-child {
+  border-radius: 0;
+  background-color: color-mix(in srgb, var(--pg-surface) 92%, var(--pg-paper));
+  background-image:
+    linear-gradient(var(--pg-grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--pg-grid-line) 1px, transparent 1px);
+  background-size: 24px 24px;
 }
 
 .pg-input {

--- a/apps/playground/src/styles.css
+++ b/apps/playground/src/styles.css
@@ -83,7 +83,8 @@ code {
 }
 
 .pg-status-rail {
-  overflow-y: hidden;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
   overscroll-behavior-inline: contain;
   scrollbar-color: var(--pg-line) transparent;
   scrollbar-width: thin;

--- a/apps/web/app/dashboard/error.tsx
+++ b/apps/web/app/dashboard/error.tsx
@@ -1,5 +1,19 @@
 "use client";
 
-export default function DashboardErrorPage() {
-  return <p>Sorry, something went wrong</p>;
+import {
+  RouteError,
+  type RouteErrorBoundaryProps,
+} from "@/components/RouteError";
+
+export default function DashboardErrorPage({ retry }: RouteErrorBoundaryProps) {
+  return (
+    <RouteError
+      backHref="/"
+      backLabel="Back to home"
+      className="min-h-[calc(100dvh-3.5rem)]"
+      description="Your workspace list is still safe. Retry the request, or return to the public home page."
+      retry={retry}
+      title="The workspace index paused."
+    />
+  );
 }

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
-import { FileText } from "lucide-react";
+import Link from "next/link";
 import { Button } from "@softmaple/ui/components/button";
 import { logout } from "@/app/actions/auth";
+import { SoftmapleWordmark } from "@/components/BrandMark";
 import { SettingsDropdown } from "@/modules/settings/settings-dropdown";
 
 export default function DashboardLayout({
@@ -9,16 +10,17 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="container mx-auto px-4 h-16 flex items-center justify-between">
-          <div className="flex items-center space-x-2">
-            <div className="w-8 h-8 bg-gradient-to-br from-orange-500 to-red-500 rounded-lg flex items-center justify-center">
-              <FileText className="w-5 h-5 text-white" />
-            </div>
-            <span className="font-semibold text-xl">Softmaple</span>
-          </div>
-          <div className="flex items-center space-x-4">
+    <div className="min-h-dvh bg-background">
+      <header className="border-b bg-background/85 backdrop-blur">
+        <div className="mx-auto flex h-14 max-w-7xl items-center justify-between gap-4 px-4 sm:px-6">
+          <Link
+            aria-label="Softmaple dashboard"
+            className="inline-flex min-w-0 items-center rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+            href="/dashboard"
+          >
+            <SoftmapleWordmark className="text-lg" />
+          </Link>
+          <div className="flex shrink-0 items-center gap-2">
             <SettingsDropdown />
 
             <Button

--- a/apps/web/app/dashboard/loading.tsx
+++ b/apps/web/app/dashboard/loading.tsx
@@ -1,3 +1,5 @@
+import { RouteLoading } from "@/components/RouteLoading";
+
 export default function Loading() {
-  return null;
+  return <RouteLoading label="Loading your workspaces" />;
 }

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,5 +1,19 @@
 "use client";
 
-export default function ErrorPage() {
-  return <p>Sorry, something went wrong</p>;
+import {
+  RouteError,
+  type RouteErrorBoundaryProps,
+} from "@/components/RouteError";
+
+export default function ErrorPage({ retry }: RouteErrorBoundaryProps) {
+  return (
+    <RouteError
+      backHref="/"
+      backLabel="Back to home"
+      className="min-h-dvh"
+      description="The page could not finish loading. Try the route again, or return to the public home page."
+      retry={retry}
+      title="The page lost its place."
+    />
+  );
 }

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -1,3 +1,5 @@
+import { RouteLoading } from "@/components/RouteLoading";
+
 export default function Loading() {
-  return null;
+  return <RouteLoading className="min-h-dvh" label="Loading Softmaple" />;
 }

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,15 +1,8 @@
 import Link from "next/link";
-import { Button } from "@softmaple/ui/components/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@softmaple/ui/components/card";
-import { FileText, Github, Mail } from "lucide-react";
 import { LoginForm } from "@/modules/auth/login-form";
 import { AuthGuard } from "@/modules/auth/auth-guard";
+import { AuthShell } from "@/modules/auth/auth-shell";
+import { AuthOAuthOptions } from "@/modules/auth/auth-oauth-options";
 
 interface LoginPageProps {
   searchParams: Promise<{ error?: string; message?: string; next?: string }>;
@@ -22,81 +15,50 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
 
   return (
     <AuthGuard>
-      <div className="min-h-screen flex items-center justify-center bg-background px-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center">
-            <div className="flex justify-center mb-4">
-              <div className="w-12 h-12 bg-gradient-to-br from-orange-500 to-red-500 rounded-lg flex items-center justify-center">
-                <FileText className="w-6 h-6 text-white" />
-              </div>
-            </div>
-            <CardTitle className="text-2xl">Welcome back</CardTitle>
-            <CardDescription>Sign in to your Softmaple account</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {message && (
-              <div className="p-3 text-sm text-green-600 bg-green-50 rounded-md">
-                {message}
-              </div>
-            )}
-            {error === undefined ? null : (
-              <div
-                className="rounded-sm bg-destructive/10 p-3 text-sm text-destructive"
-                role="alert"
-              >
-                {error}
-              </div>
-            )}
-            <LoginForm next={params.next} />
+      <AuthShell
+        description="Sign in to your Softmaple account"
+        title="Welcome back"
+      >
+        {message === undefined ? null : (
+          <p
+            className="mb-5 border-l-2 border-primary bg-muted px-3 py-2 text-sm text-foreground"
+            role="status"
+          >
+            {message}
+          </p>
+        )}
+        {error === undefined ? null : (
+          <p
+            className="mb-5 border-l-2 border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            role="alert"
+          >
+            {error}
+          </p>
+        )}
 
-            <div className="text-right">
-              <Link
-                href="/reset-password"
-                className="text-sm text-muted-foreground hover:text-primary transition-colors"
-              >
-                Forgot password?
-              </Link>
-            </div>
+        <LoginForm next={params.next} />
 
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <span className="w-full border-t" />
-              </div>
-              <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-background px-2 text-muted-foreground">
-                  Or continue with
-                </span>
-              </div>
-            </div>
+        <div className="mt-3 text-right">
+          <Link
+            className="text-sm text-muted-foreground transition-colors hover:text-primary focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            href="/reset-password"
+          >
+            Forgot password?
+          </Link>
+        </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <Button aria-describedby="oauth-note" disabled variant="outline">
-                <Github className="mr-2 h-4 w-4" />
-                GitHub
-              </Button>
-              <Button aria-describedby="oauth-note" disabled variant="outline">
-                <Mail className="mr-2 h-4 w-4" />
-                Google
-              </Button>
-            </div>
-            <p
-              className="text-center text-xs text-muted-foreground"
-              id="oauth-note"
-            >
-              GitHub and Google sign-in are coming soon.
-            </p>
+        <AuthOAuthOptions mode="sign-in" />
 
-            <div className="text-center text-sm">
-              <span className="text-muted-foreground">
-                Don&apos;t have an account?{" "}
-              </span>
-              <Link href="/signup" className="text-primary hover:underline">
-                Sign up
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          Don&apos;t have an account?{" "}
+          <Link
+            className="text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            href="/signup"
+          >
+            Sign up
+          </Link>
+        </p>
+      </AuthShell>
     </AuthGuard>
   );
 }

--- a/apps/web/app/reset-password/page.tsx
+++ b/apps/web/app/reset-password/page.tsx
@@ -1,14 +1,7 @@
 import Link from "next/link";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@softmaple/ui/components/card";
-import { FileText } from "lucide-react";
 import { ResetPasswordForm } from "@/modules/auth/reset-password-form";
 import { AuthGuard } from "@/modules/auth/auth-guard";
+import { AuthShell } from "@/modules/auth/auth-shell";
 
 interface ResetPasswordPageProps {
   searchParams: Promise<{ message?: string; error?: string }>;
@@ -23,42 +16,39 @@ export default async function ResetPasswordPage({
 
   return (
     <AuthGuard>
-      <div className="min-h-screen flex items-center justify-center bg-background px-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center">
-            <div className="flex justify-center mb-4">
-              <div className="w-12 h-12 bg-gradient-to-br from-orange-500 to-red-500 rounded-lg flex items-center justify-center">
-                <FileText className="w-6 h-6 text-white" />
-              </div>
-            </div>
-            <CardTitle className="text-2xl">Reset your password</CardTitle>
-            <CardDescription>
-              Enter your email address and we&apos;ll send you a link to reset
-              your password
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {message && (
-              <div className="p-3 text-sm text-green-600 bg-green-50 rounded-md">
-                {message}
-              </div>
-            )}
-            {error && (
-              <div className="p-3 text-sm text-red-600 bg-red-50 rounded-md">
-                {error}
-              </div>
-            )}
-            <ResetPasswordForm />
+      <AuthShell
+        description="Enter your email address and we’ll send you a link to reset your password"
+        title="Reset your password"
+      >
+        {message === undefined ? null : (
+          <p
+            className="mb-5 border-l-2 border-primary bg-muted px-3 py-2 text-sm text-foreground"
+            role="status"
+          >
+            {message}
+          </p>
+        )}
+        {error === undefined ? null : (
+          <p
+            className="mb-5 border-l-2 border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            role="alert"
+          >
+            {error}
+          </p>
+        )}
 
-            <div className="text-center text-sm text-muted-foreground">
-              Remember your password?{" "}
-              <Link href="/login" className="text-primary hover:underline">
-                Sign in
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+        <ResetPasswordForm />
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          Remember your password?{" "}
+          <Link
+            className="text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            href="/login"
+          >
+            Sign in
+          </Link>
+        </p>
+      </AuthShell>
     </AuthGuard>
   );
 }

--- a/apps/web/app/reset-password/update/page.tsx
+++ b/apps/web/app/reset-password/update/page.tsx
@@ -1,13 +1,6 @@
 import Link from "next/link";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@softmaple/ui/components/card";
-import { FileText } from "lucide-react";
 import { UpdatePasswordForm } from "@/modules/auth/update-password-form";
+import { AuthShell } from "@/modules/auth/auth-shell";
 
 interface UpdatePasswordPageProps {
   searchParams: Promise<{ message?: string; error?: string }>;
@@ -21,37 +14,37 @@ export default async function UpdatePasswordPage({
   const error = params?.error;
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background px-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="flex justify-center mb-4">
-            <div className="w-12 h-12 bg-gradient-to-br from-orange-500 to-red-500 rounded-lg flex items-center justify-center">
-              <FileText className="w-6 h-6 text-white" />
-            </div>
-          </div>
-          <CardTitle className="text-2xl">Create new password</CardTitle>
-          <CardDescription>Enter your new password below</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {message && (
-            <div className="p-3 text-sm text-green-600 bg-green-50 rounded-md">
-              {message}
-            </div>
-          )}
-          {error && (
-            <div className="p-3 text-sm text-red-600 bg-red-50 rounded-md">
-              {error}
-            </div>
-          )}
-          <UpdatePasswordForm />
+    <AuthShell
+      description="Enter your new password below"
+      title="Create new password"
+    >
+      {message === undefined ? null : (
+        <p
+          className="mb-5 border-l-2 border-primary bg-muted px-3 py-2 text-sm text-foreground"
+          role="status"
+        >
+          {message}
+        </p>
+      )}
+      {error === undefined ? null : (
+        <p
+          className="mb-5 border-l-2 border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          role="alert"
+        >
+          {error}
+        </p>
+      )}
 
-          <div className="text-center text-sm text-muted-foreground">
-            <Link href="/login" className="text-primary hover:underline">
-              Back to sign in
-            </Link>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+      <UpdatePasswordForm />
+
+      <p className="mt-6 text-center text-sm text-muted-foreground">
+        <Link
+          className="text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          href="/login"
+        >
+          Back to sign in
+        </Link>
+      </p>
+    </AuthShell>
   );
 }

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -1,74 +1,29 @@
 import Link from "next/link";
-import { Button } from "@softmaple/ui/components/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@softmaple/ui/components/card";
-import { FileText, Github, Mail } from "lucide-react";
 import { SignupForm } from "@/modules/auth/signup-form";
 import { AuthGuard } from "@/modules/auth/auth-guard";
+import { AuthShell } from "@/modules/auth/auth-shell";
+import { AuthOAuthOptions } from "@/modules/auth/auth-oauth-options";
 
-export default async function SignupPage() {
+export default function SignupPage() {
   return (
     <AuthGuard>
-      <div className="min-h-screen flex items-center justify-center bg-background px-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center">
-            <div className="flex justify-center mb-4">
-              <div className="w-12 h-12 bg-gradient-to-br from-orange-500 to-red-500 rounded-lg flex items-center justify-center">
-                <FileText className="w-6 h-6 text-white" />
-              </div>
-            </div>
-            <CardTitle className="text-2xl">Create your account</CardTitle>
-            <CardDescription>
-              Start writing with Softmaple today
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <SignupForm />
+      <AuthShell
+        description="Start writing with Softmaple today"
+        title="Create your account"
+      >
+        <SignupForm />
+        <AuthOAuthOptions mode="sign-up" />
 
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <span className="w-full border-t" />
-              </div>
-              <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-background px-2 text-muted-foreground">
-                  Or continue with
-                </span>
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <Button aria-describedby="oauth-note" disabled variant="outline">
-                <Github className="mr-2 h-4 w-4" />
-                GitHub
-              </Button>
-              <Button aria-describedby="oauth-note" disabled variant="outline">
-                <Mail className="mr-2 h-4 w-4" />
-                Google
-              </Button>
-            </div>
-            <p
-              className="text-center text-xs text-muted-foreground"
-              id="oauth-note"
-            >
-              GitHub and Google sign-up are coming soon.
-            </p>
-
-            <div className="text-center text-sm">
-              <span className="text-muted-foreground">
-                Already have an account?{" "}
-              </span>
-              <Link href="/login" className="text-primary hover:underline">
-                Sign in
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link
+            className="text-primary underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            href="/login"
+          >
+            Sign in
+          </Link>
+        </p>
+      </AuthShell>
     </AuthGuard>
   );
 }

--- a/apps/web/app/workspace/[workspaceSlug]/doc/[docSlug]/error.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/doc/[docSlug]/error.tsx
@@ -1,5 +1,18 @@
 "use client";
 
-export default function DocumentErrorPage() {
-  return <p>Sorry, something went wrong</p>;
+import {
+  RouteError,
+  type RouteErrorBoundaryProps,
+} from "@/components/RouteError";
+
+export default function DocumentErrorPage({ retry }: RouteErrorBoundaryProps) {
+  return (
+    <RouteError
+      backHref="/dashboard"
+      backLabel="All workspaces"
+      description="The document view could not finish opening. Retry the request, or return to your workspace index."
+      retry={retry}
+      title="This document is out of view."
+    />
+  );
 }

--- a/apps/web/app/workspace/[workspaceSlug]/error.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/error.tsx
@@ -1,5 +1,18 @@
 "use client";
 
-export default function WorkspaceErrorPage() {
-  return <p>Sorry, something went wrong</p>;
+import {
+  RouteError,
+  type RouteErrorBoundaryProps,
+} from "@/components/RouteError";
+
+export default function WorkspaceErrorPage({ retry }: RouteErrorBoundaryProps) {
+  return (
+    <RouteError
+      backHref="/dashboard"
+      backLabel="All workspaces"
+      description="This workspace could not finish opening. Retry the request, or return to your workspace index."
+      retry={retry}
+      title="This workspace is out of view."
+    />
+  );
 }

--- a/apps/web/app/workspace/[workspaceSlug]/layout.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/layout.tsx
@@ -57,20 +57,19 @@ export default async function WorkspaceLayoutPage(props: Props) {
     membership?.role === WORKSPACE_ROLE.Editor;
 
   return (
-    <div className="flex h-dvh min-w-0 bg-background">
-      {/* Mobile Menu Trigger */}
+    <div className="flex h-dvh min-h-0 min-w-0 flex-col overflow-hidden bg-background md:flex-row">
       <WorkspaceMobileSidebar
         canEdit={canEdit}
         documents={documents}
         workspaceSlug={workspaceSlug}
       >
         <WorkspaceDropdown
+          compact
           workspaceSlug={workspaceSlug}
           workspaces={workspaces}
         />
       </WorkspaceMobileSidebar>
 
-      {/* Desktop Sidebar */}
       <WorkspaceDesktopSidebar
         canEdit={canEdit}
         documents={documents}
@@ -82,8 +81,7 @@ export default async function WorkspaceLayoutPage(props: Props) {
         />
       </WorkspaceDesktopSidebar>
 
-      {/* Main Content */}
-      <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <Suspense>{children}</Suspense>
       </div>
     </div>

--- a/apps/web/components/BrandMark.tsx
+++ b/apps/web/components/BrandMark.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "@softmaple/ui/lib/utils";
+
+export function RaspberryRecordMark({
+  className,
+  ...props
+}: ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "grid size-9 shrink-0 place-items-center border bg-background",
+        className,
+      )}
+      {...props}
+    >
+      <span className="size-2.5 rounded-full bg-primary" />
+    </span>
+  );
+}
+
+export function SoftmapleWordmark({
+  className,
+  ...props
+}: ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "font-display font-semibold tracking-[-0.025em] text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      softmaple<span className="text-primary">.</span>
+    </span>
+  );
+}

--- a/apps/web/components/RouteError.tsx
+++ b/apps/web/components/RouteError.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, RotateCcw } from "lucide-react";
+import { Button } from "@softmaple/ui/components/button";
+import { cn } from "@softmaple/ui/lib/utils";
+import { RaspberryRecordMark } from "@/components/BrandMark";
+
+export type RouteErrorBoundaryProps = {
+  readonly retry: () => void;
+};
+
+export type RouteErrorProps = RouteErrorBoundaryProps & {
+  readonly backHref: string;
+  readonly backLabel: string;
+  readonly className?: string;
+  readonly description: string;
+  readonly title: string;
+};
+
+export function RouteError({
+  backHref,
+  backLabel,
+  className,
+  description,
+  retry,
+  title,
+}: RouteErrorProps) {
+  return (
+    <main
+      className={cn(
+        "grid min-h-0 flex-1 place-items-center overflow-y-auto bg-background px-4 py-12 sm:px-6",
+        className,
+      )}
+    >
+      <section className="w-full max-w-xl border bg-card shadow-sm">
+        <div className="flex items-center gap-3 border-b px-5 py-3">
+          <RaspberryRecordMark className="size-8" />
+          <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-primary">
+            Record interrupted
+          </p>
+        </div>
+        <div className="p-6 sm:p-8">
+          <h1 className="font-display text-3xl font-semibold tracking-tight">
+            {title}
+          </h1>
+          <p className="mt-3 max-w-md text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+          <div className="mt-7 flex flex-wrap gap-2">
+            <Button onClick={retry}>
+              <RotateCcw className="size-4" />
+              Try again
+            </Button>
+            <Button asChild variant="outline">
+              <Link href={backHref}>
+                <ArrowLeft className="size-4" />
+                {backLabel}
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/RouteLoading.tsx
+++ b/apps/web/components/RouteLoading.tsx
@@ -1,0 +1,57 @@
+import { Skeleton } from "@softmaple/ui/components/skeleton";
+import { cn } from "@softmaple/ui/lib/utils";
+import { RaspberryRecordMark } from "@/components/BrandMark";
+
+const PLACEHOLDER_CARDS = ["document", "workspace", "activity"] as const;
+
+export type RouteLoadingProps = {
+  readonly className?: string;
+  readonly label?: string;
+};
+
+export function RouteLoading({
+  className,
+  label = "Loading Softmaple",
+}: RouteLoadingProps) {
+  return (
+    <main
+      aria-busy="true"
+      aria-label={label}
+      className={cn(
+        "min-h-[calc(100dvh-3.5rem)] bg-background px-4 py-10 sm:px-6 sm:py-14",
+        className,
+      )}
+    >
+      <div className="mx-auto w-full max-w-6xl">
+        <div className="flex items-center gap-3 border-b pb-5">
+          <RaspberryRecordMark />
+          <div className="min-w-0 flex-1">
+            <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-primary">
+              Retrieving record
+            </p>
+            <Skeleton className="mt-2 h-5 w-44 max-w-full rounded-sm" />
+          </div>
+        </div>
+
+        <div className="mt-8 space-y-3">
+          <Skeleton className="h-9 w-80 max-w-[82%] rounded-sm" />
+          <Skeleton className="h-4 w-[32rem] max-w-full rounded-sm" />
+        </div>
+
+        <div className="mt-9 grid gap-px overflow-hidden border bg-border sm:grid-cols-3">
+          {PLACEHOLDER_CARDS.map((card) => (
+            <section className="bg-card p-5 sm:min-h-48" key={card}>
+              <Skeleton className="size-9 rounded-sm" />
+              <Skeleton className="mt-10 h-5 w-2/3 rounded-sm" />
+              <Skeleton className="mt-3 h-3 w-full rounded-sm" />
+              <Skeleton className="mt-2 h-3 w-4/5 rounded-sm" />
+            </section>
+          ))}
+        </div>
+      </div>
+      <span className="sr-only" role="status">
+        {label}
+      </span>
+    </main>
+  );
+}

--- a/apps/web/modules/auth/auth-brand-specimen.tsx
+++ b/apps/web/modules/auth/auth-brand-specimen.tsx
@@ -1,0 +1,60 @@
+import { Check, Circle, FileCode2, Radio, Users } from "lucide-react";
+
+const LINE_NUMBERS = ["01", "02", "03", "04", "05", "06"] as const;
+
+export const AuthBrandSpecimen = () => (
+  <div
+    aria-hidden="true"
+    className="mt-10 hidden w-full max-w-2xl border bg-card/75 shadow-[0_24px_80px_-48px_rgba(201,24,74,0.65)] lg:block"
+  >
+    <div className="flex items-center gap-2 border-b px-3 py-2 font-mono text-[10px] text-muted-foreground">
+      <Circle className="size-2.5 fill-primary text-primary" />
+      field-notes / carbon-cycle
+      <span className="ml-auto flex items-center gap-1 text-teal-600 dark:text-teal-400">
+        <Check className="size-3" /> Saved
+      </span>
+    </div>
+
+    <div className="grid grid-cols-[2.6rem_minmax(0,1fr)]">
+      <div className="border-r py-5 text-center font-mono text-[9px] leading-7 text-muted-foreground">
+        {LINE_NUMBERS.map((line) => (
+          <span className="block" key={line}>
+            {line}
+          </span>
+        ))}
+      </div>
+      <div className="relative px-5 py-5 xl:px-7">
+        <p className="font-mono text-[9px] uppercase tracking-[0.16em] text-primary">
+          Observation / 09:42
+        </p>
+        <p className="mt-4 font-display text-xl font-semibold">
+          A shared record of change
+        </p>
+        <p className="mt-3 max-w-lg text-xs leading-6 text-muted-foreground xl:text-sm">
+          Each insertion becomes a durable event. When Lina reconnects, repair
+          resumes after the last acknowledged cursor—without overwriting
+          Marco&apos;s concurrent paragraph.
+        </p>
+        <blockquote className="mt-4 border-l-2 border-primary pl-4 text-xs italic xl:text-sm">
+          The document converges; the writers keep their context.
+        </blockquote>
+        <span className="absolute right-12 top-[6.8rem] h-5 border-l-2 border-teal-500" />
+        <span className="absolute right-3 top-[7rem] bg-teal-600 px-1.5 py-0.5 font-mono text-[9px] text-white">
+          Lina
+        </span>
+      </div>
+    </div>
+
+    <div className="flex flex-wrap items-center gap-3 border-t px-3 py-2 font-mono text-[9px] text-muted-foreground">
+      <span className="flex items-center gap-1.5">
+        <Radio className="size-3 text-primary" /> 3 active
+      </span>
+      <span className="flex items-center gap-1.5">
+        <FileCode2 className="size-3" /> Markdown / LaTeX
+      </span>
+      <span className="ml-auto flex items-center gap-1.5">
+        <Users className="size-3" /> Owner · 2 editors
+      </span>
+    </div>
+  </div>
+);

--- a/apps/web/modules/auth/auth-oauth-options.tsx
+++ b/apps/web/modules/auth/auth-oauth-options.tsx
@@ -1,0 +1,37 @@
+import { Github, Mail } from "lucide-react";
+import { Button } from "@softmaple/ui/components/button";
+
+export type AuthOAuthOptionsProps = {
+  readonly mode: "sign-in" | "sign-up";
+};
+
+export const AuthOAuthOptions = ({ mode }: AuthOAuthOptionsProps) => {
+  const noteId = `oauth-${mode}-note`;
+
+  return (
+    <div className="mt-7">
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-card px-2 text-muted-foreground">
+            Or continue with
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-5 grid grid-cols-2 gap-3 sm:gap-4">
+        <Button aria-describedby={noteId} disabled variant="outline">
+          <Github className="size-4" /> GitHub
+        </Button>
+        <Button aria-describedby={noteId} disabled variant="outline">
+          <Mail className="size-4" /> Google
+        </Button>
+      </div>
+      <p className="mt-3 text-center text-xs text-muted-foreground" id={noteId}>
+        GitHub and Google {mode} are coming soon.
+      </p>
+    </div>
+  );
+};

--- a/apps/web/modules/auth/auth-shell.tsx
+++ b/apps/web/modules/auth/auth-shell.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Home } from "lucide-react";
+import { SoftmapleWordmark } from "@/components/BrandMark";
+import { AuthBrandSpecimen } from "@/modules/auth/auth-brand-specimen";
+
+export type AuthShellProps = {
+  readonly children: ReactNode;
+  readonly description: string;
+  readonly title: string;
+};
+
+export const AuthShell = ({ children, description, title }: AuthShellProps) => (
+  <main className="min-h-dvh bg-background text-foreground">
+    <div className="mx-auto grid min-h-dvh w-full max-w-[96rem] lg:grid-cols-[minmax(0,1.08fr)_minmax(27rem,0.92fr)] lg:border-x">
+      <section className="flex min-w-0 flex-col px-5 py-6 sm:px-8 lg:min-h-dvh lg:px-12 lg:py-8 xl:px-16">
+        <div className="flex items-center justify-between gap-4">
+          <Link
+            className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            href="/"
+          >
+            <SoftmapleWordmark className="text-xl font-bold" />
+          </Link>
+          <Link
+            className="inline-flex items-center gap-2 rounded-sm px-2 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            href="/"
+          >
+            <Home className="size-4" /> Back home
+          </Link>
+        </div>
+
+        <div className="flex flex-1 flex-col justify-center py-12 sm:py-16 lg:py-12">
+          <div className="h-px w-12 bg-primary" />
+          <p className="mt-8 font-mono text-[10px] uppercase tracking-[0.24em] text-primary sm:text-xs">
+            Collaborative document infrastructure
+          </p>
+          <p className="mt-10 max-w-3xl font-display text-[clamp(2.75rem,11vw,5.5rem)] font-semibold leading-[0.88] tracking-[-0.055em]">
+            Ideas move.
+            <br />
+            The record
+            <br />
+            holds.
+          </p>
+          <p className="mt-8 hidden max-w-xl text-sm leading-7 text-muted-foreground lg:block xl:text-base">
+            Softmaple is a high-density workspace for durable collaborative
+            writing, live presence, Markdown and LaTeX output, and deliberate
+            public sharing.
+          </p>
+          <AuthBrandSpecimen />
+        </div>
+      </section>
+
+      <section className="flex min-w-0 items-center border-t bg-card/70 px-5 py-10 sm:px-8 sm:py-14 lg:min-h-dvh lg:border-l lg:border-t-0 lg:px-12 xl:px-16">
+        <div className="mx-auto w-full max-w-md">
+          <h1 className="font-display text-3xl font-semibold tracking-tight sm:text-4xl">
+            {title}
+          </h1>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground sm:text-base">
+            {description}
+          </p>
+          <div className="mt-8">{children}</div>
+        </div>
+      </section>
+    </div>
+  </main>
+);

--- a/apps/web/modules/auth/login-form.tsx
+++ b/apps/web/modules/auth/login-form.tsx
@@ -10,6 +10,10 @@ import { SubmitButton } from "@/modules/auth/submit-button";
 export const LoginForm = ({ next }: { readonly next?: string }) => {
   const [state, action] = useActionState(login, null);
   const router = useRouter();
+  const emailError =
+    state !== null && !state.ok ? state.fieldErrors?.email?.[0] : undefined;
+  const passwordError =
+    state !== null && !state.ok ? state.fieldErrors?.password?.[0] : undefined;
 
   useEffect(() => {
     if (state?.ok && state.data.redirectTo !== undefined) {
@@ -33,7 +37,10 @@ export const LoginForm = ({ next }: { readonly next?: string }) => {
       <div className="space-y-2">
         <Label htmlFor="email">Email</Label>
         <Input
-          aria-describedby="email-error"
+          aria-describedby={
+            emailError === undefined ? undefined : "email-error"
+          }
+          aria-invalid={emailError === undefined ? undefined : true}
           autoComplete="email"
           id="email"
           name="email"
@@ -41,25 +48,30 @@ export const LoginForm = ({ next }: { readonly next?: string }) => {
           placeholder="you@example.com"
           required
         />
-        <p className="text-xs text-destructive" id="email-error">
-          {state !== null && !state.ok ? state.fieldErrors?.email?.[0] : null}
-        </p>
+        {emailError === undefined ? null : (
+          <p className="text-xs text-destructive" id="email-error">
+            {emailError}
+          </p>
+        )}
       </div>
       <div className="space-y-2">
         <Label htmlFor="password">Password</Label>
         <Input
-          aria-describedby="password-error"
+          aria-describedby={
+            passwordError === undefined ? undefined : "password-error"
+          }
+          aria-invalid={passwordError === undefined ? undefined : true}
           autoComplete="current-password"
           id="password"
           name="password"
           type="password"
           required
         />
-        <p className="text-xs text-destructive" id="password-error">
-          {state !== null && !state.ok
-            ? state.fieldErrors?.password?.[0]
-            : null}
-        </p>
+        {passwordError === undefined ? null : (
+          <p className="text-xs text-destructive" id="password-error">
+            {passwordError}
+          </p>
+        )}
       </div>
       <SubmitButton />
     </form>

--- a/apps/web/modules/auth/reset-password-form.tsx
+++ b/apps/web/modules/auth/reset-password-form.tsx
@@ -8,14 +8,19 @@ import { SubmitButton } from "@/modules/auth/submit-button";
 
 export const ResetPasswordForm = () => {
   const [state, action] = useActionState(resetPassword, null);
+  const emailError =
+    state !== null && !state.ok ? state.fieldErrors?.email?.[0] : undefined;
+
   return (
     <form action={action} className="space-y-4">
       {state === null ? null : (
         <p
           className={
-            state.ok ? "text-sm text-teal-600" : "text-sm text-destructive"
+            state.ok
+              ? "border-l-2 border-primary bg-muted px-3 py-2 text-sm text-foreground"
+              : "border-l-2 border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive"
           }
-          role="status"
+          role={state.ok ? "status" : "alert"}
         >
           {state.ok ? state.data.message : state.message}
         </p>
@@ -23,15 +28,21 @@ export const ResetPasswordForm = () => {
       <div className="space-y-2">
         <Label htmlFor="email">Email</Label>
         <Input
+          aria-describedby={
+            emailError === undefined ? undefined : "email-error"
+          }
+          aria-invalid={emailError === undefined ? undefined : true}
           autoComplete="email"
           id="email"
           name="email"
           type="email"
           required
         />
-        <p className="text-xs text-destructive">
-          {state !== null && !state.ok ? state.fieldErrors?.email?.[0] : null}
-        </p>
+        {emailError === undefined ? null : (
+          <p className="text-xs text-destructive" id="email-error">
+            {emailError}
+          </p>
+        )}
       </div>
       <SubmitButton text="Send reset link" />
     </form>

--- a/apps/web/modules/auth/signup-form.tsx
+++ b/apps/web/modules/auth/signup-form.tsx
@@ -7,21 +7,35 @@ import { Input } from "@softmaple/ui/components/input";
 import { signup } from "@/app/actions/auth";
 import { SubmitButton } from "@/modules/auth/submit-button";
 
-const FieldError = ({
-  field,
-  state,
-}: {
-  readonly field: string;
-  readonly state: Awaited<ReturnType<typeof signup>> | null;
-}) => (
-  <p className="text-xs text-destructive" id={`${field}-error`}>
-    {state !== null && !state.ok ? state.fieldErrors?.[field]?.[0] : null}
-  </p>
-);
+type SignupState = Awaited<ReturnType<typeof signup>> | null;
+type SignupField =
+  | "confirmPassword"
+  | "email"
+  | "firstName"
+  | "lastName"
+  | "password";
+
+const getFieldError = (
+  state: SignupState,
+  field: SignupField,
+): string | undefined =>
+  state !== null && !state.ok ? state.fieldErrors?.[field]?.[0] : undefined;
+
+const FieldError = ({ id, message }: { id: string; message?: string }) =>
+  message === undefined ? null : (
+    <p className="text-xs text-destructive" id={id}>
+      {message}
+    </p>
+  );
 
 export const SignupForm = () => {
   const [state, action] = useActionState(signup, null);
   const router = useRouter();
+  const confirmPasswordError = getFieldError(state, "confirmPassword");
+  const emailError = getFieldError(state, "email");
+  const firstNameError = getFieldError(state, "firstName");
+  const lastNameError = getFieldError(state, "lastName");
+  const passwordError = getFieldError(state, "password");
 
   useEffect(() => {
     if (state?.ok && state.data.redirectTo !== undefined) {
@@ -43,56 +57,78 @@ export const SignupForm = () => {
         <div className="space-y-2">
           <Label htmlFor="firstName">First name</Label>
           <Input
+            aria-describedby={
+              firstNameError === undefined ? undefined : "firstName-error"
+            }
+            aria-invalid={firstNameError === undefined ? undefined : true}
             autoComplete="given-name"
             id="firstName"
             name="firstName"
             required
           />
-          <FieldError field="firstName" state={state} />
+          <FieldError id="firstName-error" message={firstNameError} />
         </div>
         <div className="space-y-2">
           <Label htmlFor="lastName">Last name</Label>
           <Input
+            aria-describedby={
+              lastNameError === undefined ? undefined : "lastName-error"
+            }
+            aria-invalid={lastNameError === undefined ? undefined : true}
             autoComplete="family-name"
             id="lastName"
             name="lastName"
             required
           />
-          <FieldError field="lastName" state={state} />
+          <FieldError id="lastName-error" message={lastNameError} />
         </div>
       </div>
       <div className="space-y-2">
         <Label htmlFor="email">Email</Label>
         <Input
+          aria-describedby={
+            emailError === undefined ? undefined : "email-error"
+          }
+          aria-invalid={emailError === undefined ? undefined : true}
           autoComplete="email"
           id="email"
           name="email"
           type="email"
           required
         />
-        <FieldError field="email" state={state} />
+        <FieldError id="email-error" message={emailError} />
       </div>
       <div className="space-y-2">
         <Label htmlFor="password">Password</Label>
         <Input
+          aria-describedby={
+            passwordError === undefined ? undefined : "password-error"
+          }
+          aria-invalid={passwordError === undefined ? undefined : true}
           autoComplete="new-password"
           id="password"
           name="password"
           type="password"
           required
         />
-        <FieldError field="password" state={state} />
+        <FieldError id="password-error" message={passwordError} />
       </div>
       <div className="space-y-2">
         <Label htmlFor="confirmPassword">Confirm password</Label>
         <Input
+          aria-describedby={
+            confirmPasswordError === undefined
+              ? undefined
+              : "confirmPassword-error"
+          }
+          aria-invalid={confirmPasswordError === undefined ? undefined : true}
           autoComplete="new-password"
           id="confirmPassword"
           name="confirmPassword"
           type="password"
           required
         />
-        <FieldError field="confirmPassword" state={state} />
+        <FieldError id="confirmPassword-error" message={confirmPasswordError} />
       </div>
       <SubmitButton text="Create account" loadingText="Creating account..." />
     </form>

--- a/apps/web/modules/auth/update-password-form.tsx
+++ b/apps/web/modules/auth/update-password-form.tsx
@@ -10,6 +10,13 @@ import { SubmitButton } from "@/modules/auth/submit-button";
 export const UpdatePasswordForm = () => {
   const [state, action] = useActionState(updatePassword, null);
   const router = useRouter();
+  const confirmPasswordError =
+    state !== null && !state.ok
+      ? state.fieldErrors?.confirmPassword?.[0]
+      : undefined;
+  const passwordError =
+    state !== null && !state.ok ? state.fieldErrors?.password?.[0] : undefined;
+
   useEffect(() => {
     if (state?.ok && state.data.redirectTo !== undefined) {
       router.replace(state.data.redirectTo);
@@ -19,39 +26,52 @@ export const UpdatePasswordForm = () => {
   return (
     <form action={action} className="space-y-4">
       {state !== null && !state.ok ? (
-        <p className="text-sm text-destructive" role="alert">
+        <p
+          className="border-l-2 border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          role="alert"
+        >
           {state.message}
         </p>
       ) : null}
       <div className="space-y-2">
         <Label htmlFor="password">New password</Label>
         <Input
+          aria-describedby={
+            passwordError === undefined ? undefined : "password-error"
+          }
+          aria-invalid={passwordError === undefined ? undefined : true}
           autoComplete="new-password"
           id="password"
           name="password"
           type="password"
           required
         />
-        <p className="text-xs text-destructive">
-          {state !== null && !state.ok
-            ? state.fieldErrors?.password?.[0]
-            : null}
-        </p>
+        {passwordError === undefined ? null : (
+          <p className="text-xs text-destructive" id="password-error">
+            {passwordError}
+          </p>
+        )}
       </div>
       <div className="space-y-2">
         <Label htmlFor="confirmPassword">Confirm new password</Label>
         <Input
+          aria-describedby={
+            confirmPasswordError === undefined
+              ? undefined
+              : "confirmPassword-error"
+          }
+          aria-invalid={confirmPasswordError === undefined ? undefined : true}
           autoComplete="new-password"
           id="confirmPassword"
           name="confirmPassword"
           type="password"
           required
         />
-        <p className="text-xs text-destructive">
-          {state !== null && !state.ok
-            ? state.fieldErrors?.confirmPassword?.[0]
-            : null}
-        </p>
+        {confirmPasswordError === undefined ? null : (
+          <p className="text-xs text-destructive" id="confirmPassword-error">
+            {confirmPasswordError}
+          </p>
+        )}
       </div>
       <SubmitButton text="Update password" />
     </form>

--- a/apps/web/modules/workspaces/workspace-desktop-sidebar.tsx
+++ b/apps/web/modules/workspaces/workspace-desktop-sidebar.tsx
@@ -1,7 +1,7 @@
 import type { FC, ReactNode } from "react";
 import Link from "next/link";
-import { FileText } from "lucide-react";
 import type { DocsType } from "@/types/model";
+import { SoftmapleWordmark } from "@/components/BrandMark";
 import { WorkspaceNavigation } from "@/modules/workspaces/workspace-navigation";
 import { WorkspaceDocsList } from "@/modules/workspaces/workspace-docs-list";
 
@@ -20,11 +20,11 @@ export const WorkspaceDesktopSidebar: FC<WorkspaceDesktopSidebarProps> = ({
 }) => (
   <aside className="hidden w-72 shrink-0 flex-col border-r bg-sidebar md:flex xl:w-80">
     <div className="border-b p-4">
-      <Link className="mb-4 flex items-center gap-2" href="/dashboard">
-        <span className="grid size-8 place-items-center rounded-sm border bg-background text-primary">
-          <FileText className="size-4" />
-        </span>
-        <span className="font-display font-semibold">Softmaple</span>
+      <Link
+        className="mb-4 inline-flex rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+        href="/dashboard"
+      >
+        <SoftmapleWordmark className="text-lg" />
       </Link>
       {children}
     </div>

--- a/apps/web/modules/workspaces/workspace-dropdown.tsx
+++ b/apps/web/modules/workspaces/workspace-dropdown.tsx
@@ -8,17 +8,23 @@ import {
   DropdownMenuTrigger,
 } from "@softmaple/ui/components/dropdown-menu";
 import { Button } from "@softmaple/ui/components/button";
-import { ChevronDown, FileText, Plus, Settings } from "lucide-react";
+import { ChevronDown, LayoutGrid, Settings } from "lucide-react";
 import type { WorkspaceSummary } from "@/app/actions/workspaces";
+import { RaspberryRecordMark } from "@/components/BrandMark";
 import Link from "next/link";
 
 export type WorkspaceDropdownProps = {
+  compact?: boolean;
   workspaceSlug: string;
   workspaces: ReadonlyArray<WorkspaceSummary>;
 };
 
 export const WorkspaceDropdown: FC<WorkspaceDropdownProps> = (props) => {
-  const { workspaceSlug, workspaces: workspaceSummaries } = props;
+  const {
+    compact = false,
+    workspaceSlug,
+    workspaces: workspaceSummaries,
+  } = props;
 
   const workspaces = workspaceSummaries.map((workspace) => ({
     ...workspace,
@@ -34,37 +40,42 @@ export const WorkspaceDropdown: FC<WorkspaceDropdownProps> = (props) => {
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          className="flex items-center space-x-2 mb-4 w-full justify-start p-2 h-auto"
+          className={`w-full min-w-0 justify-start gap-2 overflow-hidden p-2 ${
+            compact ? "h-10" : "mb-4 h-auto"
+          }`}
         >
-          <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-lg flex items-center justify-center">
-            <FileText className="w-5 h-5 text-white" />
+          <RaspberryRecordMark className={compact ? "size-7" : "size-10"} />
+          <div className="min-w-0 flex-1 text-left">
+            <h2 className="truncate font-semibold">
+              {currentWorkspace?.title ?? "Workspace"}
+            </h2>
+            {compact ? null : (
+              <p className="truncate text-sm text-muted-foreground">
+                {currentWorkspace?.description || "Shared writing space"}
+              </p>
+            )}
           </div>
-          <div className="flex-1 text-left">
-            <h2 className="font-semibold">{currentWorkspace?.title}</h2>
-            <p className="text-sm text-muted-foreground">
-              {currentWorkspace?.description}
-            </p>
-          </div>
-          <ChevronDown className="h-4 w-4" />
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-64" align="start">
-        <DropdownMenuLabel>Switch Workspace</DropdownMenuLabel>
+      <DropdownMenuContent
+        className="w-[min(20rem,calc(100vw-2rem))]"
+        align="start"
+      >
+        <DropdownMenuLabel>Switch workspace</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {workspaces.map((workspace) => {
           return (
             <DropdownMenuItem asChild key={workspace.key}>
-              <Link href={`/workspace/${workspace.slug}`}>
-                <div className="flex items-center space-x-2">
-                  <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-lg flex items-center justify-center">
-                    <FileText className="w-4 h-4 text-white" />
-                  </div>
-                  <div>
-                    <div className="font-medium">{workspace.title}</div>
-                    <div className="text-xs text-muted-foreground">
+              <Link className="min-w-0" href={`/workspace/${workspace.slug}`}>
+                <RaspberryRecordMark className="size-8" />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-medium">{workspace.title}</div>
+                  {workspace.description ? (
+                    <div className="truncate text-xs text-muted-foreground">
                       {workspace.description}
                     </div>
-                  </div>
+                  ) : null}
                 </div>
               </Link>
             </DropdownMenuItem>
@@ -73,13 +84,13 @@ export const WorkspaceDropdown: FC<WorkspaceDropdownProps> = (props) => {
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link href="/dashboard">
-            <Plus className="mr-2 h-4 w-4" />
-            Create New Workspace
+            <LayoutGrid className="mr-2 size-4" />
+            All workspaces
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
           <Link href={`/workspace/${workspaceSlug}/settings`}>
-            <Settings className="mr-2 h-4 w-4" />
+            <Settings className="mr-2 size-4" />
             Workspace settings
           </Link>
         </DropdownMenuItem>

--- a/apps/web/modules/workspaces/workspace-mobile-sidebar.tsx
+++ b/apps/web/modules/workspaces/workspace-mobile-sidebar.tsx
@@ -3,15 +3,17 @@
 import type { FC, ReactNode } from "react";
 import { useState } from "react";
 import Link from "next/link";
-import { FileText, Menu } from "lucide-react";
+import { Menu } from "lucide-react";
 import { Button } from "@softmaple/ui/components/button";
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetTitle,
   SheetTrigger,
 } from "@softmaple/ui/components/sheet";
 import type { DocsType } from "@/types/model";
+import { SoftmapleWordmark } from "@/components/BrandMark";
 import { WorkspaceDocsList } from "@/modules/workspaces/workspace-docs-list";
 import { WorkspaceNavigation } from "@/modules/workspaces/workspace-navigation";
 
@@ -32,47 +34,45 @@ export const WorkspaceMobileSidebar: FC<WorkspaceMobileSidebarProps> = ({
   const close = (): void => setOpen(false);
 
   return (
-    <div className="fixed left-3 top-3 z-50 md:hidden">
-      <Sheet onOpenChange={setOpen} open={open}>
+    <Sheet onOpenChange={setOpen} open={open}>
+      <header className="flex h-14 shrink-0 items-center gap-2 border-b bg-background/90 px-3 backdrop-blur md:hidden">
         <SheetTrigger asChild>
           <Button
             aria-label="Open workspace navigation"
-            size="icon"
+            className="shrink-0"
+            size="icon-sm"
             variant="outline"
           >
             <Menu className="size-4" />
           </Button>
         </SheetTrigger>
-        <SheetContent
-          className="flex w-[min(20rem,90vw)] flex-col p-0"
-          side="left"
-        >
-          <SheetTitle className="sr-only">Workspace navigation</SheetTitle>
-          <div className="border-b p-4">
-            <Link
-              className="mb-4 flex items-center gap-2"
-              href="/dashboard"
-              onClick={close}
-            >
-              <span className="grid size-8 place-items-center rounded-sm border bg-background text-primary">
-                <FileText className="size-4" />
-              </span>
-              <span className="font-display font-semibold">Softmaple</span>
-            </Link>
-            {children}
-          </div>
-          <WorkspaceNavigation
-            onNavigate={close}
-            workspaceSlug={workspaceSlug}
-          />
-          <WorkspaceDocsList
-            canEdit={canEdit}
-            documents={documents}
-            onNavigate={close}
-            workspaceSlug={workspaceSlug}
-          />
-        </SheetContent>
-      </Sheet>
-    </div>
+        <div className="min-w-0 flex-1">{children}</div>
+      </header>
+      <SheetContent
+        className="flex h-dvh min-h-0 w-[min(20rem,90vw)] flex-col gap-0 p-0"
+        side="left"
+      >
+        <SheetTitle className="sr-only">Workspace navigation</SheetTitle>
+        <SheetDescription className="sr-only">
+          Browse workspace sections and documents.
+        </SheetDescription>
+        <div className="shrink-0 border-b p-4">
+          <Link
+            className="inline-flex rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+            href="/dashboard"
+            onClick={close}
+          >
+            <SoftmapleWordmark className="text-lg" />
+          </Link>
+        </div>
+        <WorkspaceNavigation onNavigate={close} workspaceSlug={workspaceSlug} />
+        <WorkspaceDocsList
+          canEdit={canEdit}
+          documents={documents}
+          onNavigate={close}
+          workspaceSlug={workspaceSlug}
+        />
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/apps/web/modules/workspaces/workspace-navigation.test.tsx
+++ b/apps/web/modules/workspaces/workspace-navigation.test.tsx
@@ -71,6 +71,8 @@ describe("WorkspaceNavigation", () => {
       "false",
     );
     expect(prefetchByHref["/workspace/acme/settings"]).toBe("false");
+    expect(container.querySelectorAll("a")).toHaveLength(3);
+    expect(container.querySelector("a button, button a")).toBeNull();
     act(() => {
       root.unmount();
     });

--- a/apps/web/modules/workspaces/workspace-navigation.tsx
+++ b/apps/web/modules/workspaces/workspace-navigation.tsx
@@ -21,56 +21,59 @@ export const WorkspaceNavigation: FC<WorkspaceNavigationProps> = (props) => {
 
   return (
     <div className="p-4 space-y-2">
-      <Link href={`/workspace/${workspaceSlug}`} onClick={onNavigate}>
-        <Button
-          variant={
-            isActive(`/workspace/${workspaceSlug}`) ? "secondary" : "ghost"
-          }
-          className="w-full justify-start"
-        >
+      <Button
+        asChild
+        className="w-full justify-start"
+        variant={
+          isActive(`/workspace/${workspaceSlug}`) ? "secondary" : "ghost"
+        }
+      >
+        <Link href={`/workspace/${workspaceSlug}`} onClick={onNavigate}>
           <Home className="mr-2 h-4 w-4" />
           Overview
-        </Button>
-      </Link>
+        </Link>
+      </Button>
       {/*
         Settings/Members are auth- and membership-sensitive admin routes.
         Speculative Link prefetch can race session refresh and historically
         collapsed ActionResult failures into cacheable 404s; load on navigate.
       */}
-      <Link
-        href={`/workspace/${workspaceSlug}/settings?tab=members`}
-        onClick={onNavigate}
-        prefetch={false}
+      <Button
+        asChild
+        className="w-full justify-start"
+        variant={
+          isSettings && searchParams.get("tab") === "members"
+            ? "secondary"
+            : "ghost"
+        }
       >
-        <Button
-          className="w-full justify-start"
-          variant={
-            isSettings && searchParams.get("tab") === "members"
-              ? "secondary"
-              : "ghost"
-          }
+        <Link
+          href={`/workspace/${workspaceSlug}/settings?tab=members`}
+          onClick={onNavigate}
+          prefetch={false}
         >
           <Users className="mr-2 h-4 w-4" />
           Members
-        </Button>
-      </Link>
-      <Link
-        href={`/workspace/${workspaceSlug}/settings`}
-        onClick={onNavigate}
-        prefetch={false}
+        </Link>
+      </Button>
+      <Button
+        asChild
+        className="w-full justify-start"
+        variant={
+          isSettings && searchParams.get("tab") !== "members"
+            ? "secondary"
+            : "ghost"
+        }
       >
-        <Button
-          variant={
-            isSettings && searchParams.get("tab") !== "members"
-              ? "secondary"
-              : "ghost"
-          }
-          className="w-full justify-start"
+        <Link
+          href={`/workspace/${workspaceSlug}/settings`}
+          onClick={onNavigate}
+          prefetch={false}
         >
           <Settings className="mr-2 h-4 w-4" />
           Settings
-        </Button>
-      </Link>
+        </Link>
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
Close #878 

## Summary

- Extract shared `BrandMark`, `RouteError`, `RouteLoading`, and auth shell components for the web app, then wire login/signup/reset-password flows and workspace chrome to the new brand system.
- Refactor the Lexical eg-walker playground into focused workspace chrome (`LexicalWorkspaceChrome`, presence rail, room copy control) with improved focus rings, reduced-motion handling, and accessibility labels.
- Fix workspace navigation markup by using `Button asChild` with `Link` to avoid nested interactive elements.

## Test plan

- [x] `pnpm --filter @softmaple/web test -- apps/web/modules/workspaces/workspace-navigation.test.tsx`
- [x] `pnpm --filter @softmaple/playground test -- src/modules/lexical-eg-walker/RoomCopyControl.test.tsx`
- [ ] Manual: verify auth pages (login, signup, reset password) render the new shell
- [ ] Manual: open Lexical eg-walker demo and confirm room copy + presence rail UX
- [ ] Manual: check workspace sidebar/dropdown on mobile and desktop


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collaborative Lexical editor with document status, participant presence, remote selections, and room-link copying.
  * Added branded authentication layouts, OAuth options, loading states, and retryable error screens.
  * Added responsive workspace navigation and refreshed Softmaple branding.
* **Accessibility & Usability**
  * Improved focus states, touch targets, screen-reader descriptions, form validation feedback, navigation structure, and reduced-motion support.
* **Bug Fixes**
  * Dashboard, workspace, document, and authentication errors now provide clear recovery actions.
* **Configuration**
  * Added an option to enable playground developer tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->