### PR TITLE
fix(apps/collab-cloudflare): restore the authentication deadline and answer presence closes

### DIFF
--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -55,12 +55,30 @@ so no room timer prevents an idle object from hibernating.
 Owning the whole connection also means owning its ending: `webSocketClose`
 answers the client's close frame, echoing valid non-reserved close codes
 and mapping invalid or reserved codes to 1000 so the handshake completes
-cleanly instead of the client timing out at 1006. Nothing schedules a document
-alarm, so an idle object still hibernates — including a socket that connects
-and never sends `Auth`. Such a socket holds no session, no connection lease,
-and no isolate; it is simply hibernated until it closes. There is no longer a
-Worker-side authentication deadline, because there is no longer a Worker-side
-socket to hold one.
+cleanly instead of the client timing out at 1006. `PresenceRoomDO` answers
+its clients' close frames the same way, through the same shared
+`websocket-close.ts`.
+
+A socket that connects and never sends `Auth` is closed 1008
+`Authentication timed out` at `INITIAL_AUTH_TIMEOUT_MS` (`constants.ts`).
+Both room objects enforce that deadline from a Durable Object alarm rather
+than the `setTimeout` the removed Worker proxy used, because no timer
+survives hibernation and no Worker-side socket is left to hold one. The
+accepted-at instant lives in each socket's attachment, so `alarm()` decides
+purely from attachments: a woken object evicts exactly the sockets a live one
+would, without restoring the room, revalidating a session, or calling
+Supabase — an unauthenticated socket holds no session, membership, or
+connection lease, so closing its transport is the whole eviction. The shared
+policy is `auth-deadline.ts`; a Durable Object has one alarm, so an
+authentication deadline may only pull an already-scheduled wake-up forward
+(`PresenceRoomDO`'s liveness sweep keeps its own 30s cadence). The document
+object schedules an alarm only while a socket is still awaiting `Auth` and
+re-arms only while one remains, so an idle authenticated room still
+hibernates with no timer at all. The accepted-at instant is a required
+attachment field, so a socket that was still awaiting `Auth` across a
+deployment fails the attachment parse when its object wakes on the new
+version and is closed like any other unreadable attachment — it has no
+session to lose, and the client reconnects and authenticates again.
 
 Expired peers are revalidated on room activity; if a persistence operation
 crosses a validation deadline, repair responses are checked again and expired
@@ -115,8 +133,9 @@ Cloudflare Durable Object alarm (`PRESENCE_ALARM_INTERVAL_MS`, `constants.ts`)
 is the liveness backstop: it is the only timer mechanism that survives
 hibernation, so it drives `PresenceRoom.sweep()` to close expired heartbeats
 and broadcast Leave for lapsed members even when the room is otherwise idle.
-The alarm reschedules itself only while a WebSocket is still attached, so an
-empty room does not keep waking the object.
+The same alarm also runs the shared authentication-deadline sweep described
+above. The alarm reschedules itself only while a WebSocket is still attached,
+so an empty room does not keep waking the object.
 
 ## Environment
 

--- a/apps/collab-cloudflare/eslint.config.js
+++ b/apps/collab-cloudflare/eslint.config.js
@@ -9,8 +9,12 @@ import { config } from "@softmaple/eslint-config/base";
 // symmetrically for the document side. `src/index.ts` and `test/worker.ts`
 // are composition roots that legitimately wire both sides, so neither glob
 // below includes them.
+// `auth-deadline` and `websocket-close` are shared the same way the others
+// are: pure policy/helper functions plus a caller-supplied-storage alarm
+// write. They hold no capability instance and reach neither object's room,
+// so importing them creates no coupling between the two sides.
 const SHARED_UTILITY_FILES =
-  "constants|document-id|origin|message-bytes|supabaseTypes";
+  "auth-deadline|constants|document-id|origin|message-bytes|supabaseTypes|websocket-close";
 const PRESENCE_OWN_FILES =
   "presence-[\\w-]*|awareness-presence-codec|supabase-presence-backend|memory-presence-backend";
 const DOCUMENT_OWN_FILES =

--- a/apps/collab-cloudflare/src/auth-deadline.ts
+++ b/apps/collab-cloudflare/src/auth-deadline.ts
@@ -1,0 +1,82 @@
+import { INITIAL_AUTH_TIMEOUT_MS } from "./constants";
+
+/** Close code and reason a room object answers an expired deadline with. */
+export const AUTH_DEADLINE_CLOSE_CODE = 1008;
+export const AUTH_DEADLINE_CLOSE_REASON = "Authentication timed out";
+
+/**
+ * A socket a room object accepted but that has not authenticated yet, paired
+ * with the instant its authentication deadline expires.
+ */
+export interface PendingAuthSocket {
+  readonly deadline: number;
+  readonly socket: WebSocket;
+}
+
+export interface AuthDeadlineSweep {
+  /** Sockets past their deadline; the caller closes and releases each one. */
+  readonly expired: readonly WebSocket[];
+  /** Earliest deadline still ahead, or `null` when nothing is pending. */
+  readonly nextDeadline: number | null;
+}
+
+/** The instant a socket accepted at `connectedAt` must have authenticated by. */
+export const authDeadlineFrom = (connectedAt: number): number =>
+  connectedAt + INITIAL_AUTH_TIMEOUT_MS;
+
+/**
+ * Reads the pending sockets off the hibernation API's own socket list. The
+ * caller supplies the accepted-at instant from each socket's attachment, so
+ * this works identically on a live object and on one the alarm just woke
+ * from hibernation with no in-memory state. Sockets already closing are
+ * skipped: they are leaving on their own.
+ */
+export const collectPendingAuthSockets = (
+  sockets: Iterable<WebSocket>,
+  connectedAtOf: (socket: WebSocket) => number | null,
+): readonly PendingAuthSocket[] =>
+  [...sockets].flatMap((socket) => {
+    if (socket.readyState >= WebSocket.CLOSING) return [];
+    const connectedAt = connectedAtOf(socket);
+    return connectedAt === null
+      ? []
+      : [{ deadline: authDeadlineFrom(connectedAt), socket }];
+  });
+
+export const earliestAuthDeadline = (
+  pending: readonly PendingAuthSocket[],
+): number | null =>
+  pending.reduce<number | null>(
+    (earliest, { deadline }) =>
+      earliest === null ? deadline : Math.min(earliest, deadline),
+    null,
+  );
+
+/** Splits the pending sockets into what expires now and when to wake next. */
+export const planAuthDeadlineSweep = (
+  pending: readonly PendingAuthSocket[],
+  now: number,
+): AuthDeadlineSweep => ({
+  expired: pending
+    .filter(({ deadline }) => deadline <= now)
+    .map(({ socket }) => socket),
+  nextDeadline: earliestAuthDeadline(
+    pending.filter(({ deadline }) => deadline > now),
+  ),
+});
+
+/**
+ * Moves the object's alarm earlier, never later. A Durable Object has exactly
+ * one alarm, and a room object may already have other work scheduled on it
+ * (`PresenceRoomDO`'s liveness sweep), so an authentication deadline may only
+ * pull an existing wake-up forward — never push it back or cancel it. A
+ * deadline already in the past schedules an immediate wake-up.
+ */
+export const scheduleAlarmAt = async (
+  storage: DurableObjectStorage,
+  at: number | null,
+): Promise<void> => {
+  if (at === null) return;
+  const scheduled = await storage.getAlarm();
+  if (scheduled === null || scheduled > at) await storage.setAlarm(at);
+};

--- a/apps/collab-cloudflare/src/constants.ts
+++ b/apps/collab-cloudflare/src/constants.ts
@@ -14,6 +14,12 @@ export const MAX_MESSAGE_BYTES = 256 * 1024;
 // future versioned fields.
 export const MAX_PERSISTED_AUTH_BYTES = 8 * 1024;
 
+// How long a socket may stay connected without completing authentication.
+// Both room objects enforce it from an alarm (`auth-deadline.ts`) rather than
+// a `setTimeout`, because a timer cannot survive hibernation and no Worker
+// socket sits in front of either object to hold one.
+export const INITIAL_AUTH_TIMEOUT_MS = 10_000;
+
 // Presence frames carry no document payload, so the transport limit can stay
 // well below the document room's 256 KiB.
 export const MAX_PRESENCE_MESSAGE_BYTES = 64 * 1024;

--- a/apps/collab-cloudflare/src/document-room-do.ts
+++ b/apps/collab-cloudflare/src/document-room-do.ts
@@ -19,8 +19,19 @@ import {
   type RoomPeer,
 } from "@softmaple/collab-runtime";
 import {
+  authDeadlineFrom,
+  AUTH_DEADLINE_CLOSE_CODE,
+  AUTH_DEADLINE_CLOSE_REASON,
+  collectPendingAuthSockets,
+  earliestAuthDeadline,
+  planAuthDeadlineSweep,
+  scheduleAlarmAt,
+  type PendingAuthSocket,
+} from "./auth-deadline";
+import {
   errorMessage,
   logError,
+  logMetric,
   MAX_MESSAGE_BYTES,
   MAX_PERSISTED_AUTH_BYTES,
   MESSAGE_RATE_LIMIT_MAX,
@@ -29,6 +40,7 @@ import {
 import { documentIdFromRequestUrl, normalizeDocumentId } from "./document-id";
 import { messageBytes, textFromMessage } from "./message-bytes";
 import { createRoomServices } from "./room-services";
+import { completeClose } from "./websocket-close";
 import {
   attachmentAfterReady,
   attachmentAfterResume,
@@ -355,20 +367,10 @@ interface RestoredPeer {
   readonly socket: WebSocket;
 }
 
-const NORMAL_CLOSURE = 1000;
-// Reserved codes: a close event may report them, but a close frame must never
-// carry one, so an unclean client close is answered with a normal closure.
-const RESERVED_CLOSE_CODES: ReadonlySet<number> = new Set([
-  1004, 1005, 1006, 1015,
-]);
-
-const echoableCloseCode = (code: number): number =>
-  Number.isInteger(code) &&
-  code >= 1000 &&
-  code <= 4999 &&
-  !RESERVED_CLOSE_CODES.has(code)
-    ? code
-    : NORMAL_CLOSURE;
+const CLOSE_ECHO_FALLBACK = {
+  messageType: "websocket-close-echo",
+  reason: "Collaboration connection closed",
+} as const;
 
 export class DocumentRoomDO extends DurableObject<Env> {
   private documentId: string | null = null;
@@ -421,6 +423,10 @@ export class DocumentRoomDO extends DurableObject<Env> {
       peer = new DurableObjectRoomPeer(room, server, attachment);
       this.peers.set(peer.id, peer);
       await room.join(peer);
+      await scheduleAlarmAt(
+        this.ctx.storage,
+        authDeadlineFrom(attachment.connectedAt),
+      );
     } catch (error) {
       logError(error, { documentId, messageType: "room-join" });
       if (peer !== null) await peer.transportClosed();
@@ -483,7 +489,7 @@ export class DocumentRoomDO extends DurableObject<Env> {
     reason: string,
   ): Promise<void> {
     const peer = this.peerFromSocket(socket);
-    this.completeClose(socket, code, reason);
+    completeClose(socket, code, reason, CLOSE_ECHO_FALLBACK);
     if (peer === null) return;
     await peer.transportClosed();
     this.peers.delete(peer.id);
@@ -499,6 +505,64 @@ export class DocumentRoomDO extends DurableObject<Env> {
       return;
     }
     await peer.transportError(error);
+    this.peers.delete(peer.id);
+  }
+
+  /**
+   * The authentication deadline, and nothing else. A document room needs no
+   * periodic timer — authorization and lease maintenance are message-driven —
+   * so this alarm is scheduled only while a socket is still awaiting `Auth`
+   * and re-arms only while one remains: an idle authenticated room still
+   * hibernates with no timer at all.
+   *
+   * Enforcement reads each socket's attachment rather than in-memory state,
+   * so a woken object evicts exactly the sockets a live one would. That is
+   * what replaces the deadline the removed Worker proxy held in a
+   * `setTimeout` no hibernating object could keep, and it needs no room, no
+   * session revalidation, and no Supabase call to run.
+   */
+  async alarm(): Promise<void> {
+    const { expired, nextDeadline } = planAuthDeadlineSweep(
+      this.pendingAuthSockets(),
+      Date.now(),
+    );
+    await Promise.all(
+      expired.map((socket) => this.closeUnauthenticated(socket)),
+    );
+    await scheduleAlarmAt(this.ctx.storage, nextDeadline);
+  }
+
+  /** Shared with `PresenceRoomDO`; `auth-deadline.ts` owns the policy. */
+  private pendingAuthSockets(): readonly PendingAuthSocket[] {
+    return collectPendingAuthSockets(this.ctx.getWebSockets(), (socket) => {
+      const attachment = this.attachmentFromSocket(socket);
+      return attachment !== null && attachment.phase === "awaiting-auth"
+        ? attachment.connectedAt
+        : null;
+    });
+  }
+
+  private async closeUnauthenticated(socket: WebSocket): Promise<void> {
+    const attachment = this.attachmentFromSocket(socket);
+    logMetric({
+      type: "auth-deadline-expired",
+      documentId: attachment?.documentId ?? this.documentId,
+      peerId: attachment?.peerId ?? null,
+    });
+    const peer = this.peerFromSocket(socket);
+    if (peer === null) {
+      // A woken object holds no peer for a hibernating socket; closing the
+      // transport is the whole cleanup, since an unauthenticated peer never
+      // took a session or a connection lease.
+      try {
+        socket.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
+      } catch (error) {
+        logError(error, { messageType: "auth-deadline-close" });
+      }
+      return;
+    }
+    peer.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
+    await peer.transportClosed();
     this.peers.delete(peer.id);
   }
 
@@ -598,6 +662,13 @@ export class DocumentRoomDO extends DurableObject<Env> {
       this.room = null;
       throw error;
     }
+    // The alarm itself survives hibernation in storage, so this only covers a
+    // deadline left unscheduled by an earlier failed write; a deadline already
+    // past schedules an immediate wake-up rather than closing sockets here.
+    await scheduleAlarmAt(
+      this.ctx.storage,
+      earliestAuthDeadline(this.pendingAuthSockets()),
+    );
   }
 
   private async discardRestoredPeers(
@@ -669,30 +740,6 @@ export class DocumentRoomDO extends DurableObject<Env> {
     return (
       [...this.peers.values()].find((peer) => peer.ownsSocket(socket)) ?? null
     );
-  }
-
-  /**
-   * Answers the client's close frame. A hibernatable socket's handshake is
-   * the object's own responsibility: the runtime reports the client's close
-   * through `webSocketClose` and sends no close frame of its own, so an
-   * unanswered close leaves the browser waiting for its half until it gives
-   * up with 1006. The removed Worker proxy used to terminate the browser
-   * socket in front of the object and completed this handshake there; direct
-   * routing gives the object the whole connection, including its ending.
-   */
-  private completeClose(socket: WebSocket, code: number, reason: string): void {
-    // The socket is already CLOSING here — the client's frame arrived — so
-    // this deliberately does not use `failSocket`'s `< CLOSING` guard.
-    if (socket.readyState === WebSocket.CLOSED) return;
-    const echoed = echoableCloseCode(code);
-    try {
-      socket.close(
-        echoed,
-        echoed === code ? reason : "Collaboration connection closed",
-      );
-    } catch (error) {
-      logError(error, { messageType: "websocket-close-echo" });
-    }
   }
 
   private failSocket(

--- a/apps/collab-cloudflare/src/document-room-do.ts
+++ b/apps/collab-cloudflare/src/document-room-do.ts
@@ -542,28 +542,35 @@ export class DocumentRoomDO extends DurableObject<Env> {
     });
   }
 
+  /**
+   * Never rejects. One socket that resists closing must not cancel the other
+   * evictions or the re-arm that keeps the deadline enforceable at all — an
+   * `alarm()` that throws has already been consumed, so an escaping error is
+   * exactly how "nothing evicts them" would come back. A socket left open by
+   * a failed close is still awaiting `Auth`, so the next sweep finds it again.
+   */
   private async closeUnauthenticated(socket: WebSocket): Promise<void> {
     const attachment = this.attachmentFromSocket(socket);
-    logMetric({
-      type: "auth-deadline-expired",
+    const identity = {
       documentId: attachment?.documentId ?? this.documentId,
       peerId: attachment?.peerId ?? null,
-    });
-    const peer = this.peerFromSocket(socket);
-    if (peer === null) {
-      // A woken object holds no peer for a hibernating socket; closing the
-      // transport is the whole cleanup, since an unauthenticated peer never
-      // took a session or a connection lease.
-      try {
+    };
+    try {
+      logMetric({ ...identity, type: "auth-deadline-expired" });
+      const peer = this.peerFromSocket(socket);
+      if (peer === null) {
+        // A woken object holds no peer for a hibernating socket; closing the
+        // transport is the whole cleanup, since an unauthenticated peer never
+        // took a session or a connection lease.
         socket.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
-      } catch (error) {
-        logError(error, { messageType: "auth-deadline-close" });
+        return;
       }
-      return;
+      peer.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
+      await peer.transportClosed();
+      this.peers.delete(peer.id);
+    } catch (error) {
+      logError(error, { ...identity, messageType: "auth-deadline-close" });
     }
-    peer.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
-    await peer.transportClosed();
-    this.peers.delete(peer.id);
   }
 
   private async ensureRoom(documentId: string): Promise<DocumentRoom | null> {

--- a/apps/collab-cloudflare/src/presence-attachment.ts
+++ b/apps/collab-cloudflare/src/presence-attachment.ts
@@ -19,6 +19,13 @@ interface PresenceWebSocketAttachmentBase {
 
 export interface AwaitingAuthPresenceAttachment
   extends PresenceWebSocketAttachmentBase {
+  /**
+   * When the object accepted this socket. The authentication deadline is
+   * derived from it (`auth-deadline.ts`), and it lives in the attachment
+   * rather than in memory so a hibernation-woken object enforces the same
+   * deadline a live one would.
+   */
+  readonly connectedAt: number;
   readonly phase: "awaiting-auth";
 }
 
@@ -76,7 +83,9 @@ const parseIdentity = (value: unknown): PresenceIdentity | null => {
 /** Presence rooms share the document id space; identity is validated the same way. */
 export const createAwaitingAuthAttachment = (
   roomId: string,
+  now = Date.now(),
 ): AwaitingAuthPresenceAttachment => ({
+  connectedAt: now,
   peerId: crypto.randomUUID(),
   phase: "awaiting-auth",
   roomId,
@@ -102,7 +111,13 @@ export const parsePresenceWebSocketAttachment = (
     version: ATTACHMENT_VERSION,
   } as const;
   if (value.phase === "awaiting-auth") {
-    return { ...base, phase: "awaiting-auth" };
+    // A socket whose accepted-at instant is missing or malformed has no
+    // enforceable authentication deadline, so it is rejected like any other
+    // unreadable attachment and closed — which is what an unauthenticated
+    // socket gets at its deadline anyway.
+    return isNonNegativeInteger(value.connectedAt)
+      ? { ...base, connectedAt: value.connectedAt, phase: "awaiting-auth" }
+      : null;
   }
   if (
     value.phase !== "authenticated" ||

--- a/apps/collab-cloudflare/src/presence-room-do.ts
+++ b/apps/collab-cloudflare/src/presence-room-do.ts
@@ -9,7 +9,18 @@ import {
   type PresenceRoomServices,
 } from "@softmaple/collab-runtime";
 import {
+  authDeadlineFrom,
+  AUTH_DEADLINE_CLOSE_CODE,
+  AUTH_DEADLINE_CLOSE_REASON,
+  collectPendingAuthSockets,
+  earliestAuthDeadline,
+  planAuthDeadlineSweep,
+  scheduleAlarmAt,
+  type PendingAuthSocket,
+} from "./auth-deadline";
+import {
   logError,
+  logMetric,
   MAX_PERSISTED_PRESENCE_BYTES,
   MAX_PRESENCE_MESSAGE_BYTES,
   PRESENCE_ALARM_INTERVAL_MS,
@@ -24,6 +35,12 @@ import {
   type PresenceWebSocketAttachment,
 } from "./presence-attachment";
 import { createPresenceServices } from "./presence-services";
+import { completeClose } from "./websocket-close";
+
+const CLOSE_ECHO_FALLBACK = {
+  messageType: "presence-websocket-close-echo",
+  reason: "Presence connection closed",
+} as const;
 
 const jsonBytes = (value: unknown): number =>
   new TextEncoder().encode(JSON.stringify(value)).byteLength;
@@ -255,6 +272,10 @@ export class PresenceRoomDO extends DurableObject<Env> {
       peer = new DurableObjectPresencePeer(room, server, attachment);
       this.peers.set(peer.id, peer);
       await room.join(peer);
+      await scheduleAlarmAt(
+        this.ctx.storage,
+        authDeadlineFrom(attachment.connectedAt),
+      );
     } catch (error) {
       logError(error, { messageType: "presence-room-join", roomId });
       if (peer !== null) await peer.transportClosed();
@@ -311,8 +332,13 @@ export class PresenceRoomDO extends DurableObject<Env> {
     }
   }
 
-  async webSocketClose(socket: WebSocket): Promise<void> {
+  async webSocketClose(
+    socket: WebSocket,
+    code: number,
+    reason: string,
+  ): Promise<void> {
     const peer = this.peerFromSocket(socket);
+    completeClose(socket, code, reason, CLOSE_ECHO_FALLBACK);
     if (peer === null) return;
     await peer.transportClosed();
     this.peers.delete(peer.id);
@@ -332,25 +358,81 @@ export class PresenceRoomDO extends DurableObject<Env> {
   }
 
   /**
-   * The only timer mechanism that survives hibernation; drives
-   * `PresenceRoom.sweep()`. A hibernation eviction resets every in-memory
-   * field, including `this.roomId`, so this recovers it from an attached
-   * socket the same way `webSocketMessage` does before falling back to a
-   * no-op (nothing to sweep without a room id or any attached socket).
+   * The only timer mechanism that survives hibernation; drives both
+   * `PresenceRoom.sweep()` and the shared authentication deadline. A
+   * hibernation eviction resets every in-memory field, including
+   * `this.roomId`, so this recovers it from an attached socket the same way
+   * `webSocketMessage` does before falling back to a no-op (nothing to sweep
+   * without a room id or any attached socket).
+   *
+   * The deadline sweep runs first and needs neither the room id nor the room
+   * itself: an unauthenticated socket holds no membership, session, or lease,
+   * so closing its transport is the whole eviction.
    */
   async alarm(): Promise<void> {
+    const now = Date.now();
+    const { expired, nextDeadline } = planAuthDeadlineSweep(
+      this.pendingAuthSockets(),
+      now,
+    );
+    await Promise.all(
+      expired.map((socket) => this.closeUnauthenticated(socket)),
+    );
+
     const roomId = this.roomId ?? this.roomIdFromAnySocket();
     if (roomId !== null) {
       try {
         const room = await this.ensureRoom(roomId);
-        await room?.sweep(Date.now());
+        await room?.sweep(now);
       } catch (error) {
         logError(error, { messageType: "presence-alarm", roomId });
       }
     }
+    // Both re-arms only ever move the object's single alarm earlier, so
+    // whichever of the liveness interval and the next authentication deadline
+    // comes first wins — and neither can push back a deadline armed by a
+    // connection that arrived while this handler was running.
     if (this.ctx.getWebSockets().length > 0) {
-      await this.ctx.storage.setAlarm(Date.now() + PRESENCE_ALARM_INTERVAL_MS);
+      await scheduleAlarmAt(
+        this.ctx.storage,
+        Date.now() + PRESENCE_ALARM_INTERVAL_MS,
+      );
     }
+    await scheduleAlarmAt(this.ctx.storage, nextDeadline);
+  }
+
+  /** Shared with `DocumentRoomDO`; `auth-deadline.ts` owns the policy. */
+  private pendingAuthSockets(): readonly PendingAuthSocket[] {
+    return collectPendingAuthSockets(this.ctx.getWebSockets(), (socket) => {
+      const attachment = this.attachmentFromSocket(socket);
+      return attachment !== null && attachment.phase === "awaiting-auth"
+        ? attachment.connectedAt
+        : null;
+    });
+  }
+
+  private async closeUnauthenticated(socket: WebSocket): Promise<void> {
+    const attachment = this.attachmentFromSocket(socket);
+    logMetric({
+      type: "auth-deadline-expired",
+      peerId: attachment?.peerId ?? null,
+      roomId: attachment?.roomId ?? this.roomId,
+    });
+    const peer = this.peerFromSocket(socket);
+    if (peer === null) {
+      // A woken object holds no peer for a hibernating socket; closing the
+      // transport is the whole cleanup, since an unauthenticated peer never
+      // took a membership record or a connection lease.
+      try {
+        socket.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
+      } catch (error) {
+        logError(error, { messageType: "presence-auth-deadline-close" });
+      }
+      return;
+    }
+    peer.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
+    await peer.transportClosed();
+    this.peers.delete(peer.id);
   }
 
   private roomIdFromAnySocket(): string | null {
@@ -457,6 +539,13 @@ export class PresenceRoomDO extends DurableObject<Env> {
       this.room = null;
       throw error;
     }
+    // `ensureAlarmScheduled` only arms the liveness interval when nothing is
+    // scheduled, so a restored socket still awaiting `Auth` pulls the alarm
+    // back to its own, sooner deadline here.
+    await scheduleAlarmAt(
+      this.ctx.storage,
+      earliestAuthDeadline(this.pendingAuthSockets()),
+    );
   }
 
   private async discardRestoredPeers(

--- a/apps/collab-cloudflare/src/presence-room-do.ts
+++ b/apps/collab-cloudflare/src/presence-room-do.ts
@@ -411,28 +411,38 @@ export class PresenceRoomDO extends DurableObject<Env> {
     });
   }
 
+  /**
+   * Never rejects. One socket that resists closing must not cancel the other
+   * evictions, the room sweep that follows, or either re-arm — this object's
+   * liveness rides on that alarm chain, and an `alarm()` that throws has
+   * already been consumed. A socket left open by a failed close is still
+   * awaiting `Auth`, so the next sweep finds it again.
+   */
   private async closeUnauthenticated(socket: WebSocket): Promise<void> {
     const attachment = this.attachmentFromSocket(socket);
-    logMetric({
-      type: "auth-deadline-expired",
+    const identity = {
       peerId: attachment?.peerId ?? null,
       roomId: attachment?.roomId ?? this.roomId,
-    });
-    const peer = this.peerFromSocket(socket);
-    if (peer === null) {
-      // A woken object holds no peer for a hibernating socket; closing the
-      // transport is the whole cleanup, since an unauthenticated peer never
-      // took a membership record or a connection lease.
-      try {
+    };
+    try {
+      logMetric({ ...identity, type: "auth-deadline-expired" });
+      const peer = this.peerFromSocket(socket);
+      if (peer === null) {
+        // A woken object holds no peer for a hibernating socket; closing the
+        // transport is the whole cleanup, since an unauthenticated peer never
+        // took a membership record or a connection lease.
         socket.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
-      } catch (error) {
-        logError(error, { messageType: "presence-auth-deadline-close" });
+        return;
       }
-      return;
+      peer.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
+      await peer.transportClosed();
+      this.peers.delete(peer.id);
+    } catch (error) {
+      logError(error, {
+        ...identity,
+        messageType: "presence-auth-deadline-close",
+      });
     }
-    peer.close(AUTH_DEADLINE_CLOSE_CODE, AUTH_DEADLINE_CLOSE_REASON);
-    await peer.transportClosed();
-    this.peers.delete(peer.id);
   }
 
   private roomIdFromAnySocket(): string | null {

--- a/apps/collab-cloudflare/src/websocket-attachment.ts
+++ b/apps/collab-cloudflare/src/websocket-attachment.ts
@@ -36,6 +36,13 @@ interface WebSocketAttachmentBase {
 
 export interface AwaitingAuthWebSocketAttachment
   extends WebSocketAttachmentBase {
+  /**
+   * When the object accepted this socket. The authentication deadline is
+   * derived from it (`auth-deadline.ts`), and it lives in the attachment
+   * rather than in memory so a hibernation-woken object enforces the same
+   * deadline a live one would.
+   */
+  readonly connectedAt: number;
   readonly phase: "awaiting-auth";
 }
 
@@ -119,6 +126,7 @@ export const createAwaitingAuthAttachment = (
   documentId: string,
   now = Date.now(),
 ): AwaitingAuthWebSocketAttachment => ({
+  connectedAt: now,
   documentId,
   peerId: crypto.randomUUID(),
   phase: "awaiting-auth",
@@ -148,7 +156,13 @@ export const parseDocumentWebSocketAttachment = (
     version: ATTACHMENT_VERSION,
   } as const;
   if (value.phase === "awaiting-auth") {
-    return { ...base, phase: "awaiting-auth" };
+    // A socket whose accepted-at instant is missing or malformed has no
+    // enforceable authentication deadline, so it is rejected like any other
+    // unreadable attachment and closed — which is what an unauthenticated
+    // socket gets at its deadline anyway.
+    return isNonNegativeInteger(value.connectedAt)
+      ? { ...base, connectedAt: value.connectedAt, phase: "awaiting-auth" }
+      : null;
   }
   if (
     value.phase !== "authenticated" ||
@@ -269,12 +283,18 @@ export const attachmentAfterReady = (
   validatedAt: number,
 ): AuthenticatedWebSocketAttachment | null => {
   if (!hasConsistentIdentity(attachment.documentId, auth, ready)) return null;
+  // Built field by field rather than spread: an authenticated socket has no
+  // authentication deadline left to enforce, so `connectedAt` must not be
+  // carried into (or persisted in) the authenticated attachment.
   return {
-    ...attachment,
     auth,
+    documentId: attachment.documentId,
+    peerId: attachment.peerId,
     phase: "authenticated",
+    quota: attachment.quota,
     ready,
     validatedAt,
+    version: ATTACHMENT_VERSION,
   };
 };
 

--- a/apps/collab-cloudflare/src/websocket-close.ts
+++ b/apps/collab-cloudflare/src/websocket-close.ts
@@ -1,0 +1,49 @@
+import { logError } from "./constants";
+
+const NORMAL_CLOSURE = 1000;
+// Reserved codes: a close event may report them, but a close frame must never
+// carry one, so an unclean client close is answered with a normal closure.
+const RESERVED_CLOSE_CODES: ReadonlySet<number> = new Set([
+  1004, 1005, 1006, 1015,
+]);
+
+export interface CloseEchoFallback {
+  /** Log context used when the echo itself fails. */
+  readonly messageType: string;
+  /** Reason sent when the client's own reason cannot be echoed back. */
+  readonly reason: string;
+}
+
+export const echoableCloseCode = (code: number): number =>
+  Number.isInteger(code) &&
+  code >= 1000 &&
+  code <= 4999 &&
+  !RESERVED_CLOSE_CODES.has(code)
+    ? code
+    : NORMAL_CLOSURE;
+
+/**
+ * Answers the client's close frame, for either room object. A hibernatable
+ * socket's closing handshake is the object's own responsibility: the runtime
+ * reports the client's close through `webSocketClose` and sends no close
+ * frame of its own, so an unanswered close leaves the browser waiting for its
+ * half until it gives up with 1006. Both endpoints now own their whole
+ * connection — no Worker-side socket sits in front of either — so both
+ * complete the handshake here and their clients see a clean 1000.
+ */
+export const completeClose = (
+  socket: WebSocket,
+  code: number,
+  reason: string,
+  fallback: CloseEchoFallback,
+): void => {
+  // The socket is already CLOSING here — the client's frame arrived — so this
+  // deliberately omits the `< CLOSING` guard a server-initiated close needs.
+  if (socket.readyState === WebSocket.CLOSED) return;
+  const echoed = echoableCloseCode(code);
+  try {
+    socket.close(echoed, echoed === code ? reason : fallback.reason);
+  } catch (error) {
+    logError(error, { messageType: fallback.messageType });
+  }
+};

--- a/apps/collab-cloudflare/test/document-room-do.test.ts
+++ b/apps/collab-cloudflare/test/document-room-do.test.ts
@@ -1097,26 +1097,35 @@ describe("Cloudflare DocumentRoomDO", () => {
     const expiring = [await connect(documentId), await connect(documentId)];
     const stub = env.DOCUMENT_ROOMS.getByName(documentId);
     await expect(expireAuthDeadlines(stub)).resolves.toBe(2);
-    await expect(breakOnePendingClose(stub)).resolves.toBe(2);
-    // Connected after the rewind, so this one's deadline is still ahead and
-    // it is what the handler has left to re-arm for.
-    const pending = await connect(documentId);
+    // Everything past the patch runs under `finally`: a socket left refusing
+    // to close outlives the test, and teardown would wait out its 1006 well
+    // into this suite's hook timeout.
+    const patched = await breakOnePendingClose(stub);
+    try {
+      expect(patched).toBe(2);
+      // Connected after the rewind, so this one's deadline is still ahead and
+      // it is what the handler has left to re-arm for.
+      const pending = await connect(documentId);
 
-    await runAlarm(stub);
+      await runAlarm(stub);
 
-    // The failure is contained rather than escaping the sweep. It is also
-    // logged, which is asserted only through behavior: this pool does not
-    // route a Durable Object's console output to the test's spy. An escaping
-    // error would skip the re-arm, and the alarm that fired is already
-    // consumed — leaving exactly the "nothing evicts them" case again.
-    await vi.waitFor(async () => {
-      await expect(attachedSocketCount(documentId)).resolves.toBe(2);
-    });
-    expect(
-      expiring.filter((client) => client.socket.readyState === WebSocket.OPEN),
-    ).toHaveLength(1);
-    expect(pending.socket.readyState).toBe(WebSocket.OPEN);
-    await expect(alarmAt(stub)).resolves.not.toBeNull();
-    await restorePendingCloses(stub);
+      // The failure is contained rather than escaping the sweep. It is also
+      // logged, which is asserted only through behavior: this pool does not
+      // route a Durable Object's console output to the test's spy. An
+      // escaping error would skip the re-arm, and the alarm that fired is
+      // already consumed — leaving the "nothing evicts them" case again.
+      await vi.waitFor(async () => {
+        await expect(attachedSocketCount(documentId)).resolves.toBe(2);
+      });
+      expect(
+        expiring.filter(
+          (client) => client.socket.readyState === WebSocket.OPEN,
+        ),
+      ).toHaveLength(1);
+      expect(pending.socket.readyState).toBe(WebSocket.OPEN);
+      await expect(alarmAt(stub)).resolves.not.toBeNull();
+    } finally {
+      await restorePendingCloses(stub);
+    }
   });
 });

--- a/apps/collab-cloudflare/test/document-room-do.test.ts
+++ b/apps/collab-cloudflare/test/document-room-do.test.ts
@@ -23,7 +23,10 @@ import {
 } from "cloudflare:test";
 import { env, exports } from "cloudflare:workers";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MAX_PERSISTED_AUTH_BYTES } from "../src/constants";
+import {
+  INITIAL_AUTH_TIMEOUT_MS,
+  MAX_PERSISTED_AUTH_BYTES,
+} from "../src/constants";
 import { normalizeDocumentId } from "../src/document-id";
 import type { DocumentRoomDO } from "../src/document-room-do";
 import {
@@ -204,6 +207,44 @@ const attachedSocketCount = (documentId: string): Promise<number> =>
     env.DOCUMENT_ROOMS.getByName(documentId),
     (_instance, state) => state.getWebSockets().length,
   );
+
+const alarmAt = (stub: DocumentRoomStub): Promise<number | null> =>
+  runInDurableObject(stub, (_instance, state) => state.storage.getAlarm());
+
+/**
+ * Runs the alarm the way the runtime does — the scheduled alarm is consumed
+ * before the handler runs — so whatever `getAlarm()` reports afterwards is
+ * exactly what the handler re-armed for itself.
+ */
+const runAlarm = (stub: DocumentRoomStub): Promise<void> =>
+  runInDurableObject(stub, async (instance, state) => {
+    await state.storage.deleteAlarm();
+    await instance.alarm();
+  });
+
+/**
+ * Rewinds every unauthenticated socket's accepted-at instant past the
+ * deadline. The object enforces the attachment rather than a timer, so a test
+ * never has to wait out `INITIAL_AUTH_TIMEOUT_MS`.
+ */
+const expireAuthDeadlines = (stub: DocumentRoomStub): Promise<number> =>
+  runInDurableObject(stub, (_instance, state) => {
+    const pending = state.getWebSockets().flatMap((socket) => {
+      const attachment = parseDocumentWebSocketAttachment(
+        socket.deserializeAttachment(),
+      );
+      return attachment !== null && attachment.phase === "awaiting-auth"
+        ? [{ attachment, socket }]
+        : [];
+    });
+    for (const { attachment, socket } of pending) {
+      socket.serializeAttachment({
+        ...attachment,
+        connectedAt: attachment.connectedAt - INITIAL_AUTH_TIMEOUT_MS - 1,
+      });
+    }
+    return pending.length;
+  });
 
 const sessionAudit = (stub: DocumentRoomStub) =>
   runInDurableObject(stub, (_instance, state) =>
@@ -940,6 +981,80 @@ describe("Cloudflare DocumentRoomDO", () => {
           sessionId: "unauthorized-session",
         }),
       ],
+    });
+  });
+
+  it("closes a socket that never authenticates once its deadline passes", async () => {
+    const documentId = "00000000-0000-4000-8000-0000000000c1";
+    const authenticated = await connect(documentId);
+    await expect(
+      authenticate(authenticated, documentId, "deadline-session"),
+    ).resolves.toMatchObject({ type: COLLAB_MESSAGE_TYPE.Ready });
+    const silent = await connect(documentId);
+
+    // The deadline is armed when the socket is accepted, not when it first
+    // sends something — an unauthenticated socket sends nothing by definition.
+    const stub = env.DOCUMENT_ROOMS.getByName(documentId);
+    const scheduled = await alarmAt(stub);
+    expect(scheduled).not.toBeNull();
+    expect(scheduled!).toBeLessThanOrEqual(
+      Date.now() + INITIAL_AUTH_TIMEOUT_MS,
+    );
+
+    // Non-Auth traffic cannot buy more time: the quota window moves with the
+    // message, the accepted-at instant the deadline reads does not.
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      silent.socket.send("{not json");
+      await expect(silent.next()).resolves.toMatchObject({
+        type: COLLAB_MESSAGE_TYPE.Error,
+        code: COLLAB_ERROR_CODE.InvalidMessage,
+      });
+    } finally {
+      errorLog.mockRestore();
+    }
+    await expect(alarmAt(stub)).resolves.toBe(scheduled);
+
+    const closed = silent.closed();
+    await expect(expireAuthDeadlines(stub)).resolves.toBe(1);
+    await runAlarm(stub);
+    await expect(closed).resolves.toMatchObject({
+      code: 1008,
+      reason: "Authentication timed out",
+    });
+
+    // The authenticated peer sharing the room is untouched, and with nothing
+    // left awaiting Auth the object re-arms no alarm and hibernates again.
+    expect(authenticated.socket.readyState).toBe(WebSocket.OPEN);
+    await vi.waitFor(async () => {
+      await expect(attachedSocketCount(documentId)).resolves.toBe(1);
+    });
+    await expect(alarmAt(stub)).resolves.toBeNull();
+  });
+
+  it("enforces the authentication deadline on a hibernation-woken object", async () => {
+    const documentId = "00000000-0000-4000-8000-0000000000c2";
+    const silent = await connect(documentId);
+    const stub = env.DOCUMENT_ROOMS.getByName(documentId);
+    await expect(expireAuthDeadlines(stub)).resolves.toBe(1);
+
+    const closed = silent.closed();
+    await evictDurableObject(stub, { webSockets: "hibernate" });
+    expect(silent.socket.readyState).toBe(WebSocket.OPEN);
+
+    // The woken object holds no peer, no room, and no document id in memory,
+    // so the deadline it enforces comes entirely from the socket attachment —
+    // no room restore and no Supabase call are needed to evict the socket.
+    await runAlarm(stub);
+    await expect(closed).resolves.toMatchObject({
+      code: 1008,
+      reason: "Authentication timed out",
+    });
+    await vi.waitFor(async () => {
+      await expect(attachedSocketCount(documentId)).resolves.toBe(0);
+    });
+    await expect(sessionAudit(stub)).resolves.toMatchObject({
+      authorizations: [],
     });
   });
 });

--- a/apps/collab-cloudflare/test/document-room-do.test.ts
+++ b/apps/collab-cloudflare/test/document-room-do.test.ts
@@ -246,6 +246,40 @@ const expireAuthDeadlines = (stub: DocumentRoomStub): Promise<number> =>
     return pending.length;
   });
 
+/**
+ * Makes the oldest socket still awaiting `Auth` throw from `close()`, the way
+ * one in a bad transport state would, and reports how many are pending.
+ */
+const breakOnePendingClose = (stub: DocumentRoomStub): Promise<number> =>
+  runInDurableObject(stub, (_instance, state) => {
+    const pending = state.getWebSockets().flatMap((socket) => {
+      const attachment = parseDocumentWebSocketAttachment(
+        socket.deserializeAttachment(),
+      );
+      return attachment !== null && attachment.phase === "awaiting-auth"
+        ? [{ connectedAt: attachment.connectedAt, socket }]
+        : [];
+    });
+    const oldest = pending.toSorted(
+      (left, right) => left.connectedAt - right.connectedAt,
+    )[0];
+    if (oldest === undefined) {
+      throw new Error("Expected a socket awaiting authentication");
+    }
+    oldest.socket.close = () => {
+      throw new Error("test transport refuses to close");
+    };
+    return pending.length;
+  });
+
+/** Undoes `breakOnePendingClose` so teardown does not wait out a 1006. */
+const restorePendingCloses = (stub: DocumentRoomStub): Promise<void> =>
+  runInDurableObject(stub, (_instance, state) => {
+    for (const socket of state.getWebSockets()) {
+      Reflect.deleteProperty(socket, "close");
+    }
+  });
+
 const sessionAudit = (stub: DocumentRoomStub) =>
   runInDurableObject(stub, (_instance, state) =>
     readMemorySessionAudit(state.storage),
@@ -1056,5 +1090,33 @@ describe("Cloudflare DocumentRoomDO", () => {
     await expect(sessionAudit(stub)).resolves.toMatchObject({
       authorizations: [],
     });
+  });
+
+  it("contains a socket that refuses to close and still re-arms", async () => {
+    const documentId = "00000000-0000-4000-8000-0000000000c3";
+    const expiring = [await connect(documentId), await connect(documentId)];
+    const stub = env.DOCUMENT_ROOMS.getByName(documentId);
+    await expect(expireAuthDeadlines(stub)).resolves.toBe(2);
+    await expect(breakOnePendingClose(stub)).resolves.toBe(2);
+    // Connected after the rewind, so this one's deadline is still ahead and
+    // it is what the handler has left to re-arm for.
+    const pending = await connect(documentId);
+
+    await runAlarm(stub);
+
+    // The failure is contained rather than escaping the sweep. It is also
+    // logged, which is asserted only through behavior: this pool does not
+    // route a Durable Object's console output to the test's spy. An escaping
+    // error would skip the re-arm, and the alarm that fired is already
+    // consumed — leaving exactly the "nothing evicts them" case again.
+    await vi.waitFor(async () => {
+      await expect(attachedSocketCount(documentId)).resolves.toBe(2);
+    });
+    expect(
+      expiring.filter((client) => client.socket.readyState === WebSocket.OPEN),
+    ).toHaveLength(1);
+    expect(pending.socket.readyState).toBe(WebSocket.OPEN);
+    await expect(alarmAt(stub)).resolves.not.toBeNull();
+    await restorePendingCloses(stub);
   });
 });

--- a/apps/collab-cloudflare/test/presence-room-do.test.ts
+++ b/apps/collab-cloudflare/test/presence-room-do.test.ts
@@ -9,8 +9,11 @@ import {
   runInDurableObject,
 } from "cloudflare:test";
 import { env, exports } from "cloudflare:workers";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { INITIAL_AUTH_TIMEOUT_MS } from "../src/constants";
 import { normalizeDocumentId } from "../src/document-id";
+import { parsePresenceWebSocketAttachment } from "../src/presence-attachment";
+import type { PresenceRoomDO } from "../src/presence-room-do";
 import {
   readMemoryPresenceSessionAudit,
   setMemoryPresenceAccessRevoked,
@@ -105,6 +108,52 @@ const connect = async (roomId: string): Promise<TestPresenceSocket> => {
   sockets.push(client);
   return client;
 };
+
+type PresenceRoomStub = DurableObjectStub<PresenceRoomDO>;
+
+const attachedSocketCount = (roomId: string): Promise<number> =>
+  runInDurableObject(
+    env.PRESENCE_ROOMS.getByName(roomId),
+    (_instance, state) => state.getWebSockets().length,
+  );
+
+const alarmAt = (stub: PresenceRoomStub): Promise<number | null> =>
+  runInDurableObject(stub, (_instance, state) => state.storage.getAlarm());
+
+/**
+ * Runs the alarm the way the runtime does — the scheduled alarm is consumed
+ * before the handler runs — so whatever `getAlarm()` reports afterwards is
+ * exactly what the handler re-armed for itself.
+ */
+const runAlarm = (stub: PresenceRoomStub): Promise<void> =>
+  runInDurableObject(stub, async (instance, state) => {
+    await state.storage.deleteAlarm();
+    await instance.alarm();
+  });
+
+/**
+ * Rewinds every unauthenticated socket's accepted-at instant past the
+ * deadline. The object enforces the attachment rather than a timer, so a test
+ * never has to wait out `INITIAL_AUTH_TIMEOUT_MS`.
+ */
+const expireAuthDeadlines = (stub: PresenceRoomStub): Promise<number> =>
+  runInDurableObject(stub, (_instance, state) => {
+    const pending = state.getWebSockets().flatMap((socket) => {
+      const attachment = parsePresenceWebSocketAttachment(
+        socket.deserializeAttachment(),
+      );
+      return attachment !== null && attachment.phase === "awaiting-auth"
+        ? [{ attachment, socket }]
+        : [];
+    });
+    for (const { attachment, socket } of pending) {
+      socket.serializeAttachment({
+        ...attachment,
+        connectedAt: attachment.connectedAt - INITIAL_AUTH_TIMEOUT_MS - 1,
+      });
+    }
+    return pending.length;
+  });
 
 const authPayload = (
   connectionId: string,
@@ -356,5 +405,82 @@ describe("Cloudflare PresenceRoomDO", () => {
         credential: { kind: "access-token", token: TEST_TOKEN },
       }),
     ]);
+  });
+
+  it("answers the client's close frame so a disconnect completes cleanly", async () => {
+    const roomId = "00000000-0000-4000-8000-000000000071";
+    const client = await connect(roomId);
+    await authenticateAndJoin(client, roomId, "closing-connection");
+    await expect(client.next()).resolves.toMatchObject({
+      type: WS_MESSAGE.JOIN,
+      senderId: "closing-connection",
+    });
+
+    const closed = client.closed();
+    client.close();
+    // A clean 1000/`wasClean` close proves the object answers the client's
+    // close frame itself. Without that answer the browser only ever completes
+    // its half by timing out, and reports the disconnect as 1006.
+    await expect(closed).resolves.toMatchObject({
+      code: 1000,
+      reason: "Test complete",
+      wasClean: true,
+    });
+    await vi.waitFor(async () => {
+      await expect(attachedSocketCount(roomId)).resolves.toBe(0);
+    });
+  });
+
+  it("closes a socket that never authenticates once its deadline passes", async () => {
+    const roomId = "00000000-0000-4000-8000-000000000081";
+    const joined = await connect(roomId);
+    await authenticateAndJoin(joined, roomId, "deadline-connection");
+    await expect(joined.next()).resolves.toMatchObject({
+      type: WS_MESSAGE.JOIN,
+    });
+    const silent = await connect(roomId);
+
+    // The room already carries the liveness alarm for its joined peer, so
+    // this also proves the sooner deadline pulls that single alarm forward.
+    const stub = env.PRESENCE_ROOMS.getByName(roomId);
+    const scheduled = await alarmAt(stub);
+    expect(scheduled).not.toBeNull();
+    expect(scheduled!).toBeLessThanOrEqual(
+      Date.now() + INITIAL_AUTH_TIMEOUT_MS,
+    );
+
+    const closed = silent.closed();
+    await expect(expireAuthDeadlines(stub)).resolves.toBe(1);
+    await runAlarm(stub);
+    await expect(closed).resolves.toMatchObject({
+      code: 1008,
+      reason: "Authentication timed out",
+    });
+
+    // The joined peer is untouched and still keeps the liveness alarm armed.
+    expect(joined.socket.readyState).toBe(WebSocket.OPEN);
+    await expect(alarmAt(stub)).resolves.not.toBeNull();
+  });
+
+  it("enforces the authentication deadline on a hibernation-woken object", async () => {
+    const roomId = "00000000-0000-4000-8000-000000000091";
+    const silent = await connect(roomId);
+    const stub = env.PRESENCE_ROOMS.getByName(roomId);
+    await expect(expireAuthDeadlines(stub)).resolves.toBe(1);
+
+    const closed = silent.closed();
+    await evictDurableObject(stub, { webSockets: "hibernate" });
+    expect(silent.socket.readyState).toBe(WebSocket.OPEN);
+
+    // The woken object holds no peer, no room, and no room id in memory, so
+    // the deadline it enforces comes entirely from the socket attachment.
+    await runAlarm(stub);
+    await expect(closed).resolves.toMatchObject({
+      code: 1008,
+      reason: "Authentication timed out",
+    });
+    await vi.waitFor(async () => {
+      await expect(attachedSocketCount(roomId)).resolves.toBe(0);
+    });
   });
 });

--- a/apps/collab-cloudflare/test/presence-room-do.test.ts
+++ b/apps/collab-cloudflare/test/presence-room-do.test.ts
@@ -155,6 +155,40 @@ const expireAuthDeadlines = (stub: PresenceRoomStub): Promise<number> =>
     return pending.length;
   });
 
+/**
+ * Makes the oldest socket still awaiting `Auth` throw from `close()`, the way
+ * one in a bad transport state would, and reports how many are pending.
+ */
+const breakOnePendingClose = (stub: PresenceRoomStub): Promise<number> =>
+  runInDurableObject(stub, (_instance, state) => {
+    const pending = state.getWebSockets().flatMap((socket) => {
+      const attachment = parsePresenceWebSocketAttachment(
+        socket.deserializeAttachment(),
+      );
+      return attachment !== null && attachment.phase === "awaiting-auth"
+        ? [{ connectedAt: attachment.connectedAt, socket }]
+        : [];
+    });
+    const oldest = pending.toSorted(
+      (left, right) => left.connectedAt - right.connectedAt,
+    )[0];
+    if (oldest === undefined) {
+      throw new Error("Expected a socket awaiting authentication");
+    }
+    oldest.socket.close = () => {
+      throw new Error("test transport refuses to close");
+    };
+    return pending.length;
+  });
+
+/** Undoes `breakOnePendingClose` so teardown does not wait out a 1006. */
+const restorePendingCloses = (stub: PresenceRoomStub): Promise<void> =>
+  runInDurableObject(stub, (_instance, state) => {
+    for (const socket of state.getWebSockets()) {
+      Reflect.deleteProperty(socket, "close");
+    }
+  });
+
 const authPayload = (
   connectionId: string,
   overrides: Partial<{
@@ -482,5 +516,28 @@ describe("Cloudflare PresenceRoomDO", () => {
     await vi.waitFor(async () => {
       await expect(attachedSocketCount(roomId)).resolves.toBe(0);
     });
+  });
+
+  it("contains a socket that refuses to close and still re-arms", async () => {
+    const roomId = "00000000-0000-4000-8000-0000000000a1";
+    const expiring = [await connect(roomId), await connect(roomId)];
+    const stub = env.PRESENCE_ROOMS.getByName(roomId);
+    await expect(expireAuthDeadlines(stub)).resolves.toBe(2);
+    await expect(breakOnePendingClose(stub)).resolves.toBe(2);
+
+    await runAlarm(stub);
+
+    // The failure is contained: the handler runs on to evict the other
+    // socket, sweep the room, and re-arm. An error escaping the sweep would
+    // take this object's whole liveness chain down with it, since the alarm
+    // that fired is already consumed.
+    await vi.waitFor(async () => {
+      await expect(attachedSocketCount(roomId)).resolves.toBe(1);
+    });
+    expect(
+      expiring.filter((client) => client.socket.readyState === WebSocket.OPEN),
+    ).toHaveLength(1);
+    await expect(alarmAt(stub)).resolves.not.toBeNull();
+    await restorePendingCloses(stub);
   });
 });

--- a/apps/collab-cloudflare/test/presence-room-do.test.ts
+++ b/apps/collab-cloudflare/test/presence-room-do.test.ts
@@ -523,21 +523,30 @@ describe("Cloudflare PresenceRoomDO", () => {
     const expiring = [await connect(roomId), await connect(roomId)];
     const stub = env.PRESENCE_ROOMS.getByName(roomId);
     await expect(expireAuthDeadlines(stub)).resolves.toBe(2);
-    await expect(breakOnePendingClose(stub)).resolves.toBe(2);
+    // Everything past the patch runs under `finally`: a socket left refusing
+    // to close outlives the test, and teardown would wait out its 1006 well
+    // into this suite's hook timeout.
+    const patched = await breakOnePendingClose(stub);
+    try {
+      expect(patched).toBe(2);
 
-    await runAlarm(stub);
+      await runAlarm(stub);
 
-    // The failure is contained: the handler runs on to evict the other
-    // socket, sweep the room, and re-arm. An error escaping the sweep would
-    // take this object's whole liveness chain down with it, since the alarm
-    // that fired is already consumed.
-    await vi.waitFor(async () => {
-      await expect(attachedSocketCount(roomId)).resolves.toBe(1);
-    });
-    expect(
-      expiring.filter((client) => client.socket.readyState === WebSocket.OPEN),
-    ).toHaveLength(1);
-    await expect(alarmAt(stub)).resolves.not.toBeNull();
-    await restorePendingCloses(stub);
+      // The failure is contained: the handler runs on to evict the other
+      // socket, sweep the room, and re-arm. An error escaping the sweep would
+      // take this object's whole liveness chain down with it, since the alarm
+      // that fired is already consumed.
+      await vi.waitFor(async () => {
+        await expect(attachedSocketCount(roomId)).resolves.toBe(1);
+      });
+      expect(
+        expiring.filter(
+          (client) => client.socket.readyState === WebSocket.OPEN,
+        ),
+      ).toHaveLength(1);
+      await expect(alarmAt(stub)).resolves.not.toBeNull();
+    } finally {
+      await restorePendingCloses(stub);
+    }
   });
 });

--- a/docs/design/collaboration-operations.md
+++ b/docs/design/collaboration-operations.md
@@ -113,7 +113,11 @@ presence membership in Durable Object storage so it survives hibernation.
 Both rooms are routed on the upgrade request's query string
 (`?documentId=`, `?roomId=`) and answer the browser with the object's own
 upgrade response, so the Worker holds no long-lived collaboration socket and
-every live connection hibernates with its object.
+every live connection hibernates with its object. Because no Worker-side
+socket and no `setTimeout` survives that, both objects arm a Durable Object
+alarm while a socket is still awaiting its first authentication message and
+close it 1008 `Authentication timed out` at the deadline; `PresenceRoomDO`
+shares that alarm with its presence-liveness sweep.
 Neither object uses its storage as durable document-event history; that role
 stays with Supabase Postgres. See
 [`apps/collab-cloudflare/README.md#runtime-shape`](https://github.com/softmaple/softmaple/blob/next/apps/collab-cloudflare/README.md#runtime-shape)


### PR DESCRIPTION
Two gaps left by routing document WebSockets straight to the Durable Object.

No auth deadline. The Worker's 10s unauthenticated-socket timeout went away
with the proxy, and a `setTimeout` has no hibernation-safe equivalent: a
socket that connects and never sends `Auth` holds no session and no lease,
but nothing evicted it either. Presence had the same property. Both objects
now enforce the deadline from a Durable Object alarm through one shared
`auth-deadline.ts`. The accepted-at instant lives in each socket's
attachment, so `alarm()` decides purely from attachments — a woken object
evicts exactly the sockets a live one would, with no room restore, no
session revalidation, and no Supabase call, and answers with the proxy's own
1008 `Authentication timed out`. Non-`Auth` traffic cannot extend it: the
quota window moves, the accepted-at instant does not.

A Durable Object has one alarm, so scheduling only ever moves it earlier:
`PresenceRoomDO` keeps its 30s liveness sweep and a sooner deadline pulls
that alarm forward. `DocumentRoomDO` arms an alarm only while a socket is
awaiting `Auth` and re-arms only while one remains, so an idle authenticated
room still hibernates with no timer at all. Because the accepted-at instant
is a required attachment field, a socket still awaiting `Auth` across a
deployment fails the parse when its object wakes and is closed — it has no
session to lose and the client reconnects.

Presence had the unanswered-close gap already fixed for documents: its
clients saw 1006 on every disconnect because `webSocketClose` never answered
the client's close frame. Both objects now complete the handshake through a
shared `websocket-close.ts`, so a presence disconnect ends as a clean 1000.

`eslint.config.js` classifies both new modules as shared utilities: they are
pure policy plus a caller-supplied-storage alarm write, holding no capability
instance and reaching neither object's room, so the presence/document
isolation boundary is unchanged.

Verified with typecheck, lint, the 55-test Cloudflare Vitest suite (5 new),
and the deploy dry-run build.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013GNhyhQqf3YN2riCXTZBoM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unauthenticated document and presence connections now automatically close after 10 seconds if authentication is not completed.
  - Authentication timeouts remain enforced when rooms hibernate and resume.
  - Authenticated connections remain active without interruption.
  - WebSocket closures now consistently echo valid close codes and reasons.

- **Documentation**
  - Added guidance describing authentication timeouts and their behavior across collaboration rooms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->