### PR TITLE
fix(apps/web): jitter collaboration reconnect and gate it on connectivity

### DIFF
--- a/apps/web/modules/docs/collab-reconnect.test.ts
+++ b/apps/web/modules/docs/collab-reconnect.test.ts
@@ -8,12 +8,17 @@ import {
   RECONNECT_MIN_DELAY_MS,
 } from "./collab-reconnect";
 
-/** Deterministic [0, 1) source so jitter assertions can never flake. */
+/**
+ * Deterministic [0, 1) source so jitter assertions can never flake. Lehmer's
+ * minimal standard generator: 48_271 * (2 ** 31 - 2) stays well inside the
+ * safe-integer range, so no intermediate product loses precision.
+ */
 const createRandomSequence = (seed: number): (() => number) => {
-  let state = seed % 2_147_483_647;
+  const modulus = 2_147_483_647;
+  let state = (seed % (modulus - 1)) + 1;
   return () => {
-    state = (state * 1_103_515_245 + 12_345) % 2_147_483_647;
-    return state / 2_147_483_647;
+    state = (state * 48_271) % modulus;
+    return state / modulus;
   };
 };
 

--- a/apps/web/modules/docs/collab-reconnect.test.ts
+++ b/apps/web/modules/docs/collab-reconnect.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  getReconnectDelay,
+  getReconnectDelayCap,
+  isBrowserOffline,
+  RECONNECT_BASE_DELAY_MS,
+  RECONNECT_MAX_DELAY_MS,
+  RECONNECT_MIN_DELAY_MS,
+} from "./collab-reconnect";
+
+/** Deterministic [0, 1) source so jitter assertions can never flake. */
+const createRandomSequence = (seed: number): (() => number) => {
+  let state = seed % 2_147_483_647;
+  return () => {
+    state = (state * 1_103_515_245 + 12_345) % 2_147_483_647;
+    return state / 2_147_483_647;
+  };
+};
+
+const ATTEMPTS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 20] as const;
+
+describe("getReconnectDelayCap", () => {
+  it("should grow exponentially from the base delay up to the maximum", () => {
+    // Arrange / Act
+    const caps = [0, 1, 2, 3, 4, 5, 6].map(getReconnectDelayCap);
+
+    // Assert
+    expect(caps).toEqual([500, 1_000, 2_000, 4_000, 8_000, 10_000, 10_000]);
+    expect(caps[0]).toBe(RECONNECT_BASE_DELAY_MS);
+  });
+
+  it("should never exceed the maximum delay for any attempt", () => {
+    for (const attempt of [7, 12, 40, 1_024]) {
+      expect(getReconnectDelayCap(attempt)).toBe(RECONNECT_MAX_DELAY_MS);
+    }
+  });
+
+  it("should treat fractional and negative attempts as whole retries", () => {
+    expect(getReconnectDelayCap(1.9)).toBe(getReconnectDelayCap(1));
+    expect(getReconnectDelayCap(-5)).toBe(RECONNECT_BASE_DELAY_MS);
+  });
+});
+
+describe("getReconnectDelay", () => {
+  it("should keep every jittered delay inside the attempt's window", () => {
+    // Arrange
+    const random = createRandomSequence(7);
+
+    // Act / Assert
+    for (const attempt of ATTEMPTS) {
+      for (let draw = 0; draw < 50; draw += 1) {
+        const delay = getReconnectDelay(attempt, random);
+        expect(delay).toBeGreaterThanOrEqual(RECONNECT_MIN_DELAY_MS);
+        expect(delay).toBeLessThanOrEqual(getReconnectDelayCap(attempt));
+      }
+    }
+  });
+
+  it("should map the randomness bounds onto the window bounds", () => {
+    // A zero draw is floored instead of retrying immediately, and a draw just
+    // below one reaches the top of the window.
+    expect(getReconnectDelay(0, () => 0)).toBe(RECONNECT_MIN_DELAY_MS);
+    expect(getReconnectDelay(3, () => 0.5)).toBe(2_000);
+    expect(getReconnectDelay(3, () => 0.999)).toBeCloseTo(3_996, 5);
+    expect(getReconnectDelay(9, () => 0.999)).toBeCloseTo(9_990, 5);
+  });
+
+  it("should spread a herd of clients retrying the same attempt", () => {
+    // Arrange — one delay per client disconnected by the same outage.
+    const random = createRandomSequence(11);
+
+    // Act
+    const delays = Array.from({ length: 200 }, () =>
+      getReconnectDelay(6, random),
+    );
+
+    // Assert — deterministic backoff would put all 200 on the same millisecond.
+    expect(new Set(delays).size).toBeGreaterThan(150);
+    const mean = delays.reduce((sum, delay) => sum + delay, 0) / delays.length;
+    expect(mean).toBeGreaterThan(RECONNECT_MAX_DELAY_MS * 0.35);
+    expect(mean).toBeLessThan(RECONNECT_MAX_DELAY_MS * 0.65);
+  });
+
+  it("should default to Math.random without an injected source", () => {
+    const delay = getReconnectDelay(2);
+    expect(delay).toBeGreaterThanOrEqual(RECONNECT_MIN_DELAY_MS);
+    expect(delay).toBeLessThanOrEqual(getReconnectDelayCap(2));
+  });
+});
+
+describe("isBrowserOffline", () => {
+  it("should report offline only when the browser says so", () => {
+    // Arrange
+    const setOnLine = (value: boolean): void => {
+      Object.defineProperty(window.navigator, "onLine", {
+        configurable: true,
+        get: () => value,
+      });
+    };
+
+    // Act / Assert
+    setOnLine(true);
+    expect(isBrowserOffline()).toBe(false);
+    setOnLine(false);
+    expect(isBrowserOffline()).toBe(true);
+
+    Reflect.deleteProperty(window.navigator, "onLine");
+  });
+});

--- a/apps/web/modules/docs/collab-reconnect.ts
+++ b/apps/web/modules/docs/collab-reconnect.ts
@@ -1,0 +1,58 @@
+/**
+ * Reconnect timing for the collaboration WebSocket client.
+ *
+ * A mass disconnect — Worker deployment, Durable Object restart, upstream
+ * outage, flaky network — drops every client at once. Deterministic
+ * exponential backoff then makes all of them retry in the same instants, so
+ * the herd recreates the pressure that caused the disconnect. Full jitter
+ * spreads each retry uniformly across its backoff window instead, which keeps
+ * the same worst-case wait while flattening the arrival rate.
+ */
+
+/** Backoff window for the first retry. */
+export const RECONNECT_BASE_DELAY_MS = 500;
+
+/** Upper bound on the backoff window; reached after five failed attempts. */
+export const RECONNECT_MAX_DELAY_MS = 10_000;
+
+/**
+ * Floor for a jittered delay. Full jitter can draw a value close to zero, and
+ * a server that rejects connections immediately would turn that into a hot
+ * retry loop.
+ */
+export const RECONNECT_MIN_DELAY_MS = 100;
+
+/**
+ * Backoff window for `attempt`: `RECONNECT_BASE_DELAY_MS` doubled per attempt
+ * and clamped to `RECONNECT_MAX_DELAY_MS`.
+ */
+export const getReconnectDelayCap = (attempt: number): number => {
+  const exponent = Math.max(0, Math.floor(attempt));
+  return Math.min(
+    RECONNECT_BASE_DELAY_MS * 2 ** exponent,
+    RECONNECT_MAX_DELAY_MS,
+  );
+};
+
+/**
+ * Exponential backoff with full jitter. The delay is drawn uniformly from the
+ * attempt's backoff window and clamped to `RECONNECT_MIN_DELAY_MS`, so it
+ * always lands in `[RECONNECT_MIN_DELAY_MS, getReconnectDelayCap(attempt)]`.
+ *
+ * @param attempt Zero-based retry counter for the current socket session.
+ * @param random Source of `[0, 1)` randomness; injectable for tests.
+ */
+export const getReconnectDelay = (
+  attempt: number,
+  random: () => number = Math.random,
+): number =>
+  Math.max(RECONNECT_MIN_DELAY_MS, random() * getReconnectDelayCap(attempt));
+
+/**
+ * True when the browser reports no connectivity. `navigator.onLine === true`
+ * only means an interface exists — never that the collaboration backend is
+ * reachable — so this is used to suppress retries that cannot succeed, never
+ * to assume a retry will succeed.
+ */
+export const isBrowserOffline = (): boolean =>
+  typeof navigator !== "undefined" && navigator.onLine === false;

--- a/apps/web/modules/docs/collab-reconnect.ts
+++ b/apps/web/modules/docs/collab-reconnect.ts
@@ -16,6 +16,14 @@ export const RECONNECT_BASE_DELAY_MS = 500;
 export const RECONNECT_MAX_DELAY_MS = 10_000;
 
 /**
+ * Minimum spacing between reconnects triggered immediately by a browser
+ * signal. `online` fires on every interface flap and `visibilitychange` on
+ * every focus change, so without a floor those signals would replace the
+ * backoff with a retry per event.
+ */
+export const RECONNECT_ACCELERATION_INTERVAL_MS = 5_000;
+
+/**
  * Floor for a jittered delay. Full jitter can draw a value close to zero, and
  * a server that rejects connections immediately would turn that into a hot
  * retry loop.

--- a/apps/web/modules/docs/use-collab-document.test.ts
+++ b/apps/web/modules/docs/use-collab-document.test.ts
@@ -21,13 +21,33 @@ const NITRO_TARGET: CollabTarget = {
   runtime: COLLAB_RUNTIME.Nitro,
 };
 
+type FakeSessionResult = {
+  readonly data: {
+    readonly session: {
+      readonly access_token: string;
+      readonly user: { readonly id: string };
+    } | null;
+  };
+  readonly error: null;
+};
+
+const signedOutSession = async (): Promise<FakeSessionResult> => ({
+  data: { session: null },
+  error: null,
+});
+
+/** Mutable so a test can hold the session read open mid-connect. */
+const authStub = vi.hoisted(() => ({
+  getSession: async (): Promise<FakeSessionResult> => ({
+    data: { session: null },
+    error: null,
+  }),
+}));
+
 vi.mock("@/utils/supabase/client", () => ({
   createClient: () => ({
     auth: {
-      getSession: async () => ({
-        data: { session: null },
-        error: null,
-      }),
+      getSession: () => authStub.getSession(),
     },
   }),
 }));
@@ -101,6 +121,12 @@ class FakeWebSocket {
     this.emit("open", new Event("open"));
   };
 
+  /** Close event that bypasses readyState, mirroring a stray/duplicate close. */
+  emitClose = (code = 1006): void => {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit("close", new CloseEvent("close", { code }));
+  };
+
   emitMessage = (data: unknown): void => {
     this.emit(
       "message",
@@ -124,6 +150,56 @@ class FakeWebSocket {
 
 const fakeSockets: FakeWebSocket[] = [];
 const originalWebSocket = globalThis.WebSocket;
+
+/**
+ * Fixed jitter draw: reconnect delays become base * 2 ** attempt / 2, so the
+ * timeline below is exact (250ms, 500ms, 1s, ...) with no timing tolerance.
+ */
+const FIXED_JITTER = 0.5;
+
+const setBrowserOnline = (online: boolean): void => {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    get: () => online,
+  });
+};
+
+const setPageVisibility = (visibility: "hidden" | "visible"): void => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => visibility,
+  });
+};
+
+const emitOnline = (): void => {
+  act(() => {
+    window.dispatchEvent(new Event("online"));
+  });
+};
+
+const emitVisibilityChange = (visibility: "hidden" | "visible"): void => {
+  setPageVisibility(visibility);
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+};
+
+const advance = (ms: number): void => {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+};
+
+/** Server hello for a public document session. */
+const publicReadyMessage = (documentId: string) => ({
+  protocolVersion: COLLAB_PROTOCOL_VERSION,
+  type: COLLAB_MESSAGE_TYPE.Ready,
+  accessMode: COLLAB_ACCESS_MODE.Public,
+  documentId,
+  userId: null,
+  role: null,
+  canWrite: false,
+});
 
 type HookState = ReturnType<typeof useCollabDocument>;
 
@@ -184,12 +260,17 @@ describe("useCollabDocument", () => {
     fakeSockets.length = 0;
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(FIXED_JITTER);
+    authStub.getSession = signedOutSession;
   });
 
   afterEach(() => {
     vi.useRealTimers();
     globalThis.WebSocket = originalWebSocket;
     vi.clearAllTimers();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window.navigator, "onLine");
+    Reflect.deleteProperty(document, "visibilityState");
   });
 
   it("should close invalid server payloads with an application close code", async () => {
@@ -403,5 +484,321 @@ describe("useCollabDocument", () => {
     unmountRetry();
     unmountFatal();
     unmountApply();
+  });
+
+  it("should back off exponentially with jitter and keep the same endpoint", async () => {
+    // Arrange — a fixed jitter draw halves each attempt's backoff window.
+    const { unmount } = renderCollabHook("doc-backoff");
+    const first = await waitForSocket();
+
+    // Act / Assert — attempt 0 draws from a 500ms window: 250ms here.
+    act(() => {
+      first.emitClose();
+    });
+    advance(249);
+    expect(fakeSockets).toHaveLength(1);
+    advance(1);
+    expect(fakeSockets).toHaveLength(2);
+
+    // attempt 1 doubles the window to 1s: 500ms here.
+    act(() => {
+      fakeSockets[1]?.emitClose();
+    });
+    advance(499);
+    expect(fakeSockets).toHaveLength(2);
+    advance(1);
+    expect(fakeSockets).toHaveLength(3);
+
+    // attempt 2 doubles it again to 2s: 1s here.
+    act(() => {
+      fakeSockets[2]?.emitClose();
+    });
+    advance(999);
+    expect(fakeSockets).toHaveLength(3);
+    advance(1);
+    expect(fakeSockets).toHaveLength(4);
+
+    // Reconnects stay on the runtime the server selected for the document.
+    for (const socket of fakeSockets) {
+      expect(socket.url).toBe(NITRO_TARGET.documentUrl);
+    }
+
+    unmount();
+  });
+
+  it("should reset the backoff after a connection is established", async () => {
+    // Arrange — two failures first, so the window has already grown.
+    const { result, unmount } = renderCollabHook("doc-reset");
+    const first = await waitForSocket();
+    act(() => {
+      first.emitClose();
+    });
+    advance(250);
+    act(() => {
+      fakeSockets[1]?.emitClose();
+    });
+    advance(500);
+    expect(fakeSockets).toHaveLength(3);
+
+    // Act — the third socket completes the collaboration handshake.
+    const connected = fakeSockets[2];
+    if (connected === undefined) throw new Error("expected a third socket");
+    act(() => {
+      connected.emitOpen();
+      connected.emitMessage(publicReadyMessage("doc-reset"));
+    });
+    expect(result.current.collaborationStatus).toBe("connected");
+
+    // Assert — the next disconnect starts from the shortest window again.
+    act(() => {
+      connected.emitClose();
+    });
+    advance(249);
+    expect(fakeSockets).toHaveLength(3);
+    advance(1);
+    expect(fakeSockets).toHaveLength(4);
+
+    unmount();
+  });
+
+  it("should not retry while the browser reports itself offline", async () => {
+    // Arrange
+    const { result, unmount } = renderCollabHook("doc-offline");
+    const first = await waitForSocket();
+    setBrowserOnline(false);
+
+    // Act
+    act(() => {
+      first.emitClose();
+    });
+
+    // Assert — no timer is armed, so no retry can fire while offline.
+    expect(result.current.collaborationStatus).toBe("offline");
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(1);
+
+    // A spurious online event that does not restore connectivity changes nothing.
+    emitOnline();
+    expect(fakeSockets).toHaveLength(1);
+
+    // A visible page cannot reconnect a browser that has no network either.
+    emitVisibilityChange("visible");
+    expect(fakeSockets).toHaveLength(1);
+
+    unmount();
+  });
+
+  it("should resume reconnecting when connectivity returns", async () => {
+    // Arrange
+    const { unmount } = renderCollabHook("doc-online");
+    const first = await waitForSocket();
+    setBrowserOnline(false);
+    act(() => {
+      first.emitClose();
+    });
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(1);
+
+    // Act
+    setBrowserOnline(true);
+    emitOnline();
+
+    // Assert — one reconnect, and no leftover timer adding a second socket.
+    expect(fakeSockets).toHaveLength(2);
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(2);
+    expect(fakeSockets[1]?.url).toBe(NITRO_TARGET.documentUrl);
+
+    unmount();
+  });
+
+  it("should keep one reconnect timer across repeated close events", async () => {
+    // Arrange
+    const { unmount } = renderCollabHook("doc-duplicate-close");
+    const first = await waitForSocket();
+
+    // Act — a close, a stray duplicate close, and an error-driven close.
+    act(() => {
+      first.emitClose();
+      first.emitClose();
+      first.close();
+      first.emitClose();
+    });
+
+    // Assert — exactly one reconnect for the whole burst.
+    advance(250);
+    expect(fakeSockets).toHaveLength(2);
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(2);
+
+    unmount();
+  });
+
+  it("should cancel scheduled reconnect work on unmount", async () => {
+    // Arrange
+    const { unmount } = renderCollabHook("doc-unmount");
+    const first = await waitForSocket();
+    act(() => {
+      first.emitClose();
+    });
+
+    // Act
+    unmount();
+
+    // Assert — neither the armed timer nor a browser signal may open a socket
+    // for the disposed document session.
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(1);
+    setBrowserOnline(true);
+    emitOnline();
+    emitVisibilityChange("visible");
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(1);
+  });
+
+  it("should never disconnect a healthy socket on visibility changes", async () => {
+    // Arrange
+    const { result, unmount } = renderCollabHook("doc-visibility-healthy");
+    const socket = await waitForSocket();
+    act(() => {
+      socket.emitOpen();
+      socket.emitMessage(publicReadyMessage("doc-visibility-healthy"));
+    });
+    expect(result.current.collaborationStatus).toBe("connected");
+
+    // Act
+    emitVisibilityChange("hidden");
+    advance(60_000);
+    emitVisibilityChange("visible");
+    emitOnline();
+
+    // Assert — the live socket is untouched and no second socket appears.
+    expect(socket.closeCalls).toEqual([]);
+    expect(fakeSockets).toHaveLength(1);
+    expect(result.current.collaborationStatus).toBe("connected");
+
+    unmount();
+  });
+
+  it("should accelerate a pending reconnect once the page becomes visible", async () => {
+    // Arrange
+    const { unmount } = renderCollabHook("doc-visibility-retry");
+    const first = await waitForSocket();
+    emitVisibilityChange("hidden");
+    act(() => {
+      first.emitClose();
+    });
+
+    // Act — a hidden page keeps waiting out the backoff.
+    advance(100);
+    emitVisibilityChange("hidden");
+    expect(fakeSockets).toHaveLength(1);
+
+    // Assert — becoming visible retries immediately, exactly once: the
+    // superseded timer must not open a second socket when it would have fired.
+    emitVisibilityChange("visible");
+    expect(fakeSockets).toHaveLength(2);
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(2);
+
+    unmount();
+  });
+
+  it("should keep one connection attempt while authentication is in flight", async () => {
+    // Arrange — hold the session read open so the attempt cannot complete.
+    let releaseSession: (() => void) | undefined;
+    authStub.getSession = () =>
+      new Promise<FakeSessionResult>((resolve) => {
+        releaseSession = () =>
+          resolve({
+            data: {
+              session: { access_token: "token", user: { id: "user-1" } },
+            },
+            error: null,
+          });
+      });
+
+    const { unmount } = renderCollabHook("doc-single-attempt", "authenticated");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fakeSockets).toHaveLength(0);
+
+    // Act — every reconnect trigger lands while the attempt is still pending.
+    setBrowserOnline(true);
+    emitOnline();
+    emitVisibilityChange("visible");
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(0);
+
+    // Assert — completing authentication opens exactly one socket.
+    await act(async () => {
+      releaseSession?.();
+      await Promise.resolve();
+    });
+    expect(fakeSockets).toHaveLength(1);
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(1);
+
+    unmount();
+  });
+
+  it("should not open a socket for a session disposed while authenticating", async () => {
+    // Arrange
+    let releaseSession: (() => void) | undefined;
+    authStub.getSession = () =>
+      new Promise<FakeSessionResult>((resolve) => {
+        releaseSession = () =>
+          resolve({
+            data: {
+              session: { access_token: "token", user: { id: "user-1" } },
+            },
+            error: null,
+          });
+      });
+
+    const { unmount } = renderCollabHook("doc-disposed-auth", "authenticated");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Act — the document session goes away before authentication resolves.
+    unmount();
+    await act(async () => {
+      releaseSession?.();
+      await Promise.resolve();
+    });
+
+    // Assert — a retired attempt can never open a socket for the old document.
+    expect(fakeSockets).toHaveLength(0);
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(0);
+  });
+
+  it("should ignore browser reconnect signals after a fatal server error", async () => {
+    // Arrange
+    const { unmount } = renderCollabHook("doc-fatal-signals");
+    const socket = await waitForSocket();
+    act(() => {
+      socket.emitOpen();
+      socket.emitMessage({
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        type: COLLAB_MESSAGE_TYPE.Error,
+        code: COLLAB_ERROR_CODE.Forbidden,
+        message: "Access denied",
+        retryable: false,
+      });
+    });
+
+    // Act
+    setBrowserOnline(true);
+    emitOnline();
+    emitVisibilityChange("visible");
+    advance(60_000);
+
+    // Assert
+    expect(fakeSockets).toHaveLength(1);
+
+    unmount();
   });
 });

--- a/apps/web/modules/docs/use-collab-document.test.ts
+++ b/apps/web/modules/docs/use-collab-document.test.ts
@@ -704,6 +704,38 @@ describe("useCollabDocument", () => {
     unmount();
   });
 
+  it("should not let repeated browser signals outpace the backoff", async () => {
+    // Arrange — the first signal is allowed through and opens a socket.
+    const { unmount } = renderCollabHook("doc-signal-flood");
+    const first = await waitForSocket();
+    act(() => {
+      first.emitClose();
+    });
+    emitVisibilityChange("visible");
+    expect(fakeSockets).toHaveLength(2);
+
+    // Act — that retry fails at once and a burst of signals follows.
+    act(() => {
+      fakeSockets[1]?.emitClose();
+    });
+    emitVisibilityChange("hidden");
+    emitVisibilityChange("visible");
+    emitOnline();
+    emitVisibilityChange("visible");
+
+    // Assert — the burst falls back to the jittered schedule instead of
+    // opening a socket per event, and still reconnects exactly once.
+    expect(fakeSockets).toHaveLength(2);
+    advance(499);
+    expect(fakeSockets).toHaveLength(2);
+    advance(1);
+    expect(fakeSockets).toHaveLength(3);
+    advance(60_000);
+    expect(fakeSockets).toHaveLength(3);
+
+    unmount();
+  });
+
   it("should keep one connection attempt while authentication is in flight", async () => {
     // Arrange — hold the session read open so the attempt cannot complete.
     let releaseSession: (() => void) | undefined;

--- a/apps/web/modules/docs/use-document-session.ts
+++ b/apps/web/modules/docs/use-document-session.ts
@@ -26,6 +26,7 @@ import { createOutgoingBatchQueue } from "@/modules/docs/collab-outgoing-queue";
 import {
   getReconnectDelay,
   isBrowserOffline,
+  RECONNECT_ACCELERATION_INTERVAL_MS,
 } from "@/modules/docs/collab-reconnect";
 import type { CollabTarget } from "@/modules/docs/collab-target";
 import {
@@ -143,6 +144,8 @@ const createSessionController = ({
   let wsGeneration = 0;
   /** True from the start of a connect attempt until its socket exists. */
   let connectPending = false;
+  /** Timestamp of the last reconnect a browser signal triggered immediately. */
+  let lastAcceleratedAt: number | null = null;
   let synced = false;
   let fatalConnectionError = false;
   let activeRepairRequestId: string | null = null;
@@ -389,6 +392,18 @@ const createSessionController = ({
     if (cancelled || transport !== "ws" || fatalConnectionError) return;
     if (socket !== null || connectPending) return;
     if (isBrowserOffline()) return;
+    const now = Date.now();
+    if (
+      lastAcceleratedAt !== null &&
+      now - lastAcceleratedAt < RECONNECT_ACCELERATION_INTERVAL_MS
+    ) {
+      // A flapping interface or a user switching tabs must not turn into a
+      // retry per event. Fall back to the jittered schedule rather than
+      // dropping the signal, so a loop suppressed while offline still resumes.
+      scheduleReconnect();
+      return;
+    }
+    lastAcceleratedAt = now;
     clearReconnectTimer();
     void connectWs();
   };
@@ -637,6 +652,7 @@ const createSessionController = ({
   const startWsTransport = async (): Promise<void> => {
     transport = "ws";
     reconnectAttempt = 0;
+    lastAcceleratedAt = null;
     fatalConnectionError = false;
     onCollaborationStatus("connecting");
     await connectWs();

--- a/apps/web/modules/docs/use-document-session.ts
+++ b/apps/web/modules/docs/use-document-session.ts
@@ -23,6 +23,10 @@ import {
   loadPendingBatches,
 } from "@/modules/docs/collab-pending-store";
 import { createOutgoingBatchQueue } from "@/modules/docs/collab-outgoing-queue";
+import {
+  getReconnectDelay,
+  isBrowserOffline,
+} from "@/modules/docs/collab-reconnect";
 import type { CollabTarget } from "@/modules/docs/collab-target";
 import {
   isDocumentEditable,
@@ -130,6 +134,15 @@ const createSessionController = ({
   let localPersistenceFailed = false;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectAttempt = 0;
+  /**
+   * Bumped by every WebSocket teardown. Callbacks captured under an older
+   * generation — a pending reconnect timer, an awaited auth read, socket
+   * listeners — must never touch the live session or open a socket for a
+   * session that has already been retired.
+   */
+  let wsGeneration = 0;
+  /** True from the start of a connect attempt until its socket exists. */
+  let connectPending = false;
   let synced = false;
   let fatalConnectionError = false;
   let activeRepairRequestId: string | null = null;
@@ -320,17 +333,64 @@ const createSessionController = ({
     return true;
   };
 
+  const clearReconnectTimer = (): void => {
+    if (reconnectTimer === null) return;
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  };
+
   const stopWs = (): void => {
-    if (reconnectTimer !== null) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+    // Retire every callback captured by the current WebSocket session before
+    // anything can observe the torn-down state.
+    wsGeneration += 1;
+    connectPending = false;
+    clearReconnectTimer();
     const active = socket;
     socket = null;
     synced = false;
     // Preserve pending batch identity; allow exact resend after reconnect.
     outgoing.resetInFlight();
     active?.close();
+  };
+
+  /**
+   * Arm the next reconnect. At most one timer exists per session: a pending
+   * timer, a live socket, or an in-flight connect attempt each mean the
+   * close/online/visibility event that reached here is already covered.
+   */
+  const scheduleReconnect = (): void => {
+    if (cancelled || transport !== "ws" || fatalConnectionError) return;
+    if (reconnectTimer !== null || connectPending || socket !== null) return;
+    if (isBrowserOffline()) {
+      // Retries cannot reach the backend while the browser reports no
+      // connectivity, so the loop stops here and the `online` listener resumes
+      // it. The attempt counter is left untouched: an offline stretch must not
+      // inflate the backoff a real reconnect starts from.
+      return;
+    }
+    const delay = getReconnectDelay(reconnectAttempt);
+    reconnectAttempt += 1;
+    const generation = wsGeneration;
+    const timer = setTimeout(() => {
+      if (reconnectTimer === timer) reconnectTimer = null;
+      if (generation !== wsGeneration) return;
+      void connectWs();
+    }, delay);
+    reconnectTimer = timer;
+  };
+
+  /**
+   * Reconnect now rather than waiting out the armed backoff. Driven by the
+   * browser signals that make a suppressed or pending retry worth attempting
+   * again — connectivity returning, or the page becoming visible. A healthy or
+   * in-flight connection is never disturbed.
+   */
+  const reconnectNow = (): void => {
+    if (cancelled || transport !== "ws" || fatalConnectionError) return;
+    if (socket !== null || connectPending) return;
+    if (isBrowserOffline()) return;
+    clearReconnectTimer();
+    void connectWs();
   };
 
   const stopHttp = async (): Promise<void> => {
@@ -341,8 +401,21 @@ const createSessionController = ({
     await saveCoordinator.flush(persistHttp);
   };
 
+  /**
+   * Open the collaboration socket for the endpoint this session was created
+   * with. `documentUrl` is resolved once by the server and never re-derived
+   * here, so a reconnect can only ever return to the runtime that already owns
+   * the document — runtime handoff is a separate concern that replaces the
+   * whole controller.
+   */
   const connectWs = async (): Promise<void> => {
-    if (cancelled || transport !== "ws") return;
+    if (cancelled || transport !== "ws" || fatalConnectionError) return;
+    // One connection attempt and one socket per session; a close, a timer, an
+    // `online` event and a visibility change can all land at once.
+    if (connectPending || socket !== null) return;
+    const generation = wsGeneration;
+    connectPending = true;
+    clearReconnectTimer();
     if (!localPersistenceFailed) {
       onCollaborationStatus(
         reconnectAttempt === 0 ? "connecting" : "reconnecting",
@@ -354,24 +427,45 @@ const createSessionController = ({
       | { readonly kind: "public" } = { kind: "public" };
 
     if (sessionMode === "authenticated") {
-      if (!(await ensureAuth()) || cancelled || accessToken === null) {
-        if (!cancelled && transport === "ws") {
-          const delay = Math.min(500 * 2 ** reconnectAttempt, 10_000);
-          reconnectAttempt += 1;
-          reconnectTimer = setTimeout(() => {
-            reconnectTimer = null;
-            void connectWs();
-          }, delay);
-        }
+      // A rejected session read (offline Supabase, aborted fetch) is a
+      // transient connect failure; the retry loop must survive it rather than
+      // leave the attempt flag stuck.
+      const authenticated = await ensureAuth().catch(() => false);
+      // Reading the session yields to the event loop: a dispose or a transport
+      // switch may have retired this attempt in the meantime. A retired
+      // attempt must not clear `connectPending`, which a newer attempt may
+      // already own — that is how two sockets would end up open at once.
+      if (generation !== wsGeneration) return;
+      if (cancelled || transport !== "ws") {
+        connectPending = false;
+        return;
+      }
+      if (!authenticated || accessToken === null) {
+        connectPending = false;
+        scheduleReconnect();
         return;
       }
       credential = { kind: "access-token", token: accessToken };
     }
 
-    const nextSocket = new WebSocket(documentUrl);
+    let nextSocket: WebSocket;
+    try {
+      nextSocket = new WebSocket(documentUrl);
+    } catch {
+      // The constructor only throws for an unusable endpoint (invalid URL,
+      // rejected scheme). Retrying cannot change that, so fail the session
+      // instead of spinning the reconnect loop.
+      connectPending = false;
+      fatalConnectionError = true;
+      onError(new Error("The collaboration endpoint could not be opened"));
+      onCollaborationStatus("error");
+      return;
+    }
     socket = nextSocket;
+    connectPending = false;
 
     nextSocket.addEventListener("open", () => {
+      if (generation !== wsGeneration) return;
       if (cancelled || socket !== nextSocket || transport !== "ws") return;
       sendJson(nextSocket, {
         protocolVersion: COLLAB_PROTOCOL_VERSION,
@@ -383,6 +477,7 @@ const createSessionController = ({
     });
 
     nextSocket.addEventListener("message", (event) => {
+      if (generation !== wsGeneration) return;
       if (cancelled || socket !== nextSocket || transport !== "ws") return;
       let message;
       try {
@@ -413,6 +508,9 @@ const createSessionController = ({
             ) {
               throw new Error("The collaboration access mode is invalid");
             }
+            // The connection is proven usable: drop any obsolete backoff so
+            // the next disconnect starts from the shortest window again.
+            clearReconnectTimer();
             reconnectAttempt = 0;
             fatalConnectionError = false;
             if (!localPersistenceFailed) onError(null);
@@ -489,23 +587,19 @@ const createSessionController = ({
     });
 
     nextSocket.addEventListener("close", () => {
+      if (generation !== wsGeneration) return;
       if (cancelled || socket !== nextSocket || transport !== "ws") return;
       socket = null;
       synced = false;
       // Drop in-flight markers only; pending payloads stay for idempotent resend.
       outgoing.resetInFlight();
-      if (!fatalConnectionError) {
-        onCollaborationStatus("offline");
-        const delay = Math.min(500 * 2 ** reconnectAttempt, 10_000);
-        reconnectAttempt += 1;
-        reconnectTimer = setTimeout(() => {
-          reconnectTimer = null;
-          void connectWs();
-        }, delay);
-      }
+      if (fatalConnectionError) return;
+      onCollaborationStatus("offline");
+      scheduleReconnect();
     });
 
     nextSocket.addEventListener("error", () => {
+      if (generation !== wsGeneration) return;
       if (socket === nextSocket) nextSocket.close();
     });
   };
@@ -608,6 +702,24 @@ const createSessionController = ({
     });
   };
 
+  /**
+   * Connectivity returning is the signal that ends an offline suppression, and
+   * a page becoming visible is the signal that a user is waiting on a retry
+   * that is still backing off. Neither ever closes a live socket: a hidden tab
+   * keeps collaborating exactly as before.
+   */
+  const handleOnline = (): void => {
+    reconnectNow();
+  };
+
+  const handleVisibilityChange = (): void => {
+    if (document.visibilityState !== "visible") return;
+    reconnectNow();
+  };
+
+  window.addEventListener("online", handleOnline);
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
   void setShared(initialShared);
 
   return {
@@ -616,6 +728,9 @@ const createSessionController = ({
     },
     dispose: () => {
       cancelled = true;
+      // Detach first: no browser signal may reach a session being torn down.
+      window.removeEventListener("online", handleOnline);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       saveCoordinator.dispose();
       unsubscribeReplica();
       bindingRef.current = null;


### PR DESCRIPTION
Deterministic exponential backoff made every disconnected client retry on
the same millisecond, so a Worker deployment, Durable Object restart, or
upstream outage rebuilt the load that caused the disconnect. Reconnect
delays are now drawn with full jitter from the attempt's backoff window,
and the retry loop stops entirely while the browser reports no
connectivity, resuming on `online` or when a hidden page becomes visible
again.

- add `collab-reconnect` with `getReconnectDelay`/`getReconnectDelayCap`
  (500ms base, 10s cap, 100ms floor) and `isBrowserOffline`
- schedule reconnects through a single guarded path so a close, a timer,
  an `online` event, and a visibility change can never arm two timers or
  open two sockets
- tag every WebSocket session with a generation so a retired timer,
  awaited auth read, or socket listener cannot touch a live session or
  open a socket for a previous document
- remove the `online`/`visibilitychange` listeners on dispose, before any
  other teardown runs

A healthy socket is never closed for a visibility change, and reconnects
stay on the endpoint the server already resolved for the document — no
runtime fallback is introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved collaboration session reconnection with capped exponential backoff and jitter.
  - Reconnect attempts now pause while offline and resume when connectivity returns or the page becomes visible.
  - More reliable handling of authentication, connection failures, stale events, and session cleanup.

- **Bug Fixes**
  - Prevented outdated reconnect attempts and socket events from affecting active sessions.
  - Improved protection against duplicate connection-close handling and unsafe teardown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->