### PR TITLE
docs: add comprehensive README files for all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,23 +37,23 @@ the browser to durable storage:
                                 Browser
                       apps/web · apps/playground
                                    │
-         ┌─────────────────────────┼─────────────────────────┐
-         │                         │                         │
- @softmaple/editor    @softmaple/binding-lexical   @softmaple/awareness
- Lexical UI shell        Lexical ↔ block model      ephemeral presence
-                                   │                         │
-                        @softmaple/block-model               │
-                    blocks · marks · event batches           │
-                                   │                         │
-                         @softmaple/eg-walker                │
-                    event graph · CRDT convergence           │
-                                   │                         │
-                    RichTextEventBatch on the wire           │
-                                   │                         │
-                      @softmaple/collab-protocol             │
-                        versioned wire messages              │
-                                   │                         │
-                       @softmaple/collab-runtime ────────────┘
+         ┌─────────────────────────┼──────────────────────────────┐
+         │                         │                              │
+ @softmaple/editor    @softmaple/binding-lexical        @softmaple/awareness
+ Lexical UI shell        Lexical ↔ block model           ephemeral presence
+                                   │                              │
+                        @softmaple/block-model                    │
+                    blocks · marks · event batches                │
+                                   │                              │
+                         @softmaple/eg-walker                     │
+                    event graph · CRDT convergence                │
+                                   │                              │
+                    RichTextEventBatch on the wire                │
+                                   │                              │
+                      @softmaple/collab-protocol                  │
+                        versioned wire messages                   │
+                                   │                              │
+                       @softmaple/collab-runtime ──PresenceCodec──┘
                  DocumentRoom / PresenceRoom semantics
                       ┌────────────┴────────────┐
                       │                         │
@@ -76,9 +76,13 @@ one — and is enforced by shared ESLint rules
 it only carries the batches the model produces.
 
 Awareness stays independent of every convergent document model and meets the
-bindings only inside an app. Both collaboration runtimes host the *same*
-`@softmaple/collab-runtime` semantics and write the same Postgres event log, so
-a document can move between them without a history migration.
+bindings only inside an app. `@softmaple/collab-runtime` hosts `PresenceRoom`
+but never imports `@softmaple/awareness` — the labelled edge above is the
+payload-opaque `PresenceCodec` seam, and a host app is what binds the two.
+
+Both collaboration runtimes host the *same* `@softmaple/collab-runtime`
+semantics and write the same Postgres event log, so a document can move between
+them without a history migration.
 
 Design source of truth:
 [`docs/design/collaboration-layers.md`](docs/design/collaboration-layers.md) ·

--- a/README.md
+++ b/README.md
@@ -27,6 +27,65 @@
 
 # Development
 
+## Architecture
+
+Softmaple is a collaborative $\LaTeX$-flavoured document editor. Each layer
+below is its own workspace package — here is the path a keystroke takes from
+the browser to durable storage:
+
+```text
+                                Browser
+                      apps/web · apps/playground
+                                   │
+         ┌─────────────────────────┼─────────────────────────┐
+         │                         │                         │
+ @softmaple/editor    @softmaple/binding-lexical   @softmaple/awareness
+ Lexical UI shell        Lexical ↔ block model      ephemeral presence
+                                   │                         │
+                        @softmaple/block-model               │
+                    blocks · marks · event batches           │
+                                   │                         │
+                         @softmaple/eg-walker                │
+                    event graph · CRDT convergence           │
+                                   │                         │
+                    RichTextEventBatch on the wire           │
+                                   │                         │
+                      @softmaple/collab-protocol             │
+                        versioned wire messages              │
+                                   │                         │
+                       @softmaple/collab-runtime ────────────┘
+                 DocumentRoom / PresenceRoom semantics
+                      ┌────────────┴────────────┐
+                      │                         │
+                 Node/Nitro                Cloudflare
+              apps/collab-nitro      apps/collab-cloudflare
+                      │                         │
+                    Redis                Durable Object
+              pub/sub · leases          hibernatable room
+                      │                         │
+                      └────────────┬────────────┘
+                                   │
+                           Supabase/Postgres
+                           durable event log
+```
+
+The import graph runs the same direction — a lower layer never imports a higher
+one — and is enforced by shared ESLint rules
+([`packages/eslint-config/collaboration-layers.js`](packages/eslint-config/collaboration-layers.js)).
+`@softmaple/collab-protocol` reaches the block model, not EG-walker directly;
+it only carries the batches the model produces.
+
+Awareness stays independent of every convergent document model and meets the
+bindings only inside an app. Both collaboration runtimes host the *same*
+`@softmaple/collab-runtime` semantics and write the same Postgres event log, so
+a document can move between them without a history migration.
+
+Design source of truth:
+[`docs/design/collaboration-layers.md`](docs/design/collaboration-layers.md) ·
+[`collaboration-consistency.md`](docs/design/collaboration-consistency.md) ·
+[`collaboration-runtime.md`](docs/design/collaboration-runtime.md) ·
+[`collaboration-operations.md`](docs/design/collaboration-operations.md).
+
 ## shadcn/ui [turborepo](https://turborepo.org/) architecture:
 
 - apps
@@ -34,8 +93,24 @@
     - **Next.js** v16 with `app` folder
     - **EG-walker + WebSocket** for real-time collaboration
     - **Supabase Postgres** for durable history and **Supabase Auth** for authentication
+  - [collab-cloudflare](apps/collab-cloudflare) - Collaboration runtime on Cloudflare (recommended for production)
+    - **Workers + Durable Objects** with WebSocket Hibernation
+    - **Supabase RPC** for durable appends, DO-local fan-out
+  - [collab-nitro](apps/collab-nitro) - Collaboration runtime on Nitro (local dev / fallback)
+    - **Nitro** WebSocket service behind Vercel Services
+    - **Redis** for realtime fan-out, presence TTLs, and connection leases
+  - [playground](apps/playground) - Collaboration and editor demo surface
+    - **TanStack Start** + **Vite**, wired straight to the workspace sources
 
 - packages
+  - [awareness](packages/awareness) - Presence and awareness layer
+    - **Transport-agnostic** adapters (WebSocket, BroadcastChannel, no-op)
+    - Cursors, selections, avatars, and activity indicators
+  - [bench](packages/bench) - Performance harnesses for `@softmaple/eg-walker`
+  - [binding-lexical](packages/binding-lexical) - Lexical ↔ block model binding
+  - [block-model](packages/block-model) - Editor-agnostic rich-text block model
+  - [collab-protocol](packages/collab-protocol) - Versioned collaboration wire protocol
+  - [collab-runtime](packages/collab-runtime) - Host-independent room and session semantics
   - [config](packages/config) - Site configuration
   - [db](packages/db) - Database schema and migrations
     - **Prisma** for ORM [![Made with Prisma](https://made-with.prisma.io/dark.svg)](https://prisma.io)
@@ -43,6 +118,7 @@
   - [editor](packages/editor) - Rich text editor
     - **Lexical** for rich text editing
     - **React** 19 and **Vite**
+  - [eg-walker](packages/eg-walker) - EG-walker CRDT for collaborative editing
   - [md2latex](packages/md2latex) - Markdown to $\LaTeX$ converter
   - [eslint-config](packages/eslint-config) - Shared ESLint configuration
   - [typescript-config](packages/typescript-config) - Shared TypeScript `tsconfig.json`

--- a/README.md
+++ b/README.md
@@ -69,11 +69,14 @@ the browser to durable storage:
                            durable event log
 ```
 
-The import graph runs the same direction — a lower layer never imports a higher
-one — and is enforced by shared ESLint rules
-([`packages/eslint-config/collaboration-layers.js`](packages/eslint-config/collaboration-layers.js)).
-`@softmaple/collab-protocol` reaches the block model, not EG-walker directly;
-it only carries the batches the model produces.
+The diagram is ordered by data flow, not by import direction — a package drawn
+lower is not necessarily the one being imported. The actual import graph is
+enforced by shared ESLint rules
+([`packages/eslint-config/collaboration-layers.js`](packages/eslint-config/collaboration-layers.js)):
+`@softmaple/block-model` imports `@softmaple/eg-walker`, and
+`@softmaple/collab-protocol` imports `@softmaple/block-model` — never
+`@softmaple/eg-walker` directly — so the protocol validates the batches it
+carries without depending on the sequence CRDT.
 
 Awareness stays independent of every convergent document model and meets the
 bindings only inside an app. `@softmaple/collab-runtime` hosts `PresenceRoom`

--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -46,8 +46,11 @@ for the cross-runtime operational picture and configured rollout stage.
 
 The two Durable Object namespaces are fully separate and share no capability
 instance or cross-stub call, so a presence failure structurally cannot block
-durable document convergence. Postgres remains the only durable store; a
-Durable Object holds live connection state, never the source of truth.
+durable document convergence. Postgres remains the only durable
+**document-history** store; a Durable Object holds live connection state, never
+the source of truth for document events. `PresenceRoomDO` does keep membership
+in `ctx.storage` so it survives hibernation, but that is disposable TTL state
+rebuilt from live connections — not durable history.
 
 The public Worker keeps the existing `/collab/document` WebSocket endpoint,
 now with the document UUID on the URL:

--- a/apps/collab-cloudflare/README.md
+++ b/apps/collab-cloudflare/README.md
@@ -13,6 +13,42 @@ for the cross-runtime operational picture and configured rollout stage.
 
 ## Runtime shape
 
+```text
+                             Browser (apps/web)
+                                      │
+                   wss /collab/document?documentId=<uuid>
+                      wss /collab/presence?roomId=<id>
+                                      │
+                          src/index.ts — the Worker
+                  origin check · id normalize · route only
+                                      │
+                ┌─────────────────────┴─────────────────────┐
+                │                                           │
+         DOCUMENT_ROOMS                              PRESENCE_ROOMS
+     .getByName(documentId)                        .getByName(roomId)
+                │                                           │
+         DocumentRoomDO                              PresenceRoomDO
+      hibernatable sockets                        hibernatable sockets
+      versioned attachment                        versioned attachment
+                │                                           │
+          DocumentRoom                                PresenceRoom
+     EventStore · RoomFanout                   PresenceStore (ctx.storage)
+        DO-local fan-out                        PresenceFanout · DO alarm
+                │                                           │
+       supabase-backend.ts                    supabase-presence-backend.ts
+                │                                           │
+                └─────────────────────┬─────────────────────┘
+                                      │
+                    Supabase Postgres — service_role RPC
+                        append_document_event_batches
+                          read_document_event_page
+```
+
+The two Durable Object namespaces are fully separate and share no capability
+instance or cross-stub call, so a presence failure structurally cannot block
+durable document convergence. Postgres remains the only durable store; a
+Durable Object holds live connection state, never the source of truth.
+
 The public Worker keeps the existing `/collab/document` WebSocket endpoint,
 now with the document UUID on the URL:
 `/collab/document?documentId=<uuid>`. The Worker validates the browser

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -1,8 +1,58 @@
-Welcome to your new TanStack app!
+# `@softmaple/playground`
+
+The experiment surface for Softmaple's collaboration stack: a TanStack Start +
+Vite app where a binding, an adapter, or a presence idea can be exercised
+end-to-end before it reaches `apps/web`.
 
 [![Formatted with Biome](https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev/)
 [![Linted with Biome](https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
+
+It imports the workspace packages **from source** (see
+[`workspace-aliases.ts`](./workspace-aliases.ts)), so a change in
+`@softmaple/eg-walker` or `@softmaple/awareness` shows up on the next hot
+reload without a build step.
+
+## Architecture
+
+```text
+                  apps/playground — TanStack Start + Vite
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              │                      │                      │
+       /demo/lexical-        /demo/awareness-         /demo/online-
+          eg-walker               collab              collab-editor
+              │                      │                      │
+       binding-lexical           awareness          surface-bindings/
+         block-model             adapters           textarea (staged)
+          eg-walker                  │                      │
+              │                      │                      │
+              └──────────────────────┼──────────────────────┘
+                                     │
+                    server/ — Nitro WebSocket handlers
+            /api/collab-doc · /api/presence · /api/collab-sync
+                                     │
+                 in-process rooms · no Supabase, no Redis
+```
+
+The collaboration servers here are **not** `apps/collab-nitro` or
+`apps/collab-cloudflare`. They are deliberately minimal in-process handlers
+that keep an in-memory batch log per room — enough to exercise join, repair,
+and fan-out on one machine, with no database, auth, or deployment story. Nothing
+in `server/` is a production runtime, and nothing here should grow into one.
+
+| Directory | Contents |
+| --- | --- |
+| `src/routes/demo/` | One route per demo |
+| `src/modules/lexical-eg-walker/` | Lexical + EG-walker document demo, presence rail, remote selections |
+| `src/modules/awareness-collab/` | Awareness adapter experiments |
+| `src/modules/collab-transport/` | Transport helpers (WebSocket ⇄ BroadcastChannel) |
+| `src/surface-bindings/` | Staging area for bindings before they earn a package — see its [README](./src/surface-bindings/README.md) |
+| `server/api/` | Nitro WebSocket handlers — see its [README](./server/README.md) |
+
+A binding graduates out of `src/surface-bindings/` into a standalone
+`@softmaple/binding-<surface>` package only on evidence, per the promotion rule
+in [`docs/design/surface-bindings.md`](../../docs/design/surface-bindings.md).
 
 # Getting Started
 
@@ -10,7 +60,7 @@ To run this application:
 
 ```bash
 pnpm install
-pnpm start
+pnpm --filter @softmaple/playground dev   # http://localhost:3000
 ```
 
 # Building For Production
@@ -23,10 +73,12 @@ pnpm build
 
 ## Testing
 
-This project uses [Vitest](https://vitest.dev/) for testing. You can run the tests with:
+This project uses [Vitest](https://vitest.dev/) for unit tests and
+[Playwright](https://playwright.dev/) for E2E:
 
 ```bash
 pnpm test
+pnpm test:e2e
 ```
 
 ## Styling

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -68,17 +68,19 @@ pnpm --filter @softmaple/playground dev   # http://localhost:3000
 To build this application for production:
 
 ```bash
-pnpm build
+pnpm --filter @softmaple/playground build
 ```
 
 ## Testing
 
 This project uses [Vitest](https://vitest.dev/) for unit tests and
-[Playwright](https://playwright.dev/) for E2E:
+[Playwright](https://playwright.dev/) for E2E. The repository root defines no
+`test` script, so scope these to the package (or run them from
+`apps/playground`):
 
 ```bash
-pnpm test
-pnpm test:e2e
+pnpm --filter @softmaple/playground test
+pnpm --filter @softmaple/playground test:e2e
 ```
 
 ## Styling
@@ -87,12 +89,15 @@ This project uses [Tailwind CSS](https://tailwindcss.com/) for styling.
 
 ## Linting & Formatting
 
-This project uses [Biome](https://biomejs.dev/) for linting and formatting. The following scripts are available:
+This project uses [Biome](https://biomejs.dev/) for linting and formatting —
+unlike the ESLint-based packages elsewhere in the monorepo. Root `pnpm lint` and
+`pnpm format` run repo-wide and do **not** apply this app's Biome config, so
+scope these too (root defines no `check` script at all):
 
 ```bash
-pnpm lint
-pnpm format
-pnpm check
+pnpm --filter @softmaple/playground lint
+pnpm --filter @softmaple/playground format
+pnpm --filter @softmaple/playground check
 ```
 
 ## T3Env

--- a/packages/awareness/README.md
+++ b/packages/awareness/README.md
@@ -9,6 +9,41 @@ This package provides transport-agnostic awareness and presence UI components de
 Based on the design principles outlined in [docs/design/awareness-and-presence.md](../../docs/design/awareness-and-presence.md)
 and the [Surface Binding Contract](docs/surface-binding-contract.md).
 
+## Architecture
+
+```text
+                       apps/web · apps/playground
+            PresenceBar · LiveCursor · BlockActivityIndicator
+                                    │
+                hooks/ — useUpdateCursor, usePresence, …
+                                    │
+                            PresenceProvider
+                                    │
+                         state/ — pure reducers
+                  clock-ordered merge · derived status
+                                    │
+                    AwarenessAdapter (transport seam)
+              ┌─────────────────────┬─────────────────────┐
+              │                     │                     │
+          WebSocket         BroadcastChannel            no-op
+         collab host        same-origin tabs         SSR · tests
+              │                     │                 Storybook
+      apps/collab-nitro        other tabs
+   apps/collab-cloudflare
+        PresenceRoom
+```
+
+Awareness is a **sibling** of the document stack, never a layer inside it. This
+package must not import `@softmaple/eg-walker`, `@softmaple/block-model`, a
+surface binding, or an editor framework — enforced by Biome's
+`style/noRestrictedImports` in [`biome.jsonc`](./biome.jsonc). Presence and the
+convergent document meet only inside an app.
+
+That separation is what makes presence disposable: it is ephemeral, lossy by
+design, and never durable. Losing a cursor costs nothing; losing an event
+batch would be data loss, which is why the two travel over different rooms and
+different stores.
+
 ## Features
 
 - **PresenceBar**: Global awareness of who's online, with keyboard-focusable avatars, hover/focus tooltips, and a `loading` skeleton state for in-flight connections

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -4,6 +4,31 @@ Performance harnesses for [`@softmaple/eg-walker`](../eg-walker/README.md).
 This private tooling package keeps benchmark code, fixtures, and dependencies
 out of the production CRDT package.
 
+## Architecture
+
+```text
+      vitest bench                             paper-bench
+ 5 deterministic traces                  egwalker-paper datasets
+            │                                       │
+            └───────────────────┬───────────────────┘
+                                │
+                  fresh EgWalkerReplica per run
+                                │
+                      @softmaple/eg-walker
+                      built first by turbo
+                                │
+            ┌───────────────────┴───────────────────┐
+            │                                       │
+       wall clock                            replay counters
+      per scenario                        full/partial replays
+                                     checkpoint hits · peak records
+```
+
+Wall clock alone hides algorithm regressions: a change that silently turns
+partial replays into full ones can still look fast on a small trace. Reading
+the counters next to the timings is what makes an algorithm-path or
+memory-shape regression visible.
+
 ## Verification
 
 Run tasks through Turborepo so the compiled `@softmaple/eg-walker` dependency

--- a/packages/binding-lexical/README.md
+++ b/packages/binding-lexical/README.md
@@ -1,0 +1,144 @@
+# `@softmaple/binding-lexical`
+
+The surface binding that connects a Lexical editor to a
+[`@softmaple/block-model`](../block-model/README.md) replica. It is the only
+place in the stack where Lexical types and the convergent document model meet:
+the block model knows nothing about Lexical, and this package never reaches
+past the block model into `@softmaple/eg-walker`.
+
+## Role in the stack
+
+```text
+                        Lexical editor state
+                                  │
+                 registerUpdateListener — local edit
+                                  │
+                                  ▼
+                       projectLexicalDocument
+                     Lexical → ProjectedDocument
+                                  │
+                        toBlockDocumentInput
+                                  │
+                                  ▼
+                         replica.transact(…)  ───►    RichTextEventBatch
+                       @softmaple/block-model                 │
+                                  ▲                           │
+                          applyRemoteEvents ◄─────────────────┘
+                                  │            from the collab host
+                                  ▼
+                     materializeLexicalDocument
+                                  │
+            editor.update(…, { tag: COLLABORATION_TAG })
+                                  │
+                                  ▼
+                        Lexical editor state
+```
+
+The `COLLABORATION_TAG` on every remote-applied update is what breaks the
+cycle: the update listener ignores tagged updates, so applying a remote batch
+never re-projects itself back into a new local event.
+
+| Concern | Owner |
+| --- | --- |
+| Lexical nodes, selection, DOM | Lexical + the host app |
+| Lexical ↔ block projection, selection anchoring | **this package** |
+| Blocks, marks, structure, convergence | `@softmaple/block-model` |
+| Sequence CRDT and stable anchors | `@softmaple/eg-walker` |
+| Transport, persistence, presence | `apps/*` and `@softmaple/awareness` |
+
+## Usage
+
+### React
+
+```tsx
+import { LexicalEgWalkerPlugin } from "@softmaple/binding-lexical/react";
+import { BlockReplica } from "@softmaple/block-model";
+
+const replica = new BlockReplica(sessionId);
+
+<LexicalComposer initialConfig={config}>
+  <RichTextPlugin … />
+  <LexicalEgWalkerPlugin
+    replica={replica}
+    enableEditingOnReady
+    onBindingChange={setBinding}
+    onSelectionChange={publishPresence}
+    onError={reportError}
+  />
+</LexicalComposer>;
+```
+
+The plugin is a lifecycle wrapper only — it creates the binding on mount and
+calls `destroy()` on unmount. All behavior lives in the framework-free core.
+
+### Framework-free
+
+```ts
+import { createLexicalBinding } from "@softmaple/binding-lexical";
+
+const binding = createLexicalBinding({ editor, replica });
+
+// Remote batches arriving from the collaboration host.
+binding.applyRemoteEvents(batches);
+
+// Stable, wire-safe selection for presence.
+const selection = binding.captureSelection();
+
+binding.destroy();
+```
+
+## API
+
+| Export | Purpose |
+| --- | --- |
+| `createLexicalBinding(options)` | Creates the binding; returns `LexicalBinding` |
+| `LexicalEgWalkerPlugin` (`/react`) | React lifecycle wrapper around the above |
+| `captureLogicalSelection` / `restoreLogicalSelection` | Block-id + offset selection, independent of Lexical node keys |
+| `UnsupportedLexicalNodeError` | Thrown when a node type has no projection |
+
+`LexicalBinding` members:
+
+- `applyRemoteEvents(batches)` — integrate remote batches and re-materialize.
+- `captureSelection()` — current selection as EG-walker anchors
+  (`StableBlockSelection`), safe to send over the wire.
+- `resolveSelection(selection)` — anchors back to a logical selection; throws
+  on an invalid anchor.
+- `tryResolveSelection(selection)` — the same, but answers
+  `temporarily-unresolved` when an endpoint names an atom whose creating event
+  has not been integrated yet. Use this for remote presence, which routinely
+  races ahead of document events.
+- `getBlockIndex()` — current `blockId ↔ NodeKey` maps.
+- `destroy()` — unregister listeners.
+
+## Projection scope
+
+Blocks projected today: `paragraph`, `h1`–`h3`, `quote`, `code`,
+`bullet-list`, `number-list`, `check-list`.
+
+Marks projected today: `bold`, `italic`, `underline`, `strike`,
+`inline-code`, `link`.
+
+Anything else throws `UnsupportedLexicalNodeError` rather than silently
+dropping content — a lost node in a convergent document is unrecoverable, so
+the binding fails loudly and lets the host decide.
+
+Lexical `NodeKey`s are process-local. They appear in `ProjectedBlock.sourceKey`
+as transaction-local references only and are **never** written into the
+collaborative document, so two clients never disagree about identity.
+
+## Commands
+
+```bash
+pnpm --filter @softmaple/binding-lexical build
+pnpm --filter @softmaple/binding-lexical test
+pnpm --filter @softmaple/binding-lexical typecheck
+pnpm --filter @softmaple/binding-lexical lint
+```
+
+Lexical and React are peer dependencies; the host app supplies them.
+
+## Related
+
+- [`@softmaple/block-model`](../block-model/README.md) — the model this binds to
+- [`docs/design/surface-bindings.md`](../../docs/design/surface-bindings.md) — the binding contract
+- [`docs/design/collaboration-layers.md`](../../docs/design/collaboration-layers.md) — layer boundaries

--- a/packages/block-model/README.md
+++ b/packages/block-model/README.md
@@ -3,6 +3,40 @@
 Editor-agnostic rich-text convergence on top of `@softmaple/eg-walker`.
 The package has no Lexical, React, or awareness dependency.
 
+## Architecture
+
+```text
+  @softmaple/binding-lexical                     collab host (apps/*)
+     Lexical ⇄ projection                         RichTextEventBatch
+               │                                           │
+         transact(fn)                             applyRemoteEvents()
+               │                                           │
+               └─────────────────────┬─────────────────────┘
+                                     │
+                               BlockReplica
+                    blocks · marks · causal-LWW fields
+                                     │
+               ┌─────────────────────┴─────────────────────┐
+               │                                           │
+       escaped user text                             block markers
+       one flat sequence                       event-backed ids · joins
+               │                                           │
+               └─────────────────────┬─────────────────────┘
+                                     │
+                           @softmaple/eg-walker
+                   convergent sequence · stable anchors
+```
+
+The whole document — text *and* structure — lives in **one** EG-walker
+sequence. Blocks are event-backed markers interleaved with escaped user text,
+so a concurrent split and a concurrent insert converge under the same
+algorithm rather than under a second, hand-written merge rule.
+
+`RichTextEventBatch` is JSON-safe: a batch may be persisted or broadcast
+directly, and the receiving replica needs nothing but the batch to converge.
+
+## Usage
+
 ```ts
 import {
   BOOTSTRAP_BLOCK_ID,

--- a/packages/collab-protocol/README.md
+++ b/packages/collab-protocol/README.md
@@ -1,0 +1,140 @@
+# `@softmaple/collab-protocol`
+
+The versioned wire contract between a browser collaboration client and any
+collaboration host. This package is pure value semantics: message shapes, a
+protocol version, an error taxonomy, and two runtime parsers. It contains no
+transport, no persistence, no authorization, and no editor code, so both
+runtimes and every client speak one identical format.
+
+## Role in the stack
+
+```text
+       apps/web · apps/playground            apps/collab-nitro
+            browser collab client         apps/collab-cloudflare
+                     │                               │
+                     │      Event / RepairRequest    │
+                     ├──────────────────────────────►│
+                     │  Ready / Event / DurableAck   │
+                     │◄──────────────────────────────┤
+                     │                               │
+                     └───────────────┬───────────────┘
+                                     │
+                       @softmaple/collab-protocol
+              versioned envelope · runtime validation · errors
+                                     │
+                        @softmaple/block-model
+                  parseRichTextEventBatch (payload guard)
+                                     │
+                         @softmaple/eg-walker
+                        events the batches carry
+```
+
+Both ends validate: a client parses what the server sent, a server parses what
+the client sent. Neither side trusts a raw frame, and neither side hand-rolls a
+second decoder.
+
+| Layer | May import this package |
+| --- | --- |
+| `@softmaple/collab-runtime` | yes — it maps room results onto these messages |
+| `apps/collab-nitro`, `apps/collab-cloudflare` | yes |
+| `apps/web`, `apps/playground` | yes |
+| `@softmaple/eg-walker`, `@softmaple/block-model` | **no** — lower layers |
+| `@softmaple/awareness` | **no** — presence has its own protocol |
+
+## Message flow
+
+```text
+client ──► Auth            { credential, documentId, sessionId }
+server ──► Ready           { accessMode, documentId, userId, role, canWrite }
+
+client ──► Event           { batches }
+server ──► DurableAck      { batchIds }        after the durable append
+server ──► Event           { batches }         fan-out to other peers
+
+client ──► RepairRequest   { requestId, afterCursor }
+server ──► RepairResponse  { requestId, batches, nextCursor, complete }
+
+server ──► Error           { code, message, retryable }
+```
+
+`DurableAck` is only sent once the append succeeded, so a client can treat an
+acknowledged batch id as durable. Repair pages are ordered and resumable
+through `nextCursor`, and `complete` marks the last page.
+
+## Versions
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| `COLLAB_PROTOCOL_VERSION` | `3` | Current. `Auth` carries a `CollabCredential`; `Ready` carries `accessMode` and nullable `userId` / `role`. |
+| `LEGACY_COLLAB_PROTOCOL_VERSION` | `2` | Accepted for compatibility. `Auth` carries a bare `accessToken`; `Ready` requires a non-null `userId` and `role`. |
+
+Version 3 adds public (unauthenticated) read access. A `public` session must
+report `userId: null`, `role: null`, and `canWrite: false`; `parseServerCollabMessage`
+rejects a `Ready` that claims otherwise, so a host cannot accidentally grant
+write capability to an anonymous reader.
+
+## API
+
+```ts
+import {
+  COLLAB_PROTOCOL_VERSION,
+  COLLAB_MESSAGE_TYPE,
+  COLLAB_ERROR_CODE,
+  parseClientCollabMessage,
+  parseServerCollabMessage,
+  type ClientCollabMessage,
+  type ServerCollabMessage,
+} from "@softmaple/collab-protocol";
+
+// Host side: never act on an unvalidated frame.
+const message: ClientCollabMessage = parseClientCollabMessage(
+  JSON.parse(raw),
+);
+
+// Client side: never render an unvalidated frame.
+const reply: ServerCollabMessage = parseServerCollabMessage(
+  JSON.parse(raw),
+);
+```
+
+Both parsers throw a plain `Error` on anything malformed; they never return a
+partially-trusted object. Callers translate that throw into an
+`InvalidMessage` protocol error (hosts) or a transport failure (clients).
+
+### Error codes
+
+| Code | Meaning |
+| --- | --- |
+| `authentication-failed` | Credential rejected, or the `Auth` document id does not match the routed room |
+| `forbidden` | Authenticated but not permitted (role, membership, or read-only session) |
+| `invalid-message` | Frame failed validation |
+| `conflict` | Durable append conflicted with existing history |
+| `persistence-failed` | Durable store unavailable; `retryable` distinguishes transient failures |
+
+## Validation limits
+
+Bounds are part of the contract, not host policy, so every runtime enforces the
+same ones:
+
+- `Event.batches`: 1–64 batches per message.
+- `RepairResponse.batches`: 0–100 batches per page.
+- Repair cursors (`afterCursor`, `nextCursor`): non-negative decimal strings
+  (`/^\d+$/`) — never numbers, so large cursors survive JSON round-trips.
+- Each batch is validated through `parseRichTextEventBatch` from
+  `@softmaple/block-model`; this package never inspects event internals itself.
+
+## Commands
+
+```bash
+pnpm --filter @softmaple/collab-protocol build
+pnpm --filter @softmaple/collab-protocol test
+pnpm --filter @softmaple/collab-protocol typecheck
+pnpm --filter @softmaple/collab-protocol lint
+```
+
+## Related
+
+- Room and session semantics: [`@softmaple/collab-runtime`](../collab-runtime/README.md)
+- Layer boundaries: [`docs/design/collaboration-layers.md`](../../docs/design/collaboration-layers.md)
+- Durable-write invariants: [`docs/design/collaboration-consistency.md`](../../docs/design/collaboration-consistency.md)
+- Presence protocol (separate, versioned independently): [`@softmaple/awareness`](../awareness/README.md)

--- a/packages/collab-runtime/README.md
+++ b/packages/collab-runtime/README.md
@@ -4,6 +4,41 @@ Runtime-independent semantics and contracts for hosted document collaboration.
 The package owns the concrete room/session state machine while leaving every
 infrastructure choice to a host adapter.
 
+## Architecture
+
+```text
+      apps/collab-nitro                        apps/collab-cloudflare
+   Nitro · Redis · Prisma                      Worker · Durable Object
+              │                                           │
+              └─────────────────────┬─────────────────────┘
+                                    │
+                        @softmaple/collab-runtime
+                                    │
+              ┌─────────────────────┴─────────────────────┐
+              │                                           │
+        DocumentRoom                                PresenceRoom
+     RoomPeer lifecycle                        PresencePeer lifecycle
+    sessions · admission                        payload-opaque codec
+              │                                           │
+         EventStore                                 PresenceStore
+    append · repair pages                          TTL membership
+         RoomFanout                                PresenceFanout
+      committed fan-out                           broadcast fan-out
+              │                                           │
+              └─────────────────────┬─────────────────────┘
+                                    │
+                       @softmaple/collab-protocol
+                     the messages rooms answer with
+```
+
+`EventStore`, `RoomFanout`, `PresenceStore`, and `PresenceFanout` are
+**capability interfaces**, not implementations. Redis and Durable Objects sit
+behind the same four seams, which is why both hosts can be proven equivalent by
+one conformance kit instead of by two parallel test suites.
+
+The two rooms never share a capability instance: presence outages cannot take
+document persistence with them, and vice versa.
+
 The public capabilities cover:
 
 - `DocumentRoom` and transport-neutral `RoomPeer` lifecycle

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,9 +1,9 @@
 # `@softmaple/config`
 
 Canonical site constants — public URLs, the docs and playground hosts, the
-contact address, and the OpenGraph image. One frozen object, imported directly
-as TypeScript source, so a domain change is a one-line edit rather than a
-grep across every app.
+contact address, and the OpenGraph image. One `as const` object, imported
+directly as TypeScript source, so a domain change is a one-line edit rather than
+a grep across every app.
 
 This package holds **public** values only. Nothing here is a secret: it is
 inlined into client bundles by design.
@@ -47,8 +47,10 @@ const docsHref = SITE_CONFIG.DOCS;
 | `TWITTER` | Project account |
 | `CONTACT_EMAIL` | Public contact address |
 
-`SITE_CONFIG` is `as const`, so `SiteConfig` gives each key a literal type and
-a typo fails at compile time instead of shipping a dead link.
+`SITE_CONFIG` is `as const`, so `SiteConfig` gives each key a readonly literal
+type and a typo fails at compile time instead of shipping a dead link. That is
+a type-level guarantee only — `as const` does not call `Object.freeze`, so the
+object is not frozen at runtime.
 
 ## What does not belong here
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,67 @@
+# `@softmaple/config`
+
+Canonical site constants — public URLs, the docs and playground hosts, the
+contact address, and the OpenGraph image. One frozen object, imported directly
+as TypeScript source, so a domain change is a one-line edit rather than a
+grep across every app.
+
+This package holds **public** values only. Nothing here is a secret: it is
+inlined into client bundles by design.
+
+## Role in the stack
+
+```text
+              apps/web                    packages/editor
+      metadata · auth redirects      docs / playground links
+         footers · OpenGraph           in the editor chrome
+                  │                              │
+                  └───────────────┬──────────────┘
+                                  │
+                          @softmaple/config
+                                  │
+                  ┌───────────────┴──────────────┐
+                  │                              │
+             SITE_CONFIG                 OPENGRAPH_IMAGE_URL
+       DOCS · PLAYGROUND · DOMAIN         social card asset
+    WEBSITE_URL · GITHUB_REPO · …
+```
+
+Consumed as source (`main` and `types` both point at `site.ts`), so there is no
+build step and no `dist/` to keep in sync.
+
+## Usage
+
+```ts
+import { SITE_CONFIG, OPENGRAPH_IMAGE_URL, type SiteConfig } from "@softmaple/config";
+
+const docsHref = SITE_CONFIG.DOCS;
+```
+
+| Key | Purpose |
+| --- | --- |
+| `DOCS` | Mintlify documentation site |
+| `PLAYGROUND` | Hosted `apps/playground` |
+| `WEBSITE_URL` | Canonical marketing / app origin |
+| `DOMAIN` | Bare apex domain |
+| `GITHUB_REPO` | Repository URL |
+| `TWITTER` | Project account |
+| `CONTACT_EMAIL` | Public contact address |
+
+`SITE_CONFIG` is `as const`, so `SiteConfig` gives each key a literal type and
+a typo fails at compile time instead of shipping a dead link.
+
+## What does not belong here
+
+- Anything secret — API keys, service-role tokens, connection strings. Those
+  live in environment variables, and the ones that reach the browser are
+  documented per app (see [`apps/web/README.md`](../../apps/web/README.md)).
+- Per-environment values. This file is the same in dev, preview, and
+  production; anything that differs between them is an env var.
+- Feature flags and rollout switches. Collaboration runtime routing, for
+  example, is configured through environment variables in `apps/web`.
+
+## Commands
+
+```bash
+pnpm --filter @softmaple/config lint
+```

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,143 @@
+# `@softmaple/db`
+
+Schema, migrations, and the typed Postgres client for Softmaple. Prisma
+migrations under [`prisma/migrations/`](./prisma/migrations) are the **single
+source of truth** for tables, Supabase Auth triggers, RLS policies, Data API
+grants, and the collaboration RPCs. There is no second schema definition
+anywhere in the repo.
+
+## Role in the stack
+
+```text
+       apps/web             apps/collab-nitro     apps/collab-cloudflare
+      supabase-js             Prisma client             supabase-js
+  anon / publishable          @softmaple/db            service_role
+           │                        │                        │
+           │                        │          append_document_event_batches
+           │                        │            read_document_event_page
+           │                        │                        │
+           └────────────────────────┼────────────────────────┘
+                                    │
+                           Supabase / Postgres
+           users · workspaces · workspace_members · documents
+               document_event_batches · document_event_ids
+                                    ▲
+                                    │
+                      packages/db/prisma/migrations
+             tables · triggers · RLS policies · grants · RPC
+```
+
+Three access paths, one schema:
+
+| Consumer | Path | Authority |
+| --- | --- | --- |
+| `apps/web` | Supabase Data API | End-user JWT; RLS decides everything |
+| `apps/collab-nitro` | Prisma over a pooled connection | Trusted service, authorizes in app code |
+| `apps/collab-cloudflare` | Supabase RPC | `service_role`, restricted to two narrowly-scoped functions |
+
+The Worker deliberately does not get table-level write access. It calls
+`append_document_event_batches` / `read_document_event_page`, which re-implement
+the same append and repair invariants inside the database, so both
+collaboration runtimes produce byte-identical history.
+
+## Schema
+
+```text
+users ──< workspace_members >── workspaces
+  │                                  │
+  └──────────< documents >───────────┘
+                   │
+                   └──< document_event_batches ──< document_event_ids
+```
+
+| Model | Table | Notes |
+| --- | --- | --- |
+| `User` | `users` | Mirrors `auth.users` via the `handle_new_user` trigger |
+| `Workspace` | `workspaces` | Owned by a user; cascade-deletes its documents |
+| `WorkspaceMember` | `workspace_members` | `OWNER` / `EDITOR` / `VIEWER` |
+| `Document` | `documents` | `is_public` opens anonymous read access |
+| `DocumentEventBatch` | `document_event_batches` | **Immutable** EG-walker history. Collaboration services are the only writers |
+| `DocumentEventId` | `document_event_ids` | Document-wide uniqueness guard that catches a replica/session id collision before conflicting history reaches clients |
+
+`document_event_batches` carries `payload_hash` and `parent_version` so a
+replayed append is idempotent and a conflicting one is rejected rather than
+silently accepted.
+
+## Usage
+
+```ts
+import { createPrismaClient, type PrismaClient } from "@softmaple/db";
+
+const prisma: PrismaClient = createPrismaClient(); // requires DATABASE_URL
+```
+
+The package also re-exports the generated Supabase `Database` / `Json` types
+for `supabase-js` consumers:
+
+```ts
+import type { Database } from "@softmaple/db";
+
+const supabase = createClient<Database>(url, key);
+```
+
+`createPrismaClient` throws when `DATABASE_URL` is unset rather than returning
+a client that fails later at query time.
+
+## Commands
+
+```bash
+pnpm --filter @softmaple/db db:generate   # regenerate the Prisma client
+pnpm --filter @softmaple/db db:migrate    # create + apply a dev migration
+pnpm --filter @softmaple/db db:deploy     # apply migrations (CI / production)
+pnpm --filter @softmaple/db db:types      # regenerate Supabase Database types
+pnpm --filter @softmaple/db build         # generate + compile to dist/
+```
+
+Regenerate the client after any schema change — a stale client is the usual
+cause of a type error that looks like a bug elsewhere.
+
+### Verification
+
+```bash
+pnpm --filter @softmaple/db db:verify:collab-security   # structure + grants
+pnpm --filter @softmaple/db db:verify:core-behavior     # access matrix
+pnpm --filter @softmaple/db db:clean                    # drop test data
+```
+
+`db:verify:collab-security` checks deployed structure and grants and is safe to
+run anywhere. `db:verify:core-behavior` exercises the
+Owner/Editor/Viewer/outsider/anonymous access matrix inside a transaction that
+always rolls back — run it against an **isolated test project**, never
+production.
+
+## Adding a change
+
+1. Edit [`prisma/schema.prisma`](./prisma/schema.prisma) and/or write the SQL.
+2. `pnpm --filter @softmaple/db db:migrate` to create a forward migration.
+3. Never edit an already-deployed migration, and never introduce a second
+   schema source (loose `functions/`, `rls/`, or `triggers/` SQL) — those were
+   deliberately folded into the migration ledger.
+4. Re-run `db:generate` and the verification scripts.
+
+## Layout
+
+```text
+packages/db/
+├── prisma/
+│   ├── schema.prisma          # models, enums, generator, datasource
+│   └── migrations/            # forward-only ledger, source of truth
+├── src/
+│   ├── client.ts              # createPrismaClient (PrismaPg adapter)
+│   ├── database.types.ts      # generated Supabase types
+│   └── index.ts
+└── supabase/
+    ├── README.md              # deployment notes
+    ├── cron/                  # optional operational helpers
+    └── scripts/               # verification / cleanup SQL
+```
+
+## Related
+
+- [`supabase/README.md`](./supabase/README.md) — deployment and verification detail
+- [`docs/design/collaboration-consistency.md`](../../docs/design/collaboration-consistency.md) — durable-write invariants
+- [`apps/collab-cloudflare/README.md`](../../apps/collab-cloudflare/README.md) — the RPC consumer

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -103,12 +103,18 @@ Stack: React 19, Lexical 0.44, Tailwind CSS v4, shadcn/ui via
 
 ## Adding a component
 
-Run the shadcn CLI from the app directory so aliases resolve into
-`@softmaple/ui` rather than copying files here:
+This package's [`components.json`](./components.json) maps `components`, `lib`,
+and `hooks` to `@softmaple/editor/*`, so running the CLI **here** lands the
+files here — which is what you want for an editor-local part:
 
 ```bash
-pnpm dlx shadcn@latest add [COMPONENT]
+cd packages/editor && pnpm dlx shadcn@latest add [COMPONENT]
 ```
+
+For a primitive every surface should share, add it to `@softmaple/ui` instead;
+see [its README](../ui/README.md#adding-a-component) for which directory puts
+files where. Either way `ui` and `utils` resolve to `@softmaple/ui`, so the
+generated code reuses the shared primitives and `cn()`.
 
 ## Related
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1,60 +1,117 @@
-# Lexical Editor
+# `@softmaple/editor`
 
-# Tailwind CSS `v4` with `shadcn/ui`
+The Lexical editor surface: composer setup, node registry, toolbar, keyboard
+shortcuts, markdown shortcuts, export menu, and the theme that renders them.
+Hosts mount `CoreEditor` and add their own document plumbing around it.
 
-# Storybookjs `v8`
+Consumed as **source** — `apps/web` lists it in `transpilePackages`, the Vite
+apps alias it directly — so there is no build output to keep in sync. The Vite
+dev server and Storybook in this package are a local harness for developing the
+components, not the way products consume them.
 
-# React + TypeScript + Vite
+## Role in the stack
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-});
+```text
+      apps/web                                         apps/playground
+modules/docs/collab-doc-editor                      LexicalDocumentCanvas
+          │                                                   │
+          └─────────────────────────┬─────────────────────────┘
+                                    │
+                            @softmaple/editor
+                                    │
+          ┌─────────────────────────┼─────────────────────────┐
+          │                         │                         │
+     CoreEditor              config/lexical              markdown.ts
+   LexicalComposer            theme · nodes          Lexical ⇄ markdown
+ Providers · Editor          error boundary                   │
+          │                         │                         │
+    ToolbarPlugin            PlaygroundNodes         @softmaple/md2latex
+   ShortcutsPlugin       heading · list · quote
+  MarkdownShortcut             code · link
+          │
+@softmaple/ui · Tailwind v4
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+**Collaboration is deliberately absent from this package.** It has no
+`@softmaple/binding-lexical`, `@softmaple/block-model`, or awareness
+dependency. A host composes them by rendering the collaboration plugins as
+`children` of `CoreEditor` — that is why `apps/web` can run the same editor
+with local history *or* with EG-walker collaboration, without a fork.
 
-```js
-// eslint.config.js
-import reactX from "eslint-plugin-react-x";
-import reactDom from "eslint-plugin-react-dom";
+| Concern | Owner |
+| --- | --- |
+| Composer, nodes, toolbar, shortcuts, theme | **this package** |
+| Design tokens and primitives | `@softmaple/ui` |
+| Markdown → $\LaTeX$ export | `@softmaple/md2latex` |
+| Lexical ↔ CRDT binding | `@softmaple/binding-lexical` (mounted by the host) |
+| Presence overlays | `@softmaple/awareness` (mounted by the host) |
 
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    "react-x": reactX,
-    "react-dom": reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs["recommended-typescript"].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-});
+## Usage
+
+```tsx
+import { CoreEditor } from "@softmaple/editor/components/core/CoreEditor";
+import { LEXICAL_PLAYGROUND_CONFIG } from "@softmaple/editor/config/lexical";
+
+<CoreEditor
+  lexicalConfig={LEXICAL_PLAYGROUND_CONFIG}
+  historyMode="disabled"        // "local" (default) or "disabled"
+  showToolbar
+  activeEditor={activeEditor}
+  setActiveEditor={setActiveEditor}
+>
+  {/* Host-owned plugins: collaboration binding, presence, autosave… */}
+  <LexicalEgWalkerPlugin replica={replica} />
+</CoreEditor>;
 ```
+
+Set `historyMode="disabled"` whenever a collaboration binding is mounted.
+Lexical's local history stack and a CRDT both claim authority over undo; running
+them together produces undo steps that do not match what other peers see.
+
+Imports are subpath-based (`@softmaple/editor/components/…`,
+`@softmaple/editor/config/lexical`, `@softmaple/editor/markdown`) — there is no
+barrel entry point.
+
+## Layout
+
+```text
+packages/editor/src/
+├── components/core/     # CoreEditor, Editor, Providers, ContentEditable
+│   ├── plugins/         # Toolbar, Shortcuts, MarkdownShortcut + transformers
+│   └── ExportFiles/     # Export dropdown (markdown, LaTeX)
+├── config/lexical.tsx   # InitialConfigType: theme, nodes, error boundary
+├── nodes/               # PlaygroundNodes registry (heading, list, quote,
+│                        #   code, link)
+├── context/             # SharedHistory, Toolbar, theme providers
+├── markdown.ts          # Lexical editor state ⇄ markdown
+├── lib/ · utils/        # cn() and helpers
+└── stories/             # Storybook stories
+```
+
+## Commands
+
+```bash
+pnpm --filter @softmaple/editor dev         # Vite harness
+pnpm --filter @softmaple/editor storybook   # component workbench
+pnpm --filter @softmaple/editor test
+pnpm --filter @softmaple/editor typecheck
+pnpm --filter @softmaple/editor lint
+```
+
+Stack: React 19, Lexical 0.44, Tailwind CSS v4, shadcn/ui via
+`@softmaple/ui`, Vite + Vitest, Storybook.
+
+## Adding a component
+
+Run the shadcn CLI from the app directory so aliases resolve into
+`@softmaple/ui` rather than copying files here:
+
+```bash
+pnpm dlx shadcn@latest add [COMPONENT]
+```
+
+## Related
+
+- [`@softmaple/ui`](../ui/README.md) — design system this builds on
+- [`@softmaple/binding-lexical`](../binding-lexical/README.md) — collaboration binding hosts mount alongside it
+- [`apps/web`](../../apps/web/README.md) — the production host

--- a/packages/eg-walker/README.md
+++ b/packages/eg-walker/README.md
@@ -7,10 +7,53 @@ Eg-walker implementation for collaborative plain-text editing, based on
 
 The package is organized around the paper's prepare/effect model:
 
+```text
+           local edit                                 remote events
+      applyLocalOperation()                        applyRemoteEvents()
+                │                                           │
+                └─────────────────────┬─────────────────────┘
+                                      │
+                           core/ — EgWalkerReplica
+                      public API · replay coordination
+                                      │
+                ┌─────────────────────┴─────────────────────┐
+                │                                           │
+             graph/                                      engine/
+      persistent event DAG                        prepare/effect state
+        frontier versions                          ranked B-tree index
+    causal diff · topo order                       delete-target index
+      columnar codec (§3.8)                       critical checkpoints
+                │                                           │
+                └─────────────────────┬─────────────────────┘
+                                      │
+                                document text
+                        serialize() · native snapshot
+```
+
 - `graph/`: persistent event graph, frontier versions, causal expansion/diff, columnar codec.
 - `engine/`: prepare/effect replay state, ranked B-tree index mapping, critical checkpoints, partial replay.
 - `core/`: public API and thin walker coordinator.
 - `types/`: public TypeScript types.
+
+Only the event graph is durable state. The engine's replay records are
+derived: they can be discarded at a critical version and rebuilt, which is what
+makes partial replay possible. `graph/` never imports `engine/`.
+
+### Position in the wider stack
+
+```text
+   @softmaple/binding-lexical ──► @softmaple/block-model ──► @softmaple/eg-walker
+        Lexical projection          blocks · marks · text        this package
+                                             │
+                                  RichTextEventBatch on the wire
+                                             │
+                                  @softmaple/collab-protocol
+```
+
+Surfaces never import this package directly — they go through a surface
+binding. This package must not import an editor framework, awareness, or any
+host runtime; see
+[`docs/design/collaboration-layers.md`](../../docs/design/collaboration-layers.md).
 
 The portable `serialize()` format contains plain text plus the event graph and
 does not persist CRDT replay records. `EgWalkerReplica` does cache an engine

--- a/packages/eg-walker/README.md
+++ b/packages/eg-walker/README.md
@@ -35,9 +35,11 @@ The package is organized around the paper's prepare/effect model:
 - `core/`: public API and thin walker coordinator.
 - `types/`: public TypeScript types.
 
-Only the event graph is durable state. The engine's replay records are
+The event graph is the canonical durable state. The engine's replay records are
 derived: they can be discarded at a critical version and rebuilt, which is what
-makes partial replay possible. `graph/` never imports `engine/`.
+makes partial replay possible. A native snapshot may additionally persist that
+derived cache for faster restore, but it never replaces the graph as the source
+of truth. `graph/` never imports `engine/`.
 
 ### Position in the wider stack
 

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,3 +1,89 @@
 # `@softmaple/eslint-config`
 
 Shared eslint configuration for the workspace.
+
+Four flat-config entry points build on one base, plus a set of layering rules
+that mechanically enforce the collaboration architecture.
+
+## Architecture
+
+```text
+                          eslint.config.js
+                    root · per-app · per-package
+                                  │
+            ┌─────────────────────┴─────────────────────┐
+            │                                           │
+          /base                               /collaboration-layers
+     js.recommended                           no-restricted-imports
+    typescript-eslint                           layer boundaries
+     config-prettier                                    │
+      plugin-turbo                              spread alongside
+            │                                  any config at left
+   ┌────────┴──────────┐
+   │                   │
+/next-js        /react-internal
+apps/web    ui · awareness · editor
+```
+
+`/collaboration-layers` is additive, not a variant: a package spreads it
+*alongside* whichever base it already extends.
+
+## Entry points
+
+| Subpath | Use in |
+| --- | --- |
+| `@softmaple/eslint-config/base` | Any TypeScript package |
+| `@softmaple/eslint-config/next-js` | `apps/web` |
+| `@softmaple/eslint-config/react-internal` | React component packages (`ui`, `awareness`, `editor`) |
+| `@softmaple/eslint-config/collaboration-layers` | Collaboration model, binding, protocol, and runtime packages |
+
+```js
+// packages/<name>/eslint.config.js
+import { config } from "@softmaple/eslint-config/base";
+import { egWalkerCollaborationConfig } from "@softmaple/eslint-config/collaboration-layers";
+
+export default [...config, ...egWalkerCollaborationConfig];
+```
+
+## Rules worth knowing
+
+The base config turns two repo conventions into errors rather than review
+comments:
+
+- **`@typescript-eslint/no-explicit-any`** — `error`. Replace `any` with a real
+  type; where that is genuinely infeasible, use `@ts-expect-error` with a
+  reason, never `@ts-ignore`.
+- **No TypeScript `enum`** — via `no-restricted-syntax` on
+  `TSEnumDeclaration`. Use a const object plus a derived type; enums emit
+  runtime code and defeat tree-shaking.
+
+`eslint-plugin-only-warn` is loaded so lint output stays readable during
+development; CI still fails on warnings because packages run
+`eslint . --max-warnings=0`.
+
+## Collaboration layering
+
+[`collaboration-layers.js`](./collaboration-layers.js) is the mechanical half
+of [`docs/design/collaboration-layers.md`](../../docs/design/collaboration-layers.md).
+Each exported pattern set forbids the imports that would invert the layer
+graph:
+
+| Export | Forbids |
+| --- | --- |
+| `egWalkerCollaborationPatterns` | awareness, block model, bindings, protocol, runtime, editor frameworks |
+| `blockModelCollaborationPatterns` | awareness, bindings, protocol, runtime, editor frameworks (EG-walker is allowed) |
+| `blockModelBindingCollaborationPatterns` | awareness, protocol, runtime, and reaching past the block model into EG-walker (Lexical is allowed) |
+| `collabProtocolCollaborationPatterns` | awareness, EG-walker, bindings, runtime, editor frameworks, host runtimes (the block model is allowed) |
+| `collabRuntimeCollaborationPatterns` | everything outside a narrow allowlist — convergence internals, UI, concrete host runtimes (the protocol is allowed) |
+| `egWalkerCollaborationConfig` | ready-to-spread flat config applying `egWalkerCollaborationPatterns` |
+| `combinePatterns(...sets)` | composes pattern sets — flat config *replaces* a rule rather than merging it, so layering needs an explicit combine |
+
+`@softmaple/awareness` enforces the equivalent rule through Biome's
+`style/noRestrictedImports` instead, because it lints with Biome.
+
+## Commands
+
+```bash
+pnpm --filter @softmaple/eslint-config test   # node:test over __tests__/
+pnpm lint                                      # every workspace, via turbo
+```

--- a/packages/md2latex/README.md
+++ b/packages/md2latex/README.md
@@ -71,7 +71,7 @@ empty one.
 
 | Markdown | LaTeX |
 | --- | --- |
-| `# … ##### ` | `\section` → `\subparagraph` (5 levels) |
+| `#` through `#####` | `\section` → `\subparagraph` (5 levels) |
 | `**bold**` | `\textbf{…}` |
 | `*italic*` | `\textit{…}` |
 | `***both***` | `\textbf{\textit{…}}` |

--- a/packages/md2latex/README.md
+++ b/packages/md2latex/README.md
@@ -1,0 +1,111 @@
+# `@softmaple/md2latex`
+
+A dependency-free Markdown → $\LaTeX$ transformer. Given the Markdown that
+the Lexical editor exports, it produces either a document body or a complete
+compilable `article` document.
+
+The whole package is pure functions over strings: no AST library, no I/O, no
+`\write18`, no shelling out to a $\TeX$ distribution. That keeps it safe to run
+in a browser, a server action, or a Worker alike.
+
+## Role in the stack
+
+```text
+          packages/editor                      apps/web
+     ExportFilesDropdownMenu           latex-pane · doc-header
+                    │                               │
+             $convertToMarkdownString / lexicalStateToMarkdown
+                    └───────────────┬───────────────┘
+                                    │
+                                markdown
+                                    ▼
+                           @softmaple/md2latex
+                    ┌───────────────┴───────────────┐
+                    │                               │
+             tokenizeInline                   block scanner
+           code · links · bold              headings · lists
+             italic · strike                 quotes · fences
+                    │                               │
+                    └───────────────┬───────────────┘
+                    ┌───────────────┴───────────────┐
+                    │                               │
+           markdownToLatexBody               markdownToLatex
+              body fragment                full \documentclass
+                    │                               │
+                    └───────────────┬───────────────┘
+                                    │
+                             .tex → pdflatex
+```
+
+Inline content is tokenized **before** block rendering: code spans and link
+URLs are replaced by `@@SOFTMAPLE<n>@@` placeholders, the surrounding text is
+escaped, and the placeholders are substituted back. That is why a `$` inside a
+backtick span survives as a literal `$` while a `$` in prose becomes `\$`.
+
+## Usage
+
+```ts
+import { markdownToLatex, markdownToLatexBody, escapeLatex } from "@softmaple/md2latex";
+
+// Complete document, ready for pdflatex.
+const tex = markdownToLatex(markdown, {
+  title: "On Convergent Editing",
+  author: "Ada Lovelace",
+});
+
+// Just the body, when you own the preamble.
+const body = markdownToLatexBody(markdown);
+
+// Escape a single untrusted string for LaTeX.
+const safe = escapeLatex("100% & counting_up");
+// → "100\\% \\& counting\\_up"
+```
+
+`markdownToLatex` emits an `article` document with `fontenc`, `inputenc`,
+`amssymb` (checklist boxes), `hyperref` (links, `hidelinks`), and `ulem`
+(strikethrough), plus `\maketitle`. `title` defaults to `Untitled document`;
+omitting `author` omits the `\author` line entirely rather than emitting an
+empty one.
+
+## Mapping
+
+| Markdown | LaTeX |
+| --- | --- |
+| `# … ##### ` | `\section` → `\subparagraph` (5 levels) |
+| `**bold**` | `\textbf{…}` |
+| `*italic*` | `\textit{…}` |
+| `***both***` | `\textbf{\textit{…}}` |
+| `~~strike~~` | `\sout{…}` |
+| `` `code` `` | `\texttt{…}` |
+| `[label](url)` | `\href{url}{label}` |
+| `- item` / `1. item` | `itemize` / `enumerate` |
+| `- [ ]` / `- [x]` | `\item[$\square$]` / `\item[$\boxtimes$]` |
+| `> quote` | `quote` environment |
+| ` ```fence ``` ` | `verbatim` (contents passed through unescaped) |
+| paragraph line | text plus an explicit `\\` line break |
+
+### Escaping
+
+`\ { } $ & # _ % ~ ^` are escaped everywhere except inside a `verbatim` block.
+`\` becomes `\textbackslash{}`, `~` becomes `\textasciitilde{}`, and `^`
+becomes `\textasciicircum{}` — not the bare accent forms, which would silently
+consume the following character.
+
+An unterminated code fence, list, or blockquote is closed at end of input, so
+the output is always a balanced document rather than a partially-open
+environment that breaks the whole compile.
+
+## Commands
+
+```bash
+pnpm --filter @softmaple/md2latex build
+pnpm --filter @softmaple/md2latex test
+pnpm --filter @softmaple/md2latex coverage
+pnpm --filter @softmaple/md2latex typecheck
+pnpm --filter @softmaple/md2latex lint
+```
+
+Tests live in [`tests/md2latex.test.ts`](./tests/md2latex.test.ts) (Vitest).
+Every mapping row above is worth a test case — this converter's failure mode is
+a `.tex` file that no longer compiles, which is far more expensive to debug
+than a failing assertion.

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,3 +1,59 @@
 # `@softmaple/typescript-config`
 
 Shared typescript configuration for the workspace.
+
+Three presets, one strict base. A package's `tsconfig.json` extends one of
+them and adds only what is genuinely local — paths, `include`, `outDir`.
+
+## Architecture
+
+```text
+                                base.json
+               strict · noUncheckedIndexedAccess · ES2022
+            NodeNext modules · isolatedModules · declaration
+                                    │
+            ┌───────────────────────┼───────────────────────┐
+            │                       │                       │
+    extended directly      react-library.json          nextjs.json
+            │               jsx: "react-jsx"      next plugin · ESNext
+            │                       │            Bundler · jsx preserve
+            │                       │                    noEmit
+            │                       │                       │
+        eg-walker                  ui                   apps/web
+       block-model             playground
+     binding-lexical
+      collab-* · db
+    md2latex · bench
+    collab-cloudflare
+```
+
+## Usage
+
+```jsonc
+// packages/<name>/tsconfig.json
+{
+  "extends": "@softmaple/typescript-config/base.json",
+  "compilerOptions": { "outDir": "dist" },
+  "include": ["src"]
+}
+```
+
+| Preset | For |
+| --- | --- |
+| `base.json` | Libraries and Node services — most of the repo |
+| `react-library.json` | Base + `jsx: "react-jsx"` for React component sources |
+| `nextjs.json` | Base + the `next` plugin, `Bundler` resolution, `jsx: "preserve"`, `noEmit` |
+
+## Why the base is strict
+
+`strict` and `noUncheckedIndexedAccess` are both on. The second one matters
+most in the CRDT and block-model packages: array and map lookups there are
+routinely out of range during replay, and an unchecked `arr[i]` typed as
+non-`undefined` is exactly the bug class that produces a divergent document
+rather than a crash.
+
+`isolatedModules` keeps every file independently transpilable, which is what
+lets `tsup`, Vite, Turbopack, and `wrangler` all consume the same sources.
+
+Do not weaken these in a package-level override. If a preset genuinely does not
+fit a new workspace, add a preset here rather than loosening one package.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -67,17 +67,27 @@ Current components: `avatar`, `badge`, `button`, `card`, `dialog`,
 
 ## Adding a component
 
-Run the shadcn CLI **in the app directory**, not at the repo root — the CLI
-resolves aliases from that app's `components.json`:
+The shadcn CLI resolves aliases from the `components.json` of whatever directory
+you run it in, and those differ across the repo — so the directory decides where
+the generated files land:
+
+| Run from | `components` alias | Result |
+| --- | --- | --- |
+| `packages/ui` | `@softmaple/ui/components` | Lands here — **use this for shared components** |
+| `apps/playground` | `@softmaple/ui/components` | Also lands here |
+| `apps/web` | `@/components` | Lands in the app's own `components/` |
+| `packages/editor` | `@softmaple/editor/components` | Lands in the editor package |
+
+For a component every surface should share, run it from this package:
 
 ```bash
-pnpm dlx shadcn@latest add [COMPONENT]
+cd packages/ui && pnpm dlx shadcn@latest add [COMPONENT]
 ```
 
-Aliases are already configured in [`components.json`](./components.json) to
-point at `@softmaple/ui/components`, `@softmaple/ui/lib`, and
-`@softmaple/ui/hooks`, so generated files land in this package rather than
-being copied into each app.
+Running it from `apps/web` or `packages/editor` is the right move only when the
+component is genuinely local to that surface. Every `components.json` in the
+repo points `ui` and `utils` at `@softmaple/ui`, so generated code picks up the
+shared primitives and `cn()` either way.
 
 Keep components presentational: no data fetching, no Supabase client, no
 collaboration or awareness imports. A component that needs live state takes it

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,98 @@
+# `@softmaple/ui`
+
+The shared design system: shadcn/ui components (new-york style, Radix
+primitives, Lucide icons) plus the Tailwind CSS v4 theme that every Softmaple
+surface renders against.
+
+The package ships **source**, not a build. Consumers compile it themselves —
+`apps/web` through `transpilePackages`, the Vite apps through their own
+pipeline — so there is no `dist/`, no duplicated React, and no stale build to
+regenerate after an edit.
+
+## Role in the stack
+
+```text
+       apps/web             apps/playground         packages/editor
+      Next.js 16            TanStack Start         Lexical UI shell
+           │                       │                       │
+           └───────────────────────┼───────────────────────┘
+                                   │
+                             @softmaple/ui
+                                   │
+           ┌───────────────────────┼───────────────────────┐
+           │                       │                       │
+     /components/*        /styles/globals.css           /lib/*
+      Radix + CVA         tokens · dark mode          cn() helper
+           │                       │                       │
+      @radix-ui/*           Tailwind CSS v4             clsx +
+     lucide-react           tw-animate-css          tailwind-merge
+```
+
+`globals.css` is the single theme definition: OKLCH design tokens on `:root`,
+their dark counterparts under the `.dark` variant, and `@source` globs that
+pull class names out of the consuming apps so Tailwind's scanner sees them.
+Importing it twice from two apps is fine; defining a second token set is not.
+
+## Usage
+
+Subpath imports only — there is no barrel entry point, so an app never pays for
+components it does not render:
+
+```tsx
+import { Button } from "@softmaple/ui/components/button";
+import { cn } from "@softmaple/ui/lib/utils";
+
+<Button variant="outline" className={cn("w-full", className)}>
+  Save
+</Button>;
+```
+
+Import the theme once, at the app's root stylesheet:
+
+```css
+@import "@softmaple/ui/globals.css";
+```
+
+| Subpath | Contents |
+| --- | --- |
+| `@softmaple/ui/components/*` | One component per file (`button`, `dialog`, `select`, …) |
+| `@softmaple/ui/lib/*` | `utils` → `cn()` (clsx + tailwind-merge) |
+| `@softmaple/ui/hooks/*` | Shared React hooks |
+| `@softmaple/ui/globals.css` | Tailwind v4 theme, design tokens, dark mode |
+| `@softmaple/ui/postcss.config` | Shared PostCSS config for consumers |
+
+Current components: `avatar`, `badge`, `button`, `card`, `dialog`,
+`dropdown-menu`, `input`, `label`, `scroll-area`, `select`, `separator`,
+`sheet`, `skeleton`, `sonner`, `switch`, `tabs`, `textarea`, `tooltip`.
+
+## Adding a component
+
+Run the shadcn CLI **in the app directory**, not at the repo root — the CLI
+resolves aliases from that app's `components.json`:
+
+```bash
+pnpm dlx shadcn@latest add [COMPONENT]
+```
+
+Aliases are already configured in [`components.json`](./components.json) to
+point at `@softmaple/ui/components`, `@softmaple/ui/lib`, and
+`@softmaple/ui/hooks`, so generated files land in this package rather than
+being copied into each app.
+
+Keep components presentational: no data fetching, no Supabase client, no
+collaboration or awareness imports. A component that needs live state takes it
+as props.
+
+## Commands
+
+```bash
+pnpm --filter @softmaple/ui lint
+```
+
+Consumers typecheck this package as part of their own build, since it is
+compiled from source.
+
+## Related
+
+- [`packages/editor`](../editor/README.md) — the Lexical editor built on these parts
+- [`packages/awareness`](../awareness/README.md) — presence UI, styled independently


### PR DESCRIPTION
## Changes proposed in this pull request

- Added detailed README files for 8 packages that were previously undocumented:
  - `@softmaple/binding-lexical` — Lexical ↔ block model binding
  - `@softmaple/db` — Prisma schema, migrations, and typed client
  - `@softmaple/collab-protocol` — Versioned wire contract for collaboration
  - `@softmaple/md2latex` — Markdown → LaTeX transformer
  - `@softmaple/ui` — Design system and shadcn/ui components
  - `@softmaple/config` — Site constants and configuration
  - `@softmaple/typescript-config` — Shared TypeScript presets
  - `@softmaple/eslint-config` — Shared ESLint configuration with collaboration layer rules

- Substantially rewrote `packages/editor/README.md` to document the Lexical editor surface, its role in the stack, usage patterns, and layout

- Updated existing READMEs with architecture diagrams and clarified roles:
  - `packages/eg-walker/README.md`
  - `packages/block-model/README.md`
  - `packages/collab-runtime/README.md`
  - `packages/awareness/README.md`
  - `apps/collab-cloudflare/README.md`
  - `apps/playground/README.md`
  - `packages/bench/README.md`

- Enhanced root `README.md` with a comprehensive architecture diagram showing the full stack from browser to durable storage, and clarified the import graph enforcement

## Rationale

The workspace has grown to 15+ packages with complex interdependencies. These READMEs establish:

1. **Single source of truth** for each package's purpose, API, and role in the collaboration stack
2. **Architecture diagrams** showing data flow and module relationships, making the system easier to navigate
3. **Clear boundaries** between concerns (e.g., "Lexical knows nothing about collaboration; the binding owns that seam")
4. **Usage examples** for consumers of each package
5. **Command reference** for common development tasks

The diagrams use ASCII art to remain readable in plaintext and version control, and consistently show how each layer connects to its neighbors.

## Test Plan

N/A — documentation only. No source code logic changes.

https://claude.ai/code/session_018eDMfQPtLw8sGe5ShLWXZL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture and usage documentation across collaboration apps and packages.
  * Documented collaboration data flow, runtime backends, persistence, protocol behavior, presence handling, and package boundaries.
  * Added setup, API, testing, development, and integration guidance for editor, UI, database, configuration, and tooling packages.
  * Replaced generic starter documentation with project-specific Playground and editor guidance.
  * Added references for block models, Lexical bindings, Markdown-to-LaTeX conversion, supported mappings, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->