### PR TITLE
fix(apps/web): point Playwright collab server at collab-nitro

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
   webServer: [
     {
       command: `pnpm exec nitro dev --port ${collabPort}`,
-      cwd: "../collab",
+      cwd: "../collab-nitro",
       env: {
         ...process.env,
         COLLAB_REALTIME_DRIVER: "memory",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #906 (follow-up: leftover Playwright cwd after the rename).

Changes proposed in this pull request:

- Update `apps/web/playwright.config.ts` webServer `cwd` from `../collab` to `../collab-nitro`
- The `#906` rename moved `apps/collab` to `apps/collab-nitro`, but Playwright still started Nitro from the old directory, so e2e webServer startup would fail

Test commands run:

- Confirmed `apps/web/../collab` does not exist and `apps/web/../collab-nitro` does
- `pnpm exec playwright test --list` from `apps/web` loads the updated config (17 tests)
- `pnpm exec nitro dev --port 32111` from `apps/collab-nitro` (same command Playwright uses) serves `GET /health` as `{"service":"softmaple-collab","status":"ok"}`

Did not run the full Playwright suite: it needs isolated E2E seed credentials (`E2E_SEED_SECRET` and a matching Supabase project), which this cwd-only change does not affect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6621c584-fbd2-47c1-8cdb-d4a73e542d7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6621c584-fbd2-47c1-8cdb-d4a73e542d7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the collaboration web server configuration used during browser testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->